### PR TITLE
SINGA-13 Separate intermediate files of compilation from source files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,5 @@
 CLOCAL_AMFLAGS = -I config 
+AUTOMAKE_OPTIONS = foreign subdir-objects
 
 AM_CPPFLAGS = -I$(top_srcdir)/src
 
@@ -9,7 +10,7 @@ AC_CXXFLAGS = -O3 -Wall -pthread -fPIC -std=c++11 -Wno-unknown-pragmas \
 
 INCLUDES=-I$(top_srcdir)/include
 
-PROTOS := src/proto/cluster.proto src/proto/model.proto
+PROTOS := $(top_srcdir)/src/proto/cluster.proto $(top_srcdir)/src/proto/model.proto 
 PROTO_SRCS := src/proto/cluster.pb.cc src/proto/model.pb.cc
 PROTO_HDRS := src/proto/cluster.pb.h  src/proto/model.pb.h
 PROTO_OBJS := src/proto/cluster.pb.o src/proto/model.pb.o
@@ -120,7 +121,7 @@ clean-local:
 
 
 $(PROTO_HDRS) $(PROTO_SRCS): $(PROTOS)
-	protoc --proto_path=src/proto --cpp_out=src/proto $(PROTOS)
-	mkdir -p include/proto/
-	cp src/proto/*.pb.h include/proto/
+	protoc --proto_path=$(top_srcdir)/src/proto --cpp_out=$(top_srcdir)/src/proto $(PROTOS)
+	mkdir -p $(top_srcdir)/include/proto/
+	cp $(top_srcdir)/src/proto/*.pb.h $(top_srcdir)/include/proto/
 	@echo

--- a/Makefile.in
+++ b/Makefile.in
@@ -230,13 +230,14 @@ sharedstatedir = @sharedstatedir@
 sysconfdir = @sysconfdir@
 target_alias = @target_alias@
 CLOCAL_AMFLAGS = -I config 
+AUTOMAKE_OPTIONS = foreign subdir-objects
 AM_CPPFLAGS = -I$(top_srcdir)/src
 MSHADOW_FLAGS = -DMSHADOW_USE_CUDA=0 -DMSHADOW_USE_CBLAS=1 -DMSHADOW_USE_MKL=0
 AC_CXXFLAGS = -O3 -Wall -pthread -fPIC -std=c++11 -Wno-unknown-pragmas \
 	$(MSHADOW_FLAGS) -DCPU_ONLY=1 -funroll-loops 
 
 INCLUDES = -I$(top_srcdir)/include
-PROTOS := src/proto/cluster.proto src/proto/model.proto
+PROTOS := $(top_srcdir)/src/proto/cluster.proto $(top_srcdir)/src/proto/model.proto 
 PROTO_SRCS := src/proto/cluster.pb.cc src/proto/model.pb.cc
 PROTO_HDRS := src/proto/cluster.pb.h  src/proto/model.pb.h
 PROTO_OBJS := src/proto/cluster.pb.o src/proto/model.pb.o
@@ -1111,9 +1112,9 @@ clean-local:
 	rm -rf $(PROTO_SRCS) $(PROTO_HDRS) 
 
 $(PROTO_HDRS) $(PROTO_SRCS): $(PROTOS)
-	protoc --proto_path=src/proto --cpp_out=src/proto $(PROTOS)
-	mkdir -p include/proto/
-	cp src/proto/*.pb.h include/proto/
+	protoc --proto_path=$(top_srcdir)/src/proto --cpp_out=$(top_srcdir)/src/proto $(PROTOS)
+	mkdir -p $(top_srcdir)/include/proto/
+	cp $(top_srcdir)/src/proto/*.pb.h $(top_srcdir)/include/proto/
 	@echo
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ If you want to specify your own installation directory, use the following comman
 
 	$ ./configure --prefix=/YOUR/OWN/FOLDER
 
+Also, you can create your own build directory and run those commands. For example, please try:
+
+	$ cd SINGA/FOLDER
+	$ mkdir build && cd build
+	$ ../configure
+	$ make	
+	$ make install
+
 The result of configure script will indicate you whether there exist dependency missings in your system.
 If you do not install the dependencies, you can run the following commands.
 To download & install the thirdparty dependencies:


### PR DESCRIPTION
Modify Makefile.am to support advanced compilation. Add corresponding guidance in README.