### PR TITLE
SINGA-25 - Setup glog output path

### DIFF
--- a/include/utils/common.h
+++ b/include/utils/common.h
@@ -2,6 +2,7 @@
 #define SINGA_UTILS_COMMON_H_
 
 #include <google/protobuf/message.h>
+#include <stdlib.h>
 #include <map>
 #include <sstream>
 #include <string>
@@ -9,9 +10,9 @@
 
 namespace singa {
 
-std::string IntVecToString(const std::vector<int>& vec) ;
-std::string VStringPrintf(std::string fmt, va_list l) ;
-std::string StringPrintf(std::string fmt, ...) ;
+std::string IntVecToString(const std::vector<int>& vec);
+std::string VStringPrintf(std::string fmt, va_list l);
+std::string StringPrintf(std::string fmt, ...);
 void ReadProtoFromTextFile(const char* filename,
                            google::protobuf::Message* proto);
 void WriteProtoToTextFile(const google::protobuf::Message& proto,
@@ -21,6 +22,8 @@ void ReadProtoFromBinaryFile(const char* filename,
 void WriteProtoToBinaryFile(const google::protobuf::Message& proto,
                             const char* filename);
 
+const std::string CurrentDateTime();
+void  CreateFolder(const std::string name);
 /*
 inline void Sleep(int millisec=1){
   std::this_thread::sleep_for(std::chrono::milliseconds(millisec));
@@ -29,10 +32,13 @@ inline void Sleep(int millisec=1){
 
 int gcd(int a, int b);
 int LeastCommonMultiple(int a, int b);
-inline float rand_real(){
-  return  static_cast<float>(rand())/(RAND_MAX+1.0f);
+/*
+inline float rand_real() {
+  return  static_cast<float>(rand_r())/(RAND_MAX+1.0f);
 }
+*/
 const std::string GetHostIP();
+void SetupLog(const std::string& workspace, const std::string& model);
 
 class Metric {
  public:

--- a/src/main.cc
+++ b/src/main.cc
@@ -42,7 +42,8 @@ int main(int argc, char **argv) {
   singa::ReadProtoFromTextFile(FLAGS_cluster.c_str(), &cluster);
   singa::ModelProto model;
   singa::ReadProtoFromTextFile(FLAGS_model.c_str(), &model);
-  singa::SetupLog(cluster.workspace(), model.name());
+  if(cluster.has_log_dir())
+    singa::SetupLog(cluster.log_dir(), model.name());
 
   LOG(INFO) << "The cluster config is\n" << cluster.DebugString();
   LOG(INFO) << "The model config is\n" << model.DebugString();

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,6 +1,7 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include "trainer/trainer.h"
+#include "utils/common.h"
 #ifndef GFLAGS_GFLAGS_H_
   namespace gflags = google;
 #endif  // GFLAGS_GFLAGS_H_
@@ -29,11 +30,11 @@ DEFINE_string(model, "examples/mnist/conv.conf", "Model config file");
  * If users want to use their own implemented classes, they should register
  * them here. Refer to the Worker::RegisterDefaultClasses()
  */
-void RegisterClasses(const singa::ModelProto& proto){
+void RegisterClasses(const singa::ModelProto& proto) {
 }
 
+
 int main(int argc, char **argv) {
-  // TODO set log dir
   google::InitGoogleLogging(argv[0]);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
@@ -41,8 +42,10 @@ int main(int argc, char **argv) {
   singa::ReadProtoFromTextFile(FLAGS_cluster.c_str(), &cluster);
   singa::ModelProto model;
   singa::ReadProtoFromTextFile(FLAGS_model.c_str(), &model);
-  LOG(INFO)<<"The cluster config is\n"<<cluster.DebugString();
-  LOG(INFO)<<"The model config is\n"<<model.DebugString();
+  singa::SetupLog(cluster.workspace(), model.name());
+
+  LOG(INFO) << "The cluster config is\n" << cluster.DebugString();
+  LOG(INFO) << "The model config is\n" << model.DebugString();
 
   RegisterClasses(model);
   singa::Trainer trainer;

--- a/src/proto/cluster.proto
+++ b/src/proto/cluster.proto
@@ -21,7 +21,7 @@ message ClusterProto {
   // local workspace, train/val/test shards, checkpoint files
   required string workspace = 14;
   // relative path to workspace. if not set, use the default dir of glog
-  optional string log_dir = 15 [default="/tmp"];
+  optional string log_dir = 15;
   // ip/hostname : port [, ip/hostname : port]
   optional string zookeeper_host = 16 [default = "localhost:2181"];
   // message size limit, default 1MB

--- a/src/trainer/server.cc
+++ b/src/trainer/server.cc
@@ -25,7 +25,8 @@ void Server::Setup(const UpdaterProto& proto,
 }
 
 void Server::Run(){
-  LOG(ERROR)<<"Server (group_id= "<<group_id_<<", id="<<server_id_<<") starts";
+  LOG(ERROR)<<"Server (group_id = "<<group_id_
+    <<", id = "<<server_id_<<") starts";
   dealer_=std::make_shared<Dealer>(2*thread_id_);
   dealer_->Connect(kInprocRouterEndpoint);
   auto cluster=Cluster::Get();
@@ -113,7 +114,8 @@ void Server::Run(){
     if (response!=nullptr)
       dealer_->Send(&response);
   }
-  LOG(INFO)<<"Server (group_id= "<<group_id_<<", id="<<server_id_<<") stops";
+  LOG(ERROR)<<"Server (group_id = "<<group_id_
+    <<", id = "<<server_id_<<") stops";
 }
 
 Msg* Server::HandlePut(Msg **msg){

--- a/src/trainer/worker.cc
+++ b/src/trainer/worker.cc
@@ -47,7 +47,8 @@ void Worker::ConnectStub(shared_ptr<Dealer> dealer, EntityType type){
 }
 
 void Worker::Run(){
-  LOG(ERROR)<<"Worker (group_id= "<<group_id_<<", id="<<worker_id_<<") starts";
+  LOG(ERROR)<<"Worker (group_id = "<<group_id_
+    <<", id = "<<worker_id_<<") starts";
   dealer_=make_shared<Dealer>(2*thread_id_);
   ConnectStub(dealer_, kWorkerParam);
   for(auto layer: train_net_->layers())
@@ -90,7 +91,8 @@ void Worker::Run(){
   }
 
   Stop();
-  LOG(INFO)<<"Worker (group_id= "<<group_id_<<", id="<<worker_id_<<") stops";
+  LOG(ERROR)<<"Worker (group_id = "<<group_id_
+    <<", id = "<<worker_id_<<") stops";
 }
 
 void Worker::Stop(){

--- a/src/utils/common.cc
+++ b/src/utils/common.cc
@@ -146,15 +146,14 @@ const string GetHostIP() {
   return ip;
 }
 
-void SetupLog(const std::string& workspace, const std::string& model) {
-  std::string folder = workspace+"/log/";
+void SetupLog(const std::string& log_dir, const std::string& model) {
   // TODO check if NFS, then create folder using script otherwise may have
   // problems due to multiple processes create the same folder.
-  CreateFolder(folder);
-  std::string warn = folder + model + "-warn-";
-  std::string info = folder + model + "-info-";
-  std::string error = folder + model + "-error-";
-  std::string fatal = folder + model + "-fatal-";
+  CreateFolder(log_dir);
+  std::string warn = log_dir + "/" + model + "-warn-";
+  std::string info = log_dir + "/" +  model + "-info-";
+  std::string error = log_dir + "/" +  model + "-error-";
+  std::string fatal = log_dir + "/" + model + "-fatal-";
   google::SetLogDestination(google::WARNING, warn.c_str());
   google::SetLogDestination(google::INFO, info.c_str());
   google::SetLogDestination(google::ERROR, error.c_str());

--- a/src/utils/common.cc
+++ b/src/utils/common.cc
@@ -8,14 +8,15 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <netinet/in.h>
 #include <net/if.h>
 #include <arpa/inet.h>
-
-
+#include <time.h>
+#include <string>
 
 namespace singa {
 
@@ -28,18 +29,18 @@ using google::protobuf::io::ZeroCopyInputStream;
 using google::protobuf::Message;
 
 const int kBufLen = 1024;
-std::string IntVecToString(const vector<int>& vec) {
-  string disp="(";
-  for(int x: vec)
-    disp+=std::to_string(x)+", ";
-  return disp+")";
+string IntVecToString(const vector<int>& vec) {
+  string disp = "(";
+  for (int x : vec)
+    disp += std::to_string(x) + ", ";
+  return disp + ")";
 }
 /**
  *  * Formatted string.
  *   */
 string VStringPrintf(string fmt, va_list l) {
   char buffer[32768];
-  vsnprintf(buffer, 32768, fmt.c_str(), l);
+  vsnprintf(buffer, sizeof(buffer), fmt.c_str(), l);
   return string(buffer);
 }
 
@@ -48,7 +49,7 @@ string VStringPrintf(string fmt, va_list l) {
  *   */
 string StringPrintf(string fmt, ...) {
   va_list l;
-  va_start(l, fmt); //fmt.AsString().c_str());
+  va_start(l, fmt);  // fmt.AsString().c_str());
   string result = VStringPrintf(fmt, l);
   va_end(l);
   return result;
@@ -62,6 +63,14 @@ void Debug() {
   fflush(stdout);
   while (0 == i)
     sleep(5);
+}
+
+void  CreateFolder(const std::string name) {
+  struct stat buffer;
+  if (stat(name.c_str(), &buffer) != 0) {
+    mkdir(name.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+    CHECK_EQ(stat(name.c_str(), &buffer), 0);
+  }
 }
 
 // the proto related functions are from Caffe.
@@ -100,24 +109,22 @@ void WriteProtoToBinaryFile(const Message& proto, const char* filename) {
   CHECK_NE(fd, -1) << "File cannot open: " << filename;
   CHECK(proto.SerializeToFileDescriptor(fd));
 }
-int gcd(int a, int b)
-{
-  for (;;)
-  {
+
+int gcd(int a, int b) {
+  for (;;) {
     if (a == 0) return b;
     b %= a;
     if (b == 0) return a;
     a %= b;
   }
 }
-int LeastCommonMultiple(int a, int b)
-{
+int LeastCommonMultiple(int a, int b) {
   int temp = gcd(a, b);
 
   return temp ? (a / temp * b) : 0;
 }
 
-const std::string GetHostIP(){
+const string GetHostIP() {
   int fd;
   struct ifreq ifr;
 
@@ -135,7 +142,23 @@ const std::string GetHostIP(){
 
   string ip(inet_ntoa(((struct sockaddr_in *)&ifr.ifr_addr)->sin_addr));
   /* display result */
-  LOG(INFO)<<"Host IP=("<<ip;
+  LOG(INFO) << "Host IP=(" << ip;
   return ip;
 }
+
+void SetupLog(const std::string& workspace, const std::string& model) {
+  std::string folder = workspace+"/log/";
+  // TODO check if NFS, then create folder using script otherwise may have
+  // problems due to multiple processes create the same folder.
+  CreateFolder(folder);
+  std::string warn = folder + model + "-warn-";
+  std::string info = folder + model + "-info-";
+  std::string error = folder + model + "-error-";
+  std::string fatal = folder + model + "-fatal-";
+  google::SetLogDestination(google::WARNING, warn.c_str());
+  google::SetLogDestination(google::INFO, info.c_str());
+  google::SetLogDestination(google::ERROR, error.c_str());
+  google::SetLogDestination(google::FATAL, fatal.c_str());
+}
+
 }  // namespace singa


### PR DESCRIPTION
Glog's default output folder is /tmp/, which may have a lot of files and makes it not convenient to find recent logs.
This ticket is to set the log files under <workspace>/log/ folder, where workspace is configured in cluster.conf.
The log file name is 

    <model name>-<log level>-<date time>