### PR TITLE
SINGA-14 Update layer API to be general for training different models

### DIFF
--- a/examples/cifar10/cluster.conf
+++ b/examples/cifar10/cluster.conf
@@ -1,6 +1,6 @@
-nworker_groups: 2
+nworker_groups: 1
 nserver_groups: 1
 nservers_per_group: 1
-nworkers_per_group: 1
+nworkers_per_group: 2
 nworkers_per_procs: 2
 workspace: "examples/cifar10/"

--- a/include/neuralnet/base_layer.h
+++ b/include/neuralnet/base_layer.h
@@ -109,11 +109,11 @@ class Layer {
    * @param training true if in training phase
    * @param srclayers layers connecting to this layer
    */
-  virtual void ComputeFeature(bool training, const vector<SLayer>& srclayers)=0;
+  virtual void ComputeFeature(Phase phase, const vector<SLayer>& srclayers)=0;
   /**
    * \copybrief ComputeFeature(const vector<SLayer>& srclayers)
    */
-  virtual void ComputeFeature(bool training);
+  virtual void ComputeFeature(Phase phase);
   /**
    * Compute gradients for parameters and connecting layers.
    *
@@ -286,7 +286,7 @@ class BridgeSrcLayer: public Layer {
       const vector<int> &shape,
       const vector<SLayer>& srclayers){}
 
-  virtual void ComputeFeature(bool training, const vector<SLayer>& srclayers);
+  virtual void ComputeFeature(Phase phase, const vector<SLayer>& srclayers);
   virtual void ComputeGradient(const vector<SLayer>& srclayers);
   virtual const Blob<float>& data(const Layer* from) const {
     return srclayers_[0]->data(this);
@@ -330,7 +330,7 @@ class BridgeDstLayer: public Layer {
       const vector<int> &shape,
       const vector<SLayer>& srclayers){}
 
-  virtual void ComputeFeature(bool training, const vector<SLayer>& srclayers){
+  virtual void ComputeFeature(Phase phase, const vector<SLayer>& srclayers){
     ready_=false;
   }
   virtual void ComputeGradient(const vector<SLayer>& srclayers){}
@@ -362,7 +362,7 @@ class ConcateLayer: public Layer {
       const vector<int> &shape,
       const vector<SLayer>& srclayers){}
 
-  virtual void ComputeFeature(bool training, const vector<shared_ptr<Layer>>& srclayers);
+  virtual void ComputeFeature(Phase phase, const vector<shared_ptr<Layer>>& srclayers);
   virtual void ComputeGradient(const vector<shared_ptr<Layer>>& srclayers);
 };
 
@@ -378,7 +378,7 @@ class DataLayer: public Layer{
   using Layer::ComputeFeature;
   using Layer::ComputeGradient;
 
-  virtual void ComputeFeature(bool training, const vector<SLayer>& srclayers)=0;
+  virtual void ComputeFeature(Phase phase, const vector<SLayer>& srclayers)=0;
   virtual void Setup(const LayerProto& proto, const vector<SLayer>& srclayers)=0;
   virtual bool is_datalayer() const {
     return true;
@@ -440,7 +440,7 @@ class PrefetchLayer : public Layer {
 
   virtual ~PrefetchLayer();
   virtual void Setup(const LayerProto& proto, const vector<SLayer>& srclayers);
-  virtual void ComputeFeature(bool training, const vector<SLayer>& srclayers);
+  virtual void ComputeFeature(Phase phase, const vector<SLayer>& srclayers);
   virtual void ComputeGradient(const vector<SLayer>& srclayers){};
   virtual void SetupAfterPartition(const LayerProto& proto,
       const vector<int> &shape,
@@ -460,7 +460,7 @@ class PrefetchLayer : public Layer {
     return kNone;
   }
 
-  void Prefetch(bool training);
+  void Prefetch(Phase phase);
  protected:
   vector<shared_ptr<Layer>> sublayers_;
   map<string, Blob<float>> datablobs_;
@@ -476,7 +476,7 @@ class SliceLayer: public Layer {
   using Layer::ComputeFeature;
   using Layer::ComputeGradient;
 
-  virtual void ComputeFeature(bool training, const vector<shared_ptr<Layer>>& srclayers);
+  virtual void ComputeFeature(Phase phase, const vector<shared_ptr<Layer>>& srclayers);
   virtual void ComputeGradient(const vector<shared_ptr<Layer>>& srclayers);
   virtual void Setup(const LayerProto& proto, const vector<SLayer>& srclayers);
   virtual void SetupAfterPartition();
@@ -510,7 +510,7 @@ class SplitLayer: public Layer {
       const vector<int> &shape,
       const vector<SLayer>& srclayers){}
 
-  virtual void ComputeFeature(bool training, const vector<shared_ptr<Layer>>& srclayers);
+  virtual void ComputeFeature(Phase phase, const vector<shared_ptr<Layer>>& srclayers);
   virtual void ComputeGradient(const vector<shared_ptr<Layer>>& srclayers);
 };
 
@@ -560,16 +560,16 @@ class ParserLayer: public Layer {
   /**
    * Parse records from DataLayer into blob.
    * This function is called by
-   * ComputeFeature(bool, const vector<SLayer>& srclayers)  or Prefetch(bool).
+   * ComputeFeature(Phase, const vector<SLayer>& srclayers)  or Prefetch(Phase).
    */
-  virtual void ParseRecords(bool training, const vector<Record>& records,
+  virtual void ParseRecords(Phase phase, const vector<Record>& records,
       Blob<float>* blob)=0;
 
   virtual bool is_parserlayer() const {
     return true;
   }
 
-  virtual void ComputeFeature(bool training, const vector<SLayer>& srclayers);
+  virtual void ComputeFeature(Phase phase, const vector<SLayer>& srclayers);
   /**
    * Dummy function. ParserLayer does not compute gradients.
    */

--- a/include/neuralnet/layer.h
+++ b/include/neuralnet/layer.h
@@ -42,7 +42,7 @@ class ConvolutionLayer: public Layer {
       const vector<int> &shape,
       const vector<SLayer>& srclayers);
 
-  virtual void ComputeFeature(bool training, const vector<shared_ptr<Layer>>& srclayers);
+  virtual void ComputeFeature(Phase phase, const vector<shared_ptr<Layer>>& srclayers);
   virtual void ComputeGradient(const vector<shared_ptr<Layer>>& srclayers);
   virtual vector<shared_ptr<Param>> GetParams() {
     return vector<shared_ptr<Param>>{weight_, bias_};
@@ -73,7 +73,7 @@ class DropoutLayer: public Layer {
       const vector<int> &shape,
       const vector<SLayer>& srclayers);
 
-  virtual void ComputeFeature(bool training, const vector<shared_ptr<Layer>>& srclayers);
+  virtual void ComputeFeature(Phase phase, const vector<shared_ptr<Layer>>& srclayers);
   virtual void ComputeGradient(const vector<shared_ptr<Layer>>& srclayers);
  protected:
   // drop probability
@@ -108,7 +108,7 @@ class InnerProductLayer: public Layer {
     return kOneToAll;
   }
 
-  virtual void ComputeFeature(bool training, const vector<shared_ptr<Layer>>& srclayers);
+  virtual void ComputeFeature(Phase phase, const vector<shared_ptr<Layer>>& srclayers);
   virtual void ComputeGradient(const vector<shared_ptr<Layer>>& srclayers);
   //virtual void ToProto(LayerProto *layer_proto, bool copyData);
   virtual vector<shared_ptr<Param>> GetParams() {
@@ -129,7 +129,7 @@ class LabelLayer: public ParserLayer {
   using ParserLayer::Setup;
 
   virtual void Setup(const LayerProto& proto, const vector<SLayer>& srclayers);
-  virtual void ParseRecords(bool training, const vector<Record>& records,
+  virtual void ParseRecords(Phase phase, const vector<Record>& records,
       Blob<float>* blob);
 };
 
@@ -156,7 +156,7 @@ class LRNLayer: public Layer {
       const vector<SLayer>& srclayers);
 
 
-  virtual void ComputeFeature(bool training, const vector<shared_ptr<Layer>>& srclayers);
+  virtual void ComputeFeature(Phase phase, const vector<shared_ptr<Layer>>& srclayers);
   virtual void ComputeGradient(const vector<shared_ptr<Layer>>& srclayers);
  protected:
   //! shape of the bottom layer feature
@@ -173,7 +173,7 @@ class MnistImageLayer: public ParserLayer {
   using Layer::Setup;
 
   virtual void Setup(const LayerProto& proto, const vector<SLayer>& srclayers);
-  virtual void ParseRecords(bool training, const vector<Record>& records,
+  virtual void ParseRecords(Phase phase, const vector<Record>& records,
       Blob<float>* blob);
 
  protected:
@@ -199,7 +199,7 @@ class PoolingLayer: public Layer {
   virtual void SetupAfterPartition(const LayerProto& proto,
       const vector<int> &shape,
       const vector<SLayer>& srclayers);
-  virtual void ComputeFeature(bool training, const vector<shared_ptr<Layer>>& srclayers);
+  virtual void ComputeFeature(Phase phase, const vector<shared_ptr<Layer>>& srclayers);
   virtual void ComputeGradient(const vector<shared_ptr<Layer>>& srclayers);
  protected:
   int kernel_, pad_, stride_;
@@ -221,7 +221,7 @@ class ReLULayer: public Layer {
       const vector<int> &shape,
       const vector<SLayer>& srclayers);
 
-  virtual void ComputeFeature(bool training, const vector<shared_ptr<Layer>>& srclayers);
+  virtual void ComputeFeature(Phase phase, const vector<shared_ptr<Layer>>& srclayers);
   virtual void ComputeGradient(const vector<shared_ptr<Layer>>& srclayers);
 };
 
@@ -257,7 +257,7 @@ class SoftmaxLossLayer: public LossLayer {
     return kOneToAll;
   }
 
-  virtual void ComputeFeature(bool training, const vector<shared_ptr<Layer>>& srclayers);
+  virtual void ComputeFeature(Phase phase, const vector<shared_ptr<Layer>>& srclayers);
   virtual void ComputeGradient(const vector<shared_ptr<Layer>>& srclayers);
  private:
   int batchsize_;
@@ -271,7 +271,7 @@ class RGBImageLayer: public ParserLayer {
   using Layer::Setup;
 
   virtual void Setup(const LayerProto& proto, const vector<SLayer>& srclayers);
-  virtual void ParseRecords(bool training, const vector<Record>& records,
+  virtual void ParseRecords(Phase phase, const vector<Record>& records,
       Blob<float>* blob);
 
  private:
@@ -287,7 +287,7 @@ class ShardDataLayer: public DataLayer{
   using Layer::ComputeFeature;
   using Layer::ComputeGradient;
 
-  virtual void ComputeFeature(bool training, const vector<shared_ptr<Layer>>& srclayers);
+  virtual void ComputeFeature(Phase phase, const vector<shared_ptr<Layer>>& srclayers);
   virtual void ComputeGradient(const vector<shared_ptr<Layer>>& srclayers){};
   virtual void Setup(const LayerProto& proto, const vector<SLayer>& srclayers);
  private:
@@ -299,7 +299,7 @@ class LMDBDataLayer: public DataLayer{
   using Layer::ComputeFeature;
   using Layer::ComputeGradient;
 
-  virtual void ComputeFeature(bool training, const vector<shared_ptr<Layer>>& srclayers);
+  virtual void ComputeFeature(Phase phase, const vector<shared_ptr<Layer>>& srclayers);
   virtual void ComputeGradient(const vector<shared_ptr<Layer>>& srclayers){};
   virtual void Setup(const LayerProto& proto, const vector<SLayer>& srclayers);
   void ConvertDatumToSingleLableImageRecord(const Datum& datum,
@@ -333,7 +333,7 @@ class TanhLayer: public Layer {
       const vector<SLayer>& srclayers);
 
 
-  virtual void ComputeFeature(bool training, const vector<shared_ptr<Layer>>& srclayers);
+  virtual void ComputeFeature(Phase phase, const vector<shared_ptr<Layer>>& srclayers);
   virtual void ComputeGradient(const vector<shared_ptr<Layer>>& srclayers);
  private:
   float outer_scale_, inner_scale_;

--- a/src/neuralnet/layer.cc
+++ b/src/neuralnet/layer.cc
@@ -60,7 +60,7 @@ void ConvolutionLayer::SetupAfterPartition(const LayerProto& proto,
   Setup(newproto, srclayers);
 }
 
-void ConvolutionLayer::ComputeFeature(bool training, const vector<SLayer>& srclayers){
+void ConvolutionLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers){
   Tensor<cpu, 4> src(srclayers[0]->mutable_data(this)->mutable_cpu_data(),
       Shape4(batchsize_, channels_, height_, width_));
   Tensor<cpu, 3> data(data_.mutable_cpu_data(),
@@ -137,9 +137,9 @@ void DropoutLayer::SetupAfterPartition(const LayerProto& proto,
   Setup(proto, srclayers);
 }
 
-void DropoutLayer::ComputeFeature(bool training, const vector<SLayer>& srclayers) {
+void DropoutLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers) {
   // check training
-  if(!training){
+  if(phase!= kTrain){//!training){
     data_.CopyFrom(srclayers[0]->data(this));
     return;
   }
@@ -185,7 +185,7 @@ void InnerProductLayer::SetupAfterPartition(const LayerProto& proto,
   Setup(newproto, srclayers);
 }
 
-void InnerProductLayer::ComputeFeature(bool training, const vector<SLayer>& srclayers) {
+void InnerProductLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers) {
   Tensor<cpu, 2> data(data_.mutable_cpu_data(), Shape2(batchsize_,hdim_));
   CHECK_EQ(srclayers[0]->data(this).count(), batchsize_*vdim_);
   Tensor<cpu, 2> src(srclayers[0]->mutable_data(this)->mutable_cpu_data(),
@@ -223,7 +223,7 @@ void LabelLayer::Setup(const LayerProto& proto,
   data_.Reshape(vector<int>{batchsize});
 }
 
-void LabelLayer::ParseRecords(bool training, const vector<Record>& records,
+void LabelLayer::ParseRecords(Phase phase, const vector<Record>& records,
     Blob<float>* blob){
   int rid=0;
   float *label= blob->mutable_cpu_data() ;
@@ -236,7 +236,7 @@ void LabelLayer::ParseRecords(bool training, const vector<Record>& records,
 
 
 /*********************LMDBDataLayer**********************************/
-void LMDBDataLayer::ComputeFeature(bool training, const vector<SLayer>& srclayers){
+void LMDBDataLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers){
   if(random_skip_){
     int nskip=rand()%random_skip_;
     int n=0;
@@ -355,7 +355,7 @@ void LRNLayer::SetupAfterPartition(const LayerProto& proto,
   Setup(proto, srclayers);
 }
 
-void LRNLayer::ComputeFeature(bool training, const vector<SLayer>& srclayers){
+void LRNLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers){
   const float salpha = alpha_ / lsize_;
   Shape<4> s=Shape4(batchsize_,channels_, height_, width_);
   Tensor<cpu, 4> src(srclayers[0]->mutable_data(this)->mutable_cpu_data(), s);
@@ -381,7 +381,7 @@ void LRNLayer::ComputeGradient(const vector<SLayer>& srclayers) {
 
 /**************** Implementation for MnistImageLayer******************/
 
-void MnistImageLayer::ParseRecords(bool training,
+void MnistImageLayer::ParseRecords(Phase phase,
     const vector<Record>& records, Blob<float>* blob){
   LOG_IF(ERROR, records.size()==0)<<"Empty records to parse";
   int ndim=records.at(0).image().shape_size();
@@ -509,7 +509,7 @@ void PoolingLayer::SetupAfterPartition(const LayerProto& proto,
   Setup(proto, srclayers);
 }
 
-void PoolingLayer::ComputeFeature(bool training, const vector<SLayer>& srclayers){
+void PoolingLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers){
   Tensor<cpu, 4> src(srclayers[0]->mutable_data(this)->mutable_cpu_data(),
       Shape4(batchsize_, channels_, height_, width_));
   Tensor<cpu, 4> data(data_.mutable_cpu_data(),
@@ -553,7 +553,7 @@ void ReLULayer::SetupAfterPartition(const LayerProto& proto,
   Setup(proto, srclayers);
 }
 
-void ReLULayer::ComputeFeature(bool training, const vector<SLayer>& srclayers){
+void ReLULayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers){
   Tensor<cpu, 1> data(data_.mutable_cpu_data(), Shape1(data_.count()));
   Tensor<cpu, 1> src(srclayers[0]->mutable_data(this)->mutable_cpu_data(),
       Shape1(data_.count()));
@@ -570,7 +570,7 @@ void ReLULayer::ComputeGradient(const vector<SLayer>& srclayers) {
 
 /*************** Implementation for RGBImageLayer *************************/
 
-void RGBImageLayer::ParseRecords(bool training,
+void RGBImageLayer::ParseRecords(Phase phase,
     const vector<Record>& records, Blob<float>* blob){
   const vector<int>& s=blob->shape();
   Tensor<cpu, 4> images(data_.mutable_cpu_data(), Shape4(s[0],s[1],s[2],s[3]));
@@ -585,8 +585,8 @@ void RGBImageLayer::ParseRecords(bool training,
   const float* meandptr=mean_.cpu_data();
   for(const Record& record: records){
     auto image=images[rid];
-    bool do_crop=cropsize_>0&&training;
-    bool do_mirror=mirror_&&rand()%2&&training;
+    bool do_crop=cropsize_>0&&(phase == kTrain);
+    bool do_mirror=mirror_&&rand()%2&&(phase == kTrain);
     float* dptr=nullptr;
     if(do_crop||do_mirror)
       dptr=raw_image.dptr;
@@ -663,7 +663,7 @@ void RGBImageLayer::Setup(const LayerProto& proto,
 }
 
 /***************Implementation for ShardDataLayer**************************/
-void ShardDataLayer::ComputeFeature(bool training, const vector<SLayer>& srclayers){
+void ShardDataLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers){
   if(random_skip_){
     int nskip=rand()%random_skip_;
     LOG(INFO)<<"Random Skip "<<nskip<<" records, there are "<<shard_->Count()
@@ -708,7 +708,7 @@ void TanhLayer::SetupAfterPartition(const LayerProto& proto,
 }
 
 
-void TanhLayer::ComputeFeature(bool training, const vector<SLayer>& srclayers){
+void TanhLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers){
   Tensor<cpu, 1> data(data_.mutable_cpu_data(), Shape1(data_.count()));
   Tensor<cpu, 1> src(srclayers[0]->mutable_data(this)->mutable_cpu_data(),
       Shape1(data_.count()));
@@ -738,7 +738,7 @@ void SoftmaxLossLayer::SetupAfterPartition(const LayerProto& proto,
       const vector<SLayer>& srclayers){
   Setup(proto, srclayers);
 }
-void SoftmaxLossLayer::ComputeFeature(bool training, const vector<SLayer>& srclayers) {
+void SoftmaxLossLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers) {
   Shape<2> s=Shape2(batchsize_, dim_);
   Tensor<cpu, 2> prob(data_.mutable_cpu_data(), s);
   Tensor<cpu, 2> src(srclayers[0]->mutable_data(this)->mutable_cpu_data(), s);

--- a/src/proto/model.proto
+++ b/src/proto/model.proto
@@ -25,6 +25,8 @@ enum Phase {
   kTrain = 0;
   kValidation=1;
   kTest= 2;
+  kPositive = 3;
+  kNegative = 4;
 }
 enum ShareOption{
   kValueOnly=0;

--- a/src/trainer/worker.cc
+++ b/src/trainer/worker.cc
@@ -263,7 +263,7 @@ void BPWorker::Forward(int step, Phase phase, shared_ptr<NeuralNet> net){
         }
       }
       //clock_t s=clock();
-      layer->ComputeFeature(phase==kTrain);
+      layer->ComputeFeature(phase);
       //LOG(ERROR)<<layer->name()<<":"<<(clock()-s)*1.0/CLOCKS_PER_SEC;
       if(layer->is_bridgesrclayer()){
         auto dst=layer->dstlayers().at(0);


### PR DESCRIPTION
Replace the boolean type variable "training" in ComputeFeature function (and other functions) with Phase type variable "phase". This update is to support the training of different models, e.g., RBM, and feed forward models like CNN. Phase can be kTrain (for training phase), kTest (for test phase),
kPositive (for positive phase of the contrastive divergence algorithm), etc.