### PR TITLE
SINGA-15 Fixg a bug from ConnectStub function which gets stuck for connecting layer_dealer_

### DIFF
--- a/include/trainer/worker.h
+++ b/include/trainer/worker.h
@@ -128,7 +128,7 @@ class Worker {
    */
   void ReceiveBlobs(shared_ptr<NeuralNet> net);
   void SendBlob();
-  void ConnectStub(shared_ptr<Dealer> dealer);
+  void ConnectStub(shared_ptr<Dealer> dealer, EntityType type);
  protected:
   int thread_id_, group_id_, worker_id_;
   int step_;

--- a/src/trainer/trainer.cc
+++ b/src/trainer/trainer.cc
@@ -227,8 +227,7 @@ void Trainer::Run(int nworkers, int nservers,
             LOG(ERROR)<<prefix<<" step-" <<step<<", "<<perf.ToString();
             perf.Reset();
           }
-          delete msg;
-          msg=nullptr;
+          DeleteMsg(&msg);
         }else if(cluster->nserver_groups()>0){
           int group_id=msg->src_first();
           int paramid=msg->target_first();

--- a/src/trainer/worker.cc
+++ b/src/trainer/worker.cc
@@ -29,10 +29,10 @@ void Worker::Setup(const ModelProto& model,
   }
 }
 
-void Worker::ConnectStub(shared_ptr<Dealer> dealer){
+void Worker::ConnectStub(shared_ptr<Dealer> dealer, EntityType type){
   dealer->Connect(kInprocRouterEndpoint);
   Msg* ping=new Msg();
-  ping->set_src(group_id_, worker_id_, kWorkerParam);
+  ping->set_src(group_id_, worker_id_, type);
   ping->set_dst(-1,-1,kStub);
   ping->set_type(kConnect);
   ping->add_frame("PING", 4);
@@ -45,12 +45,12 @@ void Worker::ConnectStub(shared_ptr<Dealer> dealer){
 
 void Worker::Run(){
   dealer_=make_shared<Dealer>(2*thread_id_);
-  ConnectStub(dealer_);
+  ConnectStub(dealer_, kWorkerParam);
   for(auto layer: train_net_->layers())
     if(layer->partitionid()==worker_id_)
       if(layer->is_bridgedstlayer()||layer->is_bridgesrclayer()){
         layer_dealer_=make_shared<Dealer>(2*thread_id_+1);
-        ConnectStub(layer_dealer_);
+        ConnectStub(layer_dealer_, kWorkerLayer);
         break;
       }
   step_=modelproto_.step();


### PR DESCRIPTION
The ConnectStub function wraps the ping-pong messages for connecting worker dealers (including the dealer for transferring parameters and the dealer for transferring features) with the stub router.
The bug comes from that we fixed the entity type to kWorkerParam. Consequently, it can only work for one dealer. The other dealer then gets stuck. It happens when we need to transfer features between workers, e.g., model partitioning as shown in the [quick start page](http://singa.incubator.apache.org/quick-start.html).