### PR TITLE
SINGA-29 Update NeuralNet class to enable layer partition type customization

### DIFF
--- a/include/neuralnet/base_layer.h
+++ b/include/neuralnet/base_layer.h
@@ -1,5 +1,5 @@
-#ifndef SINGA_BASE_LAYER_H_
-#define SINGA_BASE_LAYER_H_
+#ifndef SINGA_NEURALNET_BASE_LAYER_H_
+#define SINGA_NEURALNET_BASE_LAYER_H_
 
 #include <vector>
 #include <string>
@@ -14,7 +14,7 @@
 #include "utils/common.h"
 #include "utils/blob.h"
 
-namespace singa{
+namespace singa {
 
 using std::vector;
 using std::string;
@@ -31,8 +31,8 @@ class Layer;
  */
 class Layer {
  public:
-  Layer(){}
-  virtual ~Layer(){}
+  Layer() { }
+  virtual ~Layer() {}
   /**
    * Setup layer properties.
    *
@@ -43,7 +43,7 @@ class Layer {
    * @param npartitions num of total partitions of the original layer. This
    * layer should be setup as one partition.
    */
-  virtual void Setup(const LayerProto& proto,int npartitions = 1);
+  virtual void Setup(const LayerProto& proto, int npartitions = 1);
 
   /**
    * Compute features of this layer based on connected layers.
@@ -73,7 +73,7 @@ class Layer {
    * @return parameters associated with this layer
    */
   virtual const vector<Param*> GetParams() const {
-    return vector<Param*>{};
+    return vector<Param*> {};
   }
   /**
    * Return the connection type between one neuron of this layer and
@@ -143,7 +143,7 @@ class Layer {
   virtual const Blob<float>& data(const Layer* from) const {
     return data_;
   }
-  virtual Blob<float>* mutable_data(const Layer* from){
+  virtual Blob<float>* mutable_data(const Layer* from) {
     return &data_;
   }
 
@@ -182,10 +182,10 @@ class Layer {
     srclayers_.clear();
   }
 
-  virtual void add_srclayer(Layer* src){
+  virtual void add_srclayer(Layer* src) {
     srclayers_.push_back(src);
   }
-  virtual void add_dstlayer(Layer* dst){
+  virtual void add_dstlayer(Layer* dst) {
     dstlayers_.push_back(dst);
   }
 
@@ -205,7 +205,7 @@ class Layer {
     return false;
   }
 
-protected:
+ protected:
   LayerProto layer_proto_;
   Blob<float> data_, grad_;
   vector<Layer*> srclayers_, dstlayers_;
@@ -247,11 +247,12 @@ class BridgeSrcLayer: public Layer {
     return true;
   }
   void set_ready(bool a) {
-    ready_=a;
+    ready_ = a;
   }
   bool ready() const {
     return ready_;
   }
+
  protected:
   //!< true if received grad from BridgeDstLayer
   bool ready_;
@@ -267,7 +268,7 @@ class BridgeDstLayer: public Layer {
 
   void Setup(const LayerProto& proto, int npartitions) override;
   void ComputeFeature(Phase phase, Metric* perf) override {
-   // reset ready_ for next iteration.
+    // reset ready_ for next iteration.
     ready_ = false;
   }
   void ComputeGradient(Phase phase) override {}
@@ -293,7 +294,7 @@ class ConcateLayer: public Layer {
   using Layer::ComputeFeature;
   using Layer::ComputeGradient;
 
-  virtual void Setup(const LayerProto& proto,int npartitions) override;
+  void Setup(const LayerProto& proto, int npartitions) override;
   void ComputeFeature(Phase phase, Metric* perf) override;
   void ComputeGradient(Phase phase) override;
 };
@@ -309,7 +310,7 @@ class DataLayer: public Layer{
   using Layer::dst_layer_connection;
 
   void ComputeGradient(Phase phase) override {}
-  virtual bool is_datalayer() const override {
+  bool is_datalayer() const override {
     return true;
   }
   Blob<float>* mutable_data(const Layer* layer) override {
@@ -334,6 +335,7 @@ class DataLayer: public Layer{
   virtual const vector<Record>& records() const {
     return records_;
   }
+
  protected:
   int random_skip_, batchsize_;
   Record sample_;
@@ -357,18 +359,19 @@ class PrefetchLayer : public Layer {
   void ComputeGradient(Phase phase) override {};
 
   const Blob<float>& data(const Layer* from) const override;
-  Blob<float>* mutable_data(const Layer* layer) override ;
+  Blob<float>* mutable_data(const Layer* layer) override;
 
   Blob<float>* mutable_grad(const Layer* layer) override {
     return nullptr;
   }
-  const Blob<float>& grad(const Layer* from) const override{
-    CHECK(false)<<"Loss layer has not gradient blob";
+  const Blob<float>& grad(const Layer* from) const override {
+    CHECK(false) << "Loss layer has not gradient blob";
     return grad_;
   }
 
   void Prefetch(Phase phase);
   virtual ~PrefetchLayer();
+
  protected:
   vector<Layer*> sublayers_;
   map<string, Blob<float>> datablobs_;
@@ -412,7 +415,7 @@ class SplitLayer: public Layer {
   using Layer::ComputeFeature;
   using Layer::ComputeGradient;
 
-  void Setup(const LayerProto& proto, int npartitions) override ;
+  void Setup(const LayerProto& proto, int npartitions) override;
   void ComputeFeature(Phase phase, Metric* perf) override;
   void ComputeGradient(Phase phase) override;
   ConnectionType dst_layer_connection() const override {
@@ -431,14 +434,14 @@ class LossLayer: public Layer{
   using Layer::grad;
   using Layer::is_losslayer;
 
-  virtual Blob<float>* mutable_grad(const Layer* layer){
+  Blob<float>* mutable_grad(const Layer* layer) override {
     return nullptr;
   }
-  virtual const Blob<float>& grad(const Layer* from) const {
-    CHECK(false)<<"Loss layer has not gradient blob";
+  const Blob<float>& grad(const Layer* from) const override {
+    CHECK(false) << "Loss layer has not gradient blob";
     return grad_;
   }
-  virtual bool is_losslayer() const {
+  bool is_losslayer() const override {
     return true;
   }
 
@@ -463,18 +466,18 @@ class ParserLayer: public Layer {
    * Parse records from DataLayer into blob.
    */
   virtual void ParseRecords(Phase phase, const vector<Record>& records,
-      Blob<float>* blob)=0;
-  bool is_parserlayer() const override{
+      Blob<float>* blob) = 0;
+  bool is_parserlayer() const override {
     return true;
   }
   Blob<float>* mutable_grad(const Layer* layer) override {
     return nullptr;
   }
   const Blob<float>& grad(const Layer* from) const  override {
-    CHECK(false)<<"Parser layer has not gradient blob";
+    CHECK(false) << "Parser layer has not gradient blob";
     return grad_;
   }
 };
-} // singa
+}  // namespace singa
 
-#endif // SINGA_BASE_LAYER_H_
+#endif  // SINGA_NEURALNET_BASE_LAYER_H_

--- a/include/neuralnet/layer.h
+++ b/include/neuralnet/layer.h
@@ -1,5 +1,7 @@
-#ifndef INCLUDE_NET_LAYER_H_
-#define INCLUDE_NET_LAYER_H_
+#ifndef SINGA_NEURALNET_LAYER_H_
+#define SINGA_NEURALNET_LAYER_H_
+
+#include <lmdb.h>
 
 #include <vector>
 #include <string>
@@ -9,12 +11,10 @@
 #include <memory>
 #include <chrono>
 #include <random>
-#include <lmdb.h>
 
 #include "proto/model.pb.h"
 #include "utils/data_shard.h"
 #include "neuralnet/base_layer.h"
-
 
 /**
  * \file this file includes the declarations neuron layer classes that conduct
@@ -37,14 +37,15 @@ class ConvolutionLayer: public Layer {
     vector<Param*> params{weight_, bias_};
     return params;
   }
-  ConnectionType src_neuron_connection(int k) const  override{
+  ConnectionType src_neuron_connection(int k) const  override {
     // CHECK_LT(k, srclayers_.size());
     return kOneToAll;
   }
   ~ConvolutionLayer();
+
  protected:
-  int kernel_, pad_,  stride_ ;
-  int batchsize_,  channels_, height_,width_;
+  int kernel_, pad_,  stride_;
+  int batchsize_,  channels_, height_, width_;
   int col_height_, col_width_, conv_height_, conv_width_, num_filters_;
   Param* weight_, *bias_;
   Blob<float> col_data_, col_grad_;
@@ -85,11 +86,12 @@ class InnerProductLayer: public Layer {
     // CHECK_LT(k, srclayers_.size());
     return kOneToAll;
   }
-  const vector<Param*> GetParams() const override{
+  const vector<Param*> GetParams() const override {
     vector<Param*> params{weight_, bias_};
     return params;
   }
   ~InnerProductLayer();
+
  private:
   //! dimension of the hidden layer
   int hdim_;
@@ -148,7 +150,7 @@ class MnistLayer: public ParserLayer {
   // n^2 images are processed as a batch for elastic distortion
   // conv height and conv width
   // gauss kernel values, displacements, column image and tmp buffer
-  //float* gauss_, *displacementx_, *displacementy_, *colimg_, *tmpimg_;
+  // float* gauss_, *displacementx_, *displacementy_, *colimg_, *tmpimg_;
   float  gamma_, beta_, sigma_, kernel_, alpha_, norm_a_, norm_b_;
   int resize_, elastic_freq_;
 };
@@ -164,7 +166,7 @@ class PoolingLayer: public Layer {
 
  protected:
   int kernel_, pad_, stride_;
-  int batchsize_,channels_, height_, width_, pooled_height_, pooled_width_;
+  int batchsize_, channels_, height_, width_, pooled_height_, pooled_width_;
   PoolingProto_PoolMethod pool_;
 };
 
@@ -272,4 +274,4 @@ class TanhLayer: public Layer {
 
 }  // namespace singa
 
-#endif  // INCLUDE_NET_LAYER_H_
+#endif  // SINGA_NEURALNET_LAYER_H_

--- a/include/trainer/server.h
+++ b/include/trainer/server.h
@@ -9,7 +9,7 @@
 
 using std::shared_ptr;
 namespace singa {
-typedef std::unordered_map<int, shared_ptr<Param>> ServerShard;
+typedef std::unordered_map<int, Param*> ServerShard;
 /* Repsond to worker's get/put/udpate request, and periodically syncing with
   * other servers.
   *
@@ -24,6 +24,7 @@ class Server{
  public:
 
   Server(int thread_id, int group_id, int server_id);
+  virtual ~Server() {};
   void Setup(const UpdaterProto& proto, shared_ptr<ServerShard> shard,
       const vector<int>& slice2group);
   void Run();
@@ -41,14 +42,14 @@ class Server{
    *
    * @return the orignal message or response message
    */
-	virtual Msg* HandleGet(shared_ptr<Param> param, Msg** msg);
+	virtual Msg* HandleGet(Param* param, Msg** msg);
 
 	/**
 	 * Process Update request.
    *
    * @return the orignal message or response message
    */
-	virtual Msg* HandleUpdate(shared_ptr<Param> param, Msg** msg);
+	virtual Msg* HandleUpdate(Param* param, Msg** msg);
 
 	/**
 	 * Process PUT request.
@@ -61,7 +62,7 @@ class Server{
 	/**
    * TODO Process SYNC request.
 	 */
-	virtual Msg* HandleSyncRequest(shared_ptr<Param> param, Msg** msg);
+	virtual Msg* HandleSyncRequest(Param* param, Msg** msg);
 
  protected:
   int thread_id_,group_id_, server_id_;

--- a/include/trainer/trainer.h
+++ b/include/trainer/trainer.h
@@ -43,7 +43,7 @@ typedef struct HandleContext_{
   */
 class ParamInfo{
    public:
-  ParamInfo(shared_ptr<Param> p,int local, int owner):
+  ParamInfo(Param* p,int local, int owner):
     num_update(0), next_version(-1),num_local(local), num_total(1),
     owner_procs(owner){
       shares.push_back(p);
@@ -57,7 +57,7 @@ class ParamInfo{
     *  otherwise
     * @param owner the procs id of the worker who ownes this Param object
     */
-  void AddParam(shared_ptr<Param> p, bool local){
+  void AddParam(Param* p, bool local){
     num_local+=local;
     num_total+=1;
     if(local)
@@ -68,7 +68,7 @@ class ParamInfo{
   int num_local; //!< # local workers uses the shared parameter
   int num_total; //!< # total workers uses the shared parameter
   int owner_procs; //!< the procs id of the worker that owns the parameter
-  vector<shared_ptr<Param>> shares;
+  vector<Param*> shares;
 };
 
 typedef std::map<int, shared_ptr<ParamInfo>> WorkerShard;
@@ -95,13 +95,12 @@ class Trainer{
   // point.
 
  protected:
-  vector<shared_ptr<Server>> CreateServers(int nthread, const ModelProto& mproto,
+  vector<Server*> CreateServers(int nthread, const ModelProto& mproto,
       const vector<int> slices, vector<HandleContext*>* ctx);
-  vector<shared_ptr<Worker>> CreateWorkers(int nthread,
-      const ModelProto& mproto, vector<int> *slice_size);
+  vector<Worker*> CreateWorkers(int nthread, const ModelProto& mproto,
+      vector<int> *slice_size);
 
-  void Run(const vector<shared_ptr<Worker>>& workers,
-      const vector<shared_ptr<Server>>& servers);
+  void Run(const vector<Worker*>& workers, const vector<Server*>& servers);
   /**
    * Register default implementations for all base classes used in the system,
    * e.g., the Updater, BaseMsg, etc.

--- a/include/trainer/worker.h
+++ b/include/trainer/worker.h
@@ -19,7 +19,7 @@ const int kCollectSleepTime=5;//milliseconds;
 class Worker {
  public:
   Worker(int thread_id, int group_id, int worker_id);
-  ~Worker(){}
+  virtual ~Worker(){}
   void Setup(const ModelProto& model, shared_ptr<NeuralNet> train_net);
   void set_test_net(shared_ptr<NeuralNet> test_net){
     test_net_=test_net;
@@ -29,10 +29,10 @@ class Worker {
   }
 
   void Stop();
-  int Put(shared_ptr<Param> param, int step);
-  int Get(shared_ptr<Param> param, int step);
-  int Update(shared_ptr<Param> param, int step);
-  int Collect(shared_ptr<Param> param, int step);
+  int Put(Param* param, int step);
+  int Get(Param* param, int step);
+  int Update(Param* param, int step);
+  int Collect(Param* param, int step);
   int CollectAll(shared_ptr<NeuralNet> net, int step);
   /**
     * check validation/test firstly, then TrainOneBatch
@@ -49,7 +49,8 @@ class Worker {
   /**
    * Test/validate one mini-batch.
    */
-  virtual void TestOneBatch(int step, Phase phase, shared_ptr<NeuralNet> net, Metric* perf)=0;
+  virtual void TestOneBatch(int step, Phase phase, shared_ptr<NeuralNet> net,
+      Metric* perf)=0;
   /**
     * Test the perforance of the learned model on validation or test dataset.
     * Test is done by the first group.
@@ -77,7 +78,7 @@ class Worker {
   const bool DisplayDebugInfo(const int step) const {
     return DisplayNow(step)&&modelproto_.debug()&&group_id_==0;
   }
-  const void DisplayPerformance(const Metric & perf, const string& prefix);
+  void DisplayPerformance(const string& prefix, const Metric & perf);
 
   /**
    * return true if the stop condition is satisfied, e.g., the maximum number
@@ -142,9 +143,11 @@ class BPWorker: public Worker{
  public:
   BPWorker(int thread_id, int group_id, int worker_id);
   ~BPWorker(){}
-  virtual void TrainOneBatch(int step, Metric* perf);
-  virtual void TestOneBatch(int step, Phase phase, shared_ptr<NeuralNet> net, Metric* perf);
-  void Forward(int step, Phase phase, shared_ptr<NeuralNet> net);
+  void TrainOneBatch(int step, Metric* perf) override;
+  void TestOneBatch(int step, Phase phase, shared_ptr<NeuralNet> net,
+      Metric* perf) override;
+
+  void Forward(int step, Phase phase, shared_ptr<NeuralNet> net, Metric* perf);
   void Backward(int step, shared_ptr<NeuralNet> net);
 };
 }  // namespace singa

--- a/include/utils/graph.h
+++ b/include/utils/graph.h
@@ -1,150 +1,101 @@
-#ifndef INCLUDE_UTILS_GRAPH_H_
-#define INCLUDE_UTILS_GRAPH_H_
-#include <glog/logging.h>
+#ifndef SINGA_UTILS_GRAPH_H_
+#define SINGA_UTILS_GRAPH_H_
 #include <vector>
 #include <string>
 #include <map>
 #include <stack>
 #include <memory>
 
+namespace singa {
 using std::vector;
 using std::string;
 using std::map;
-using std::pair;
-using std::shared_ptr;
-using std::make_shared;
 
-
-typedef struct _LayerInfo{
-  // origin identifies the origin of this node, i.e., the corresponding layer
-  string origin;
-  //int locationid;// locationidation id;
-  int partitionid;
-  int slice_dimension;
-  int concate_dimension;
-}LayerInfo;
-typedef LayerInfo V;
-
-
-class Node;
-typedef shared_ptr<Node> SNode;
-
-class Node{
+class Node {
  public:
-  typedef shared_ptr<Node> SNode;
-  Node(string name): name_(name){}
-  Node(string name, const V& v):
-    name_(name), val_(v){}
+  /**
+   * Node constructor.
+   *
+   * @param name name of the corresponding layer
+   */
+  explicit Node(string name);
+  /**
+   * Node constructor.
+   *
+   * This node is a partition of some node.
+   * @param name node name
+   * @param origin  name of the original node
+   * @param id partition id of this node
+   * @param proto conf of the corresponding layer
+   */
+  Node(const string& name, const string& origin, int id, void* proto);
+  ~Node();
+  void AddDstNode(Node* dstnode);
+  void AddSrcNode(Node* srcnode);
+  void RemoveDstNode(Node* dst);
+  void RemoveSrcNode(Node* src);
 
-  void AddDstNode(SNode dstnode){
-    dstnodes_.push_back(dstnode);
-  }
-  void AddSrcNode(SNode srcnode){
-    srcnodes_.push_back(srcnode);
-  }
+ public:
+  string name;
+  //! name of the origin node/layer from which is node is derived
+  string origin;
+  //! partition id
+  int partition_id;
+  //! proto of the corresponding layer
+  void* proto;
 
-  void RemoveDstNode(SNode dst){
-    auto iter=dstnodes_.begin();
-    while((*iter)->name_!=dst->name_&&iter!=dstnodes_.end()) iter++;
-    CHECK((*iter)->name_==dst->name_);
-    dstnodes_.erase(iter);
-  }
-  void RemoveSrcNode(SNode src){
-    auto iter=srcnodes_.begin();
-    while((*iter)->name_!=src->name_&&iter!=srcnodes_.end()) iter++;
-    CHECK((*iter)->name_==src->name_);
-    srcnodes_.erase(iter);
-  }
-  const string& name() const {return name_;}
-  const V& val() const {return val_;}
-  const SNode srcnodes(int k) const {return srcnodes_[k]; }
-  const SNode dstnodes(int k) const {return dstnodes_[k]; }
-  const vector<SNode>& srcnodes() const {return srcnodes_; }
-  const vector<SNode>& dstnodes() const {return dstnodes_; }
-  int  dstnodes_size() const {return dstnodes_.size(); }
-  int  srcnodes_size() const {return srcnodes_.size(); }
-
- private:
-  string name_;
-  vector<SNode> srcnodes_;
-  vector<SNode> dstnodes_;
-
-  V val_;
-    // properties
-  string color_, weight_, shape_;
+  vector<Node*> srcnodes;
+  vector<Node*> dstnodes;
 };
 
-
 /**
- * For partition neuralnet and displaying the neuralnet structure
+ * Neuralnet is constructed by creating a graph with each node representing one
+ * layer at first. After topology sort for graph nodes, layers are created and
+ * connected.
  */
-class Graph{
+class Graph {
  public:
-  Graph(){}
-  void Sort();
-  const SNode& AddNode(string name, V origin){
-    nodes_.push_back(make_shared<Node>(name, origin));
-    name2node_[name]=nodes_.back();
-    return nodes_.back();
-  }
-  const SNode& AddNode(string name){
-    nodes_.push_back(make_shared<Node>(name));
-    name2node_[name]=nodes_.back();
-    return nodes_.back();
-  }
-
-  void AddEdge(SNode srcnode, SNode dstnode){
-    srcnode->AddDstNode(dstnode);
-    dstnode->AddSrcNode(srcnode);
-  }
-
-  void AddEdge(const string& src, const string& dst){
-    CHECK(name2node_.find(src)!=name2node_.end())<<"can't find src node "<<src;
-    CHECK(name2node_.find(dst)!=name2node_.end())<<"can't find dst node "<<dst;
-
-    SNode srcnode=name2node_[src], dstnode=name2node_[dst];
-    AddEdge(srcnode, dstnode);
-  }
-
-  void RemoveEdge(const string &src, const string& dst){
-    CHECK(name2node_.find(src)!=name2node_.end())<<"can't find src node "<<src;
-    CHECK(name2node_.find(dst)!=name2node_.end())<<"can't find dst node "<<dst;
-
-    SNode srcnode=name2node_[src], dstnode=name2node_[dst];
-    RemoveEdge(srcnode, dstnode);
-  }
-
-  void RemoveEdge(SNode src, SNode dst){
-    src->RemoveDstNode(dst);
-    dst->RemoveSrcNode(src);
-  }
-
-  const vector<SNode>& nodes() const{
+  Graph() {}
+  ~Graph();
+  /**
+   * @return all nodes of the graph
+   */
+  const vector<Node*>& nodes() const {
     return nodes_;
-  };
-
-  const SNode& node(string name) const{
-    CHECK(name2node_.find(name)!= name2node_.end())
-      <<"can't find dst node "<<name;
+  }
+  /**
+   * @param name node name
+   * @return return the node of given name
+   */
+  Node* node(const string& name) const {
     return name2node_.at(name);
   }
 
-  const string ToString() const;
-  const string ToString(const map<string, string>& info) const ;
-
-  bool Check() const;
-
-  SNode InsertSliceNode(SNode srcnode, const vector<SNode>& dstnodes,
-      const V& info, bool connect_dst=true);
-  SNode InsertConcateNode(const vector<SNode>&srcnodes, SNode dstnode,
-      const V& info);
-  SNode InsertSplitNode(SNode srcnode, const vector<SNode>& dstnodes);
-  std::pair<SNode, SNode> InsertBridgeNode(SNode srcnode, SNode dstnode);
-  void topology_sort_inner(SNode node, map<string, bool> *visited,
-    std::stack<string> *stack);
+  void AddNode(Node* node);
+  Node* AddNode(const string& name);
+  void AddEdge(Node* srcnode, Node* dstnode);
+  void AddEdge(const string& src, const string& dst);
+  void RemoveEdge(Node* src, Node* dst);
+  void RemoveEdge(const string &src, const string& dst);
+  /**
+   * Dump the graph into json string which can be used to draw a picture by
+   * graphviz
+   */
+  const string ToJson() const;
+  /**
+   * \copybreif ToJson()
+   *
+   * @param info info associated with each node
+   */
+  const string ToJson(const map<string, string>& info) const;
+  /**
+   * Do topology sort for all nodes of the graph.
+   */
+  void Sort();
 
  private:
-  vector<SNode> nodes_;
-  map<string, SNode> name2node_;
+  vector<Node*> nodes_;
+  map<string, Node*> name2node_;
 };
-#endif // INCLUDE_UTILS_GRAPH_H_
+}  // namespace singa
+#endif  // SINGA_UTILS_GRAPH_H_

--- a/include/utils/param.h
+++ b/include/utils/param.h
@@ -115,7 +115,7 @@ class Param {
    *
    * @param other the Param object whose owner owns the data blob
    */
-  void ShareData(shared_ptr<Param> other){
+  void ShareData(Param* other){
     proto_.set_owner(other->owner());
     if(data_!=nullptr)
       CHECK(std::equal(data_->shape().begin(), data_->shape().end(),

--- a/include/utils/updater.h
+++ b/include/utils/updater.h
@@ -12,7 +12,7 @@ class Updater{
   virtual void Init(const UpdaterProto &proto){
     proto_=proto;
   }
-  virtual void Update(int step, shared_ptr<Param> param, float grad_scale=1.0f)=0;
+  virtual void Update(int step, Param* param, float grad_scale=1.0f)=0;
 
   float GetLearningRate(int step);
  protected:
@@ -21,7 +21,7 @@ class Updater{
 class SGDUpdater : public Updater{
  public:
   virtual void Init(const UpdaterProto& proto);
-  virtual void Update(int step, shared_ptr<Param> param, float grad_scale=1.0f);
+  virtual void Update(int step, Param* param, float grad_scale=1.0f);
 
  protected:
   float base_lr_;
@@ -31,7 +31,7 @@ class SGDUpdater : public Updater{
 class NesterovUpdater : public Updater{
  public:
   virtual void Init(const UpdaterProto& proto);
-  virtual void Update(int step, shared_ptr<Param> param, float grad_scale=1.0f);
+  virtual void Update(int step, Param* param, float grad_scale=1.0f);
 
  protected:
   float base_lr_;
@@ -41,7 +41,7 @@ class NesterovUpdater : public Updater{
 class AdaGradUpdater : public Updater{
  public:
   virtual void Init(const UpdaterProto& proto);
-  virtual void Update(int step, shared_ptr<Param> param, float grad_scale=1.0f);
+  virtual void Update(int step, Param* param, float grad_scale=1.0f);
 
  protected:
   float base_lr_;
@@ -52,7 +52,7 @@ class AdaGradUpdater : public Updater{
 class RMSPropUpdater : public Updater{
  public:
   virtual void Init(const UpdaterProto& proto);
-  virtual void Update(int step, shared_ptr<Param> param, float grad_scale=1.0f);
+  virtual void Update(int step, Param* param, float grad_scale=1.0f);
 
  protected:
   float base_lr_;
@@ -65,7 +65,7 @@ class RMSPropUpdater : public Updater{
 class AdaDeltaUpdater : public Updater{
  public:
   virtual void Init(const UpdaterProto& proto);
-  virtual void Update(int step, shared_ptr<Param> param, float grad_scale=1.0f);
+  virtual void Update(int step, Param* param, float grad_scale=1.0f);
 
  protected:
   float rho_;

--- a/src/neuralnet/layer.cc
+++ b/src/neuralnet/layer.cc
@@ -13,18 +13,47 @@ using namespace mshadow;
 using namespace mshadow::expr;
 
 namespace singa {
+inline Tensor<cpu, 4> Tensor4(Blob<float>* blob) {
+  const vector<int>& shape = blob->shape();
+  Tensor<cpu, 4> tensor(blob->mutable_cpu_data(),
+      Shape4(shape[0], shape[1], shape[2], shape[3]));
+  return tensor;
+}
+
+inline Tensor<cpu, 3> Tensor3(Blob<float>* blob){
+  const vector<int>& shape = blob->shape();
+  Tensor<cpu, 3> tensor(blob->mutable_cpu_data(),
+      Shape3(shape[0], shape[1], blob->count() / shape[0] / shape[1]));
+  return tensor;
+}
+inline Tensor<cpu, 2> Tensor2(Blob<float>* blob){
+  const vector<int>& shape = blob->shape();
+  Tensor<cpu, 2> tensor(blob->mutable_cpu_data(),
+      Shape2(shape[0], blob->count() / shape[0]));
+  return tensor;
+}
+inline Tensor<cpu, 1> Tensor1(Blob<float>* blob){
+  Tensor<cpu, 1> tensor(blob->mutable_cpu_data(), Shape1(blob->count()));
+  return tensor;
+}
 
 /************ Implementation for ConvProductLayer*************************/
-void ConvolutionLayer::Setup(const LayerProto& proto,
-      const vector<SLayer>& srclayers){
-  CHECK_EQ(srclayers.size(),1);
+ConvolutionLayer::~ConvolutionLayer() {
+  delete weight_;
+  delete bias_;
+}
+void ConvolutionLayer::Setup(const LayerProto& proto, int npartitions) {
+  Layer::Setup(proto, npartitions);
   ConvolutionProto conv_conf=proto.convolution_conf();
   kernel_=conv_conf.kernel();
   CHECK_GT(kernel_, 0) << "Filter size cannot be zero.";
   pad_=conv_conf.pad();
   stride_=conv_conf.stride();
   num_filters_=conv_conf.num_filters();
-  const vector<int>& srcshape=srclayers[0]->data(this).shape();
+  if(partition_dim() > 0)
+    num_filters_ /= npartitions;
+
+  const vector<int>& srcshape=srclayers_[0]->data(this).shape();
   int dim=srcshape.size();
   CHECK_GT(dim, 2);
   width_=srcshape[dim-1];
@@ -45,32 +74,18 @@ void ConvolutionLayer::Setup(const LayerProto& proto,
   col_grad_.Reshape(vector<int>{col_height_, col_width_});
 
   Factory<Param>* factory=Singleton<Factory<Param>>::Instance();
-  weight_=shared_ptr<Param>(factory->Create("Param"));
+  weight_ = factory->Create("Param");
   weight_->Setup(proto.param(0), vector<int>{num_filters_, col_height_});
-  bias_=shared_ptr<Param>(factory->Create("Param"));
+  bias_ = factory->Create("Param");
   bias_->Setup(proto.param(1), vector<int>{num_filters_});
 }
 
-void ConvolutionLayer::SetupAfterPartition(const LayerProto& proto,
-      const vector<int> &shape,
-      const vector<SLayer>& srclayers){
-  LayerProto newproto(proto);
-  ConvolutionProto *conv_conf=newproto.mutable_convolution_conf();
-  conv_conf->set_num_filters(shape[1]);
-  Setup(newproto, srclayers);
-}
-
-void ConvolutionLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers){
-  Tensor<cpu, 4> src(srclayers[0]->mutable_data(this)->mutable_cpu_data(),
-      Shape4(batchsize_, channels_, height_, width_));
-  Tensor<cpu, 3> data(data_.mutable_cpu_data(),
-      Shape3(batchsize_, num_filters_, conv_height_* conv_width_));
-  Tensor<cpu, 2> col(col_data_.mutable_cpu_data(),
-      Shape2(col_height_, col_width_));
-  Tensor<cpu, 2> weight(weight_->mutable_cpu_data(),
-      Shape2(num_filters_, col_height_));
-  Tensor<cpu, 1> bias(bias_->mutable_cpu_data(),
-      Shape1(num_filters_));
+void ConvolutionLayer::ComputeFeature(Phase phase, Metric* perf){
+  auto src = Tensor4(srclayers_[0]->mutable_data(this));
+  auto data = Tensor3(&data_);
+  auto col = Tensor2(&col_data_);
+  auto weight = Tensor2(weight_->mutable_data());
+  auto bias = Tensor1(bias_->mutable_data());
 
   for(int n=0;n<batchsize_;n++){
     if(pad_>0)
@@ -82,144 +97,126 @@ void ConvolutionLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclaye
   data+=broadcast<1>(bias, data.shape);
 }
 
-void ConvolutionLayer::ComputeGradient(const vector<SLayer>& srclayers) {
-  Tensor<cpu, 4> src(srclayers[0]->mutable_data(this)->mutable_cpu_data(),
-      Shape4(batchsize_, channels_, height_, width_));
-  Tensor<cpu, 2> col(col_data_.mutable_cpu_data(),
-      Shape2(col_height_, col_width_));
-  Tensor<cpu, 2> weight(weight_->mutable_cpu_data(),
-      Shape2(num_filters_, col_height_));
+void ConvolutionLayer::ComputeGradient(Phase phase) {
+  auto src = Tensor4(srclayers_[0]->mutable_data(this));
+  auto col = Tensor2(&col_data_);
+  auto weight = Tensor2(weight_->mutable_data());
 
-  Blob<float>* gsrcblob=srclayers[0]->mutable_grad(this);
+  auto grad = Tensor3(&grad_);
+  auto gcol = Tensor2(&col_grad_);
+  auto gweight = Tensor2(weight_->mutable_grad());
+  auto gbias = Tensor1(bias_->mutable_grad());
+
+  Blob<float>* gsrcblob=srclayers_[0]->mutable_grad(this);
   Tensor<cpu, 4> gsrc(nullptr, Shape4(batchsize_, channels_, height_, width_));
   if(gsrcblob!=nullptr)
     gsrc.dptr=gsrcblob->mutable_cpu_data();
-  Tensor<cpu, 3> grad(grad_.mutable_cpu_data(),
-      Shape3(batchsize_, num_filters_, conv_height_* conv_width_));
-  Tensor<cpu, 2> gcol(col_grad_.mutable_cpu_data(),
-      Shape2(col_height_, col_width_));
-  Tensor<cpu, 2> gweight(weight_->mutable_cpu_grad(),
-      Shape2(num_filters_, col_height_));
-  Tensor<cpu, 1> gbias(bias_->mutable_cpu_grad(),
-      Shape1(num_filters_));
-
-  gweight=0.0f;
   gbias=sumall_except_dim<1>(grad);
-  Shape<3> padshape(gsrc.shape.SubShape());
-  padshape[0]+=2*pad_;padshape[1]+=2*pad_;
-  Shape<2> imgshape=Shape2(height_, width_);
+
+  gweight = 0.0f;
+  Shape<3> padshp(gsrc.shape.SubShape());
+  padshp[0] += 2 * pad_;
+  padshp[1] += 2 * pad_;
+  Shape<2> imgshp = Shape2(height_, width_);
   for(int n=0;n<batchsize_;n++){
     if(pad_>0)
       col=unpack_patch2col(pad(src[n], pad_), kernel_, stride_);
     else
       col=unpack_patch2col(src[n], kernel_, stride_);
-    gweight+=dot(grad[n], col.T());
+    gweight += dot(grad[n], col.T());
 
     if(gsrcblob!=nullptr){
-      gcol=dot(weight.T(), grad[n]);
-      gsrc[n]=crop(pack_col2patch(gcol, padshape, kernel_, stride_), imgshape);
+      gcol = dot(weight.T(), grad[n]);
+      gsrc[n] = crop(pack_col2patch(gcol, padshp, kernel_, stride_), imgshp);
     }
   }
 }
 
 /****************** Implementation for DropoutLayer ***********************/
-void DropoutLayer::Setup(const LayerProto& proto,
-      const vector<SLayer>& srclayers){
-  data_.ReshapeLike(srclayers[0]->data(this));
-  grad_.ReshapeLike(*srclayers[0]->mutable_grad(this));
-  mask_.Reshape(srclayers[0]->data(this).shape());
-  pdrop_=proto.dropout_conf().dropout_ratio();
+void DropoutLayer::Setup(const LayerProto& proto, int npartitions) {
+  Layer::Setup(proto, npartitions);
+  data_.ReshapeLike(srclayers_[0]->data(this));
+  grad_.ReshapeLike(*srclayers_[0]->mutable_grad(this));
+  mask_.Reshape(srclayers_[0]->data(this).shape());
+  pdrop_ = proto.dropout_conf().dropout_ratio();
 }
 
-void DropoutLayer::SetupAfterPartition(const LayerProto& proto,
-      const vector<int> &shape,
-      const vector<SLayer>& srclayers){
-  Setup(proto, srclayers);
-}
-
-void DropoutLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers) {
+void DropoutLayer::ComputeFeature(Phase phase, Metric* perf) {
   // check training
-  if(phase!= kTrain){//!training){
-    data_.CopyFrom(srclayers[0]->data(this));
+  if(phase != kTrain){//!training){
+    data_.CopyFrom(srclayers_[0]->data(this));
     return;
   }
   float pkeep=1-pdrop_;
-  Tensor<cpu, 1> mask(mask_.mutable_cpu_data(), Shape1(mask_.count()));
+  auto mask = Tensor1(&mask_);
   mask = F<op::threshold>(TSingleton<Random<cpu>>::Instance()\
       ->uniform(mask.shape), pkeep ) * (1.0f/pkeep);
-  Tensor<cpu, 1> data(data_.mutable_cpu_data(), Shape1(data_.count()));
-  Blob<float>* srcblob=srclayers[0]->mutable_data(this);
-  Tensor<cpu, 1> src(srcblob->mutable_cpu_data(), Shape1(srcblob->count()));
-  data=src*mask;
+  auto data = Tensor1(&data_);
+  auto src = Tensor1(srclayers_[0]->mutable_data(this));
+  data = src * mask;
 }
 
-void DropoutLayer::ComputeGradient(const vector<SLayer>& srclayers)  {
-  Tensor<cpu, 1> grad(grad_.mutable_cpu_data(), Shape1(data_.count()));
-  Tensor<cpu, 1> mask(mask_.mutable_cpu_data(), Shape1(mask_.count()));
-  Blob<float>* gsrcblob=srclayers[0]->mutable_grad(this);
-  Tensor<cpu, 1> gsrc(gsrcblob->mutable_cpu_data(), Shape1(gsrcblob->count()));
-  gsrc=grad*mask;
+void DropoutLayer::ComputeGradient(Phase phase)  {
+  auto mask = Tensor1(&mask_);
+  auto grad = Tensor1(&grad_);
+  auto gsrc = Tensor1(srclayers_[0]->mutable_grad(this));
+  gsrc = grad * mask;
 }
-/**************** Implementation for InnerProductLayer********************/
-void InnerProductLayer::Setup(const LayerProto& proto,
-      const vector<SLayer>& srclayers){
-  CHECK_EQ(srclayers.size(),1);
-  const auto& src=srclayers[0]->data(this);
+
+/*********** Implementation for InnerProductLayer**********/
+InnerProductLayer::~InnerProductLayer() {
+  delete weight_;
+  delete bias_;
+}
+void InnerProductLayer::Setup(const LayerProto& proto, int npartitions) {
+  Layer::Setup(proto, npartitions);
+  CHECK_EQ(srclayers_.size(), 1);
+  const auto& src=srclayers_[0]->data(this);
   batchsize_=src.shape()[0];
   vdim_=src.count()/batchsize_;
   hdim_=proto.innerproduct_conf().num_output();
+  if(partition_dim()>0)
+    hdim_ /= npartitions;
   data_.Reshape(vector<int>{batchsize_, hdim_});
   grad_.ReshapeLike(data_);
   Factory<Param>* factory=Singleton<Factory<Param>>::Instance();
-  weight_=shared_ptr<Param>(factory->Create("Param"));
-  bias_=shared_ptr<Param>(factory->Create("Param"));
+  weight_ = factory->Create("Param");
+  bias_ = factory->Create("Param");
   weight_->Setup(proto.param(0), vector<int>{vdim_, hdim_});
   bias_->Setup(proto.param(1), vector<int>{hdim_});
 }
-void InnerProductLayer::SetupAfterPartition(const LayerProto& proto,
-      const vector<int> &shape,
-      const vector<SLayer>& srclayers){
-  LayerProto newproto(proto);
-  InnerProductProto * innerproto=newproto.mutable_innerproduct_conf();
-  innerproto->set_num_output(shape[1]);
-  Setup(newproto, srclayers);
-}
 
-void InnerProductLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers) {
-  Tensor<cpu, 2> data(data_.mutable_cpu_data(), Shape2(batchsize_,hdim_));
-  CHECK_EQ(srclayers[0]->data(this).count(), batchsize_*vdim_);
-  Tensor<cpu, 2> src(srclayers[0]->mutable_data(this)->mutable_cpu_data(),
-      Shape2(batchsize_,vdim_));
-  Tensor<cpu, 2> weight(weight_->mutable_cpu_data(), Shape2(vdim_,hdim_));
-  Tensor<cpu, 1> bias(bias_->mutable_cpu_data(), Shape1(hdim_));
+void InnerProductLayer::ComputeFeature(Phase phase, Metric* perf) {
+  auto data = Tensor2(&data_);
+  auto src = Tensor2(srclayers_[0]->mutable_data(this));
+  auto weight = Tensor2(weight_->mutable_data());
+  auto bias = Tensor1(bias_->mutable_data());
   data=dot(src, weight);
   // repmat: repeat bias vector into batchsize rows
   data+=repmat(bias, batchsize_);
 }
 
-void InnerProductLayer::ComputeGradient(const vector<SLayer>& srclayers) {
-  Tensor<cpu, 2> src(srclayers[0]->mutable_data(this)->mutable_cpu_data(),
-      Shape2(batchsize_,vdim_));
-  Tensor<cpu, 2> grad(grad_.mutable_cpu_data(),Shape2(batchsize_,hdim_));
-  Tensor<cpu, 2> weight(weight_->mutable_cpu_data(), Shape2(vdim_,hdim_));
-  Tensor<cpu, 2> gweight(weight_->mutable_cpu_grad(), Shape2(vdim_,hdim_));
-  Tensor<cpu, 1> gbias(bias_->mutable_cpu_grad(), Shape1(hdim_));
+void InnerProductLayer::ComputeGradient(Phase phas) {
+  auto src = Tensor2(srclayers_[0]->mutable_data(this));
+  auto grad = Tensor2(&grad_);
+  auto weight = Tensor2(weight_->mutable_data());
+  auto gweight = Tensor2(weight_->mutable_grad());
+  auto gbias = Tensor1(bias_->mutable_grad());
 
   gbias=sum_rows(grad);
   gweight=dot(src.T(), grad);
-  if(srclayers[0]->mutable_grad(this)!=nullptr){
-    Tensor<cpu, 2> gsrc(srclayers[0]->mutable_grad(this)->mutable_cpu_data(),
-        Shape2(batchsize_,vdim_));
+  if(srclayers_[0]->mutable_grad(this)!=nullptr){
+    auto gsrc = Tensor2(srclayers_[0]->mutable_grad(this));
     gsrc=dot(grad, weight.T());
   }
 }
 /*****************************************************************************
  * Implementation for LabelLayer
  *****************************************************************************/
-void LabelLayer::Setup(const LayerProto& proto,
-    const vector<SLayer>& srclayers){
-  CHECK_EQ(srclayers.size(),1);
-  int batchsize=static_cast<DataLayer*>(srclayers[0].get())->batchsize();
+void LabelLayer::Setup(const LayerProto& proto, int npartitions){
+  Layer::Setup(proto, npartitions);
+  CHECK_EQ(srclayers_.size(),1);
+  int batchsize=static_cast<DataLayer*>(srclayers_[0])->batchsize();
   data_.Reshape(vector<int>{batchsize});
 }
 
@@ -236,7 +233,7 @@ void LabelLayer::ParseRecords(Phase phase, const vector<Record>& records,
 
 
 /*********************LMDBDataLayer**********************************/
-void LMDBDataLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers){
+void LMDBDataLayer::ComputeFeature(Phase phase, Metric* perf){
   if(random_skip_){
     int nskip=rand()%random_skip_;
     int n=0;
@@ -296,8 +293,8 @@ void LMDBDataLayer::ConvertDatumToSingleLableImageRecord(const Datum& datum,
   }
 }
 
-void LMDBDataLayer::Setup(const LayerProto& proto,
-    const vector<SLayer>& srclayers){
+void LMDBDataLayer::Setup(const LayerProto& proto, int npartitions) {
+  Layer::Setup(proto, npartitions);
   CHECK_EQ(mdb_env_create(&mdb_env_), MDB_SUCCESS) << "mdb_env_create failed";
   CHECK_EQ(mdb_env_set_mapsize(mdb_env_, 1099511627776), MDB_SUCCESS); // 1TB
   CHECK_EQ(mdb_env_open(mdb_env_,
@@ -325,21 +322,23 @@ void LMDBDataLayer::Setup(const LayerProto& proto,
   ConvertDatumToSingleLableImageRecord(datum, record);
 
   batchsize_=batchsize();
+  if(partition_dim() == 0)
+    batchsize_ /= npartitions;
   records_.resize(batchsize_);
   random_skip_=proto.lmdbdata_conf().random_skip();
 }
 
 /***************** Implementation for LRNLayer *************************/
-void LRNLayer::Setup(const LayerProto& proto,
-      const vector<SLayer>& srclayers){
-  CHECK_EQ(srclayers.size(),1);
+void LRNLayer::Setup(const LayerProto& proto, int npartitions) {
+  Layer::Setup(proto, npartitions);
+  CHECK_EQ(srclayers_.size(),1);
   lsize_ = proto.lrn_conf().local_size();
   CHECK_EQ(lsize_ % 2, 1) << "LRN only supports odd values for Localvol";
   knorm_=proto.lrn_conf().knorm();
   alpha_ = proto.lrn_conf().alpha();
   beta_ = proto.lrn_conf().beta();
 
-  const vector<int>& s=srclayers[0]->data(this).shape();
+  const vector<int>& s=srclayers_[0]->data(this).shape();
   data_.Reshape(s);
   grad_.Reshape(s);
   norm_.Reshape(s);
@@ -349,30 +348,22 @@ void LRNLayer::Setup(const LayerProto& proto,
   width_=s[3];
 }
 
-void LRNLayer::SetupAfterPartition(const LayerProto& proto,
-      const vector<int> &shape,
-      const vector<SLayer>& srclayers){
-  Setup(proto, srclayers);
-}
-
-void LRNLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers){
+void LRNLayer::ComputeFeature(Phase phase, Metric* perf) {
   const float salpha = alpha_ / lsize_;
-  Shape<4> s=Shape4(batchsize_,channels_, height_, width_);
-  Tensor<cpu, 4> src(srclayers[0]->mutable_data(this)->mutable_cpu_data(), s);
-  Tensor<cpu, 4> data(data_.mutable_cpu_data(), s);
-  Tensor<cpu, 4> norm(norm_.mutable_cpu_data(), s);
+  auto src = Tensor4(srclayers_[0]->mutable_data(this));
+  auto data = Tensor4(&data_);
+  auto norm = Tensor4(&norm_);
   // stores normalizer without power
   norm= chpool<red::sum>( F<op::square>(src) , lsize_ ) * salpha + knorm_;
   data = src * F<op::power>(norm, -beta_ );
 }
 
-void LRNLayer::ComputeGradient(const vector<SLayer>& srclayers) {
+void LRNLayer::ComputeGradient(Phase phase) {
   const float salpha = alpha_ / lsize_;
-  Shape<4> s=Shape4(batchsize_,channels_, height_, width_);
-  Tensor<cpu, 4> src(srclayers[0]->mutable_data(this)->mutable_cpu_data(), s);
-  Tensor<cpu, 4> norm(norm_.mutable_cpu_data(), s);
-  Tensor<cpu, 4> grad(grad_.mutable_cpu_data(), s);
-  Tensor<cpu, 4> gsrc(srclayers[0]->mutable_grad(this)->mutable_cpu_data(), s);
+  auto src = Tensor4(srclayers_[0]->mutable_data(this));
+  auto norm = Tensor4(&norm_);
+  auto grad = Tensor4(&grad_);
+  auto gsrc = Tensor4(srclayers_[0]->mutable_grad(this));
 
   gsrc = grad * F<op::power>( norm, -beta_ );
   gsrc += ( - 2.0f * beta_ * salpha ) * chpool<red::sum>(
@@ -448,11 +439,11 @@ void MnistLayer::ParseRecords(Phase phase,
   }
   CHECK_EQ(dptr, blob->mutable_cpu_data()+blob->count());
 }
-void MnistLayer::Setup(const LayerProto& proto,
-    const vector<SLayer>& srclayers){
-  CHECK_EQ(srclayers.size(),1);
-  int batchsize=static_cast<DataLayer*>(srclayers[0].get())->batchsize();
-  Record sample=static_cast<DataLayer*>(srclayers[0].get())->sample();
+void MnistLayer::Setup(const LayerProto& proto, int npartitions) {
+  Layer::Setup(proto, npartitions);
+  CHECK_EQ(srclayers_.size(),1);
+  int batchsize=static_cast<DataLayer*>(srclayers_[0])->batchsize();
+  Record sample=static_cast<DataLayer*>(srclayers_[0])->sample();
   kernel_=proto.mnist_conf().kernel();
   sigma_=proto.mnist_conf().sigma();
   alpha_=proto.mnist_conf().alpha();
@@ -475,9 +466,9 @@ void MnistLayer::Setup(const LayerProto& proto,
 }
 
 /******************** Implementation for PoolingLayer******************/
-void PoolingLayer::Setup(const LayerProto& proto,
-      const vector<SLayer>& srclayers){
-  CHECK_EQ(srclayers.size(),1);
+void PoolingLayer::Setup(const LayerProto& proto, int npartitions) {
+  Layer::Setup(proto, npartitions);
+  CHECK_EQ(srclayers_.size(),1);
   PoolingProto pool_conf = proto.pooling_conf();
   kernel_=pool_conf.kernel();
   stride_=pool_conf.stride();
@@ -487,7 +478,7 @@ void PoolingLayer::Setup(const LayerProto& proto,
         || pool_ == PoolingProto_PoolMethod_MAX)
       << "Padding implemented only for average and max pooling.";
 
-  const auto& srcshape=srclayers[0]->data(this).shape();
+  const auto& srcshape=srclayers_[0]->data(this).shape();
   int dim=srcshape.size();
   CHECK_GT(dim,2);
   width_ = srcshape[dim-1];
@@ -503,68 +494,49 @@ void PoolingLayer::Setup(const LayerProto& proto,
   grad_.ReshapeLike(data_);
 }
 
-void PoolingLayer::SetupAfterPartition(const LayerProto& proto,
-      const vector<int> &shape,
-      const vector<SLayer>& srclayers){
-  Setup(proto, srclayers);
-}
-
-void PoolingLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers){
-  Tensor<cpu, 4> src(srclayers[0]->mutable_data(this)->mutable_cpu_data(),
-      Shape4(batchsize_, channels_, height_, width_));
-  Tensor<cpu, 4> data(data_.mutable_cpu_data(),
-      Shape4(batchsize_, channels_, pooled_height_, pooled_width_));
+void PoolingLayer::ComputeFeature(Phase phase, Metric* perf) {
+  auto src = Tensor4(srclayers_[0]->mutable_data(this));
+  auto data = Tensor4(&data_);
   if(pool_ == PoolingProto_PoolMethod_MAX)
     data=pool<red::maximum>(src, kernel_, stride_);
   else if(pool_ == PoolingProto_PoolMethod_AVE)
-    data=pool<red::sum>(src, kernel_, stride_)
-      *(1.0f/(kernel_*kernel_));
+    data=pool<red::sum>(src, kernel_, stride_) *(1.0f/(kernel_*kernel_));
 }
 
 /*
  * partition only on num/channel dim
  * assume grad and data have the same paritition
  */
-void PoolingLayer::ComputeGradient(const vector<SLayer>& srclayers) {
-  Shape<4> s1= Shape4(batchsize_, channels_, height_, width_);
-  Tensor<cpu, 4> src(srclayers[0]->mutable_data(this)->mutable_cpu_data(),s1);
-  Tensor<cpu, 4> gsrc(srclayers[0]->mutable_grad(this)->mutable_cpu_data(),s1);
-  Shape<4> s2= Shape4(batchsize_, channels_, pooled_height_, pooled_width_);
-  Tensor<cpu, 4> data(data_.mutable_cpu_data(), s2);
-  Tensor<cpu, 4> grad(grad_.mutable_cpu_data(), s2);
+void PoolingLayer::ComputeGradient(Phase phase) {
+  auto src = Tensor4(srclayers_[0]->mutable_data(this));
+  auto gsrc = Tensor4(srclayers_[0]->mutable_grad(this));
+  auto data = Tensor4(&data_);
+  auto grad = Tensor4(&grad_);
   if(pool_ == PoolingProto_PoolMethod_MAX)
-      gsrc = unpool<red::maximum>(src, data, grad, kernel_, stride_);
+    gsrc = unpool<red::maximum>(src, data, grad, kernel_, stride_);
   else if(pool_ == PoolingProto_PoolMethod_AVE)
-      gsrc = unpool<red::sum>(src, data, grad, kernel_, stride_)
-        *(1.0f/(kernel_*kernel_));
+    gsrc = unpool<red::sum>(src, data, grad, kernel_, stride_)
+      *(1.0f/(kernel_*kernel_));
 }
 
 /***************** Implementation for ReLULayer *****************************/
 
-void ReLULayer::Setup(const LayerProto& proto,
-      const vector<SLayer>& srclayers){
-  data_.ReshapeLike(srclayers[0]->data(this));
-  grad_.ReshapeLike(*(srclayers[0]->mutable_grad(this)));
+void ReLULayer::Setup(const LayerProto& proto, int npartitions) {
+  Layer::Setup(proto, npartitions);
+  data_.ReshapeLike(srclayers_[0]->data(this));
+  grad_.ReshapeLike(*(srclayers_[0]->mutable_grad(this)));
 }
 
-void ReLULayer::SetupAfterPartition(const LayerProto& proto,
-      const vector<int> &shape,
-      const vector<SLayer>& srclayers){
-  Setup(proto, srclayers);
-}
-
-void ReLULayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers){
-  Tensor<cpu, 1> data(data_.mutable_cpu_data(), Shape1(data_.count()));
-  Tensor<cpu, 1> src(srclayers[0]->mutable_data(this)->mutable_cpu_data(),
-      Shape1(data_.count()));
+void ReLULayer::ComputeFeature(Phase phase, Metric* perf) {
+  auto data = Tensor1(&data_);
+  auto src = Tensor1(srclayers_[0]->mutable_data(this));
   data=F<op::relu>(src);
 }
 
-void ReLULayer::ComputeGradient(const vector<SLayer>& srclayers) {
-  Tensor<cpu, 1> grad(grad_.mutable_cpu_data(), Shape1(grad_.count()));
-  Tensor<cpu, 1> data(data_.mutable_cpu_data(), Shape1(data_.count()));
-  Tensor<cpu, 1> gsrc(srclayers[0]->mutable_grad(this)->mutable_cpu_data(),
-      Shape1(data_.count()));
+void ReLULayer::ComputeGradient(Phase phase) {
+  auto data = Tensor1(&data_);
+  auto grad = Tensor1(&grad_);
+  auto gsrc = Tensor1(srclayers_[0]->mutable_grad(this));
   gsrc=F<op::relu_grad>(data)*grad;
 }
 
@@ -573,7 +545,7 @@ void ReLULayer::ComputeGradient(const vector<SLayer>& srclayers) {
 void RGBImageLayer::ParseRecords(Phase phase,
     const vector<Record>& records, Blob<float>* blob){
   const vector<int>& s=blob->shape();
-  Tensor<cpu, 4> images(data_.mutable_cpu_data(), Shape4(s[0],s[1],s[2],s[3]));
+  auto images = Tensor4(&data_);
   const SingleLabelImageRecord& r=records.at(0).image();
   Tensor<cpu, 3> raw_image(Shape3(r.shape(0),r.shape(1),r.shape(2)));
   AllocSpace(raw_image);
@@ -625,14 +597,14 @@ void RGBImageLayer::ParseRecords(Phase phase,
   if(cropsize_)
     FreeSpace(croped_image);
 }
-void RGBImageLayer::Setup(const LayerProto& proto,
-    const vector<SLayer>& srclayers){
-  CHECK_EQ(srclayers.size(),1);
+void RGBImageLayer::Setup(const LayerProto& proto, int npartitions) {
+  ParserLayer::Setup(proto, npartitions);
+  CHECK_EQ(srclayers_.size(),1);
   scale_=proto.rgbimage_conf().scale();
   cropsize_=proto.rgbimage_conf().cropsize();
   mirror_=proto.rgbimage_conf().mirror();
-  int batchsize=static_cast<DataLayer*>(srclayers[0].get())->batchsize();
-  Record sample=static_cast<DataLayer*>(srclayers[0].get())->sample();
+  int batchsize=static_cast<DataLayer*>(srclayers_[0])->batchsize();
+  Record sample=static_cast<DataLayer*>(srclayers_[0])->sample();
   vector<int> shape;
   shape.push_back(batchsize);
   for(int x: sample.image().shape()){
@@ -663,7 +635,7 @@ void RGBImageLayer::Setup(const LayerProto& proto,
 }
 
 /***************Implementation for ShardDataLayer**************************/
-void ShardDataLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers){
+void ShardDataLayer::ComputeFeature(Phase phase, Metric* perf){
   if(random_skip_){
     int nskip=rand()%random_skip_;
     LOG(INFO)<<"Random Skip "<<nskip<<" records, there are "<<shard_->Count()
@@ -683,67 +655,55 @@ void ShardDataLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers
   }
 }
 
-void ShardDataLayer::Setup(const LayerProto& proto,
-    const vector<SLayer>& srclayers){
+void ShardDataLayer::Setup(const LayerProto& proto, int npartitions) {
+  Layer::Setup(proto, npartitions);
   shard_= std::make_shared<DataShard>(proto.sharddata_conf().path(),
       DataShard::kRead);
   string key;
   shard_->Next(&key, &sample_);
   batchsize_=proto.sharddata_conf().batchsize();
+  if(partition_dim() == 0)
+    batchsize_ /= npartitions;
 
   records_.resize(batchsize_);
   random_skip_=proto.sharddata_conf().random_skip();
 }
 /*******************Implementation of TanLayer***************************/
-void TanhLayer::Setup(const LayerProto& proto,
-      const vector<SLayer>& srclayers){
-  data_.ReshapeLike(srclayers[0]->data(this));
-  grad_.ReshapeLike(srclayers[0]->grad(this));
+void TanhLayer::Setup(const LayerProto& proto, int npartitions){
+  Layer::Setup(proto, npartitions);
+  data_.ReshapeLike(srclayers_[0]->data(this));
+  grad_.ReshapeLike(srclayers_[0]->grad(this));
 }
 
-void TanhLayer::SetupAfterPartition(const LayerProto& proto,
-      const vector<int> &shape,
-      const vector<SLayer>& srclayers){
-  Setup(proto, srclayers);
-}
-
-
-void TanhLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers){
-  Tensor<cpu, 1> data(data_.mutable_cpu_data(), Shape1(data_.count()));
-  Tensor<cpu, 1> src(srclayers[0]->mutable_data(this)->mutable_cpu_data(),
-      Shape1(data_.count()));
+void TanhLayer::ComputeFeature(Phase phase, Metric* perf) {
+  auto data = Tensor1(&data_);
+  auto src = Tensor1(srclayers_[0]->mutable_data(this));
   data=F<op::stanh>(src);
 }
 
-void TanhLayer::ComputeGradient(const vector<SLayer>& srclayers) {
-  Tensor<cpu, 1> data(data_.mutable_cpu_data(), Shape1(data_.count()));
-  Tensor<cpu, 1> grad(grad_.mutable_cpu_data(), Shape1(grad_.count()));
-  Tensor<cpu, 1> gsrc(srclayers[0]->mutable_grad(this)->mutable_cpu_data(),
-      Shape1(data_.count()));
+void TanhLayer::ComputeGradient(Phase phase) {
+  auto data = Tensor1(&data_);
+  auto grad = Tensor1(&grad_);
+  auto gsrc = Tensor1(srclayers_[0]->mutable_grad(this));
   gsrc=F<op::stanh_grad>(data)*grad;
 }
 /********** * Implementation for SoftmaxLossLayer*************************/
-void SoftmaxLossLayer::Setup(const LayerProto& proto,
-    const vector<SLayer>& srclayers){
-  CHECK_EQ(srclayers.size(),2);
-  data_.Reshape(srclayers[0]->data(this).shape());
+void SoftmaxLossLayer::Setup(const LayerProto& proto, int npartitions) {
+  LossLayer::Setup(proto, npartitions);
+  CHECK_EQ(srclayers_.size(),2);
+  data_.Reshape(srclayers_[0]->data(this).shape());
   batchsize_=data_.shape()[0];
   dim_=data_.count()/batchsize_;
   topk_=proto.softmaxloss_conf().topk();
   metric_.Reshape(vector<int>{2});
   scale_=proto.softmaxloss_conf().scale();
 }
-void SoftmaxLossLayer::SetupAfterPartition(const LayerProto& proto,
-      const vector<int> &shape,
-      const vector<SLayer>& srclayers){
-  Setup(proto, srclayers);
-}
-void SoftmaxLossLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclayers) {
+void SoftmaxLossLayer::ComputeFeature(Phase phase, Metric* perf) {
   Shape<2> s=Shape2(batchsize_, dim_);
   Tensor<cpu, 2> prob(data_.mutable_cpu_data(), s);
-  Tensor<cpu, 2> src(srclayers[0]->mutable_data(this)->mutable_cpu_data(), s);
+  Tensor<cpu, 2> src(srclayers_[0]->mutable_data(this)->mutable_cpu_data(), s);
   Softmax(prob, src);
-  const float* label=srclayers[1]->data(this).cpu_data();
+  const float* label=srclayers_[1]->data(this).cpu_data();
   const float* probptr=prob.dptr;
   float loss=0, precision=0;
   for(int n=0;n<batchsize_;n++){
@@ -769,14 +729,13 @@ void SoftmaxLossLayer::ComputeFeature(Phase phase, const vector<SLayer>& srclaye
     probptr+=dim_;
   }
   CHECK_EQ(probptr, prob.dptr+prob.shape.Size());
-  float *metric=metric_.mutable_cpu_data();
-  metric[0]=loss*scale_/(1.0f*batchsize_);
-  metric[1]=precision*scale_/(1.0f*batchsize_);
+  perf->Add("loss", loss*scale_/(1.0f*batchsize_));
+  perf->Add("accuracy", precision*scale_/(1.0f*batchsize_));
 }
 
-void SoftmaxLossLayer::ComputeGradient(const vector<SLayer>& srclayers) {
-  const float* label=srclayers[1]->data(this).cpu_data();
-  Blob<float>* gsrcblob=srclayers[0]->mutable_grad(this);
+void SoftmaxLossLayer::ComputeGradient(Phase phase) {
+  const float* label=srclayers_[1]->data(this).cpu_data();
+  Blob<float>* gsrcblob=srclayers_[0]->mutable_grad(this);
   gsrcblob->CopyFrom(data_);
   float* gsrcptr=gsrcblob->mutable_cpu_data();
   for(int n=0;n<batchsize_;n++){

--- a/src/proto/common.proto
+++ b/src/proto/common.proto
@@ -38,6 +38,7 @@ message BlobProtos {
 enum ConnectionType {
   kOneToOne = 0;
   kOneToAll = 1;
+  kOneToMany = 2;
 }
 
 // to import caffe's lmdb dataset
@@ -78,4 +79,10 @@ message SingleLabelImageRecord {
   optional int32 label = 2;
   optional bytes pixel = 3;
   repeated float data = 4;
+}
+
+message MetricProto {
+  repeated string name =1;
+  repeated int32 count = 2;
+  repeated float val = 3;
 }

--- a/src/proto/model.proto
+++ b/src/proto/model.proto
@@ -7,6 +7,8 @@ enum Phase {
   kPositive = 3;
   // negative phase for contrastive divergence algorithm
   kNegative = 4;
+  kForward = 5;
+  kBackward = 6;
 }
 
 message ModelProto {
@@ -58,7 +60,7 @@ message ModelProto {
 message NetProto {
   repeated LayerProto layer = 1;
   // partitioning type for parallelism
-  optional PartitionType partition_type = 3 [default = kNone];
+  optional int32 partition_dim = 2 [default = -1];
 }
 
 // weight matrix should be defined before bias vector
@@ -99,7 +101,7 @@ message ParamProto {
   // multiplied on the global weight decay.
   optional float weight_decay_multiplier = 16 [default = 1];
   // partition dimension, -1 for no partition
-  optional int32 partition_dim = 30 [default = -1];
+  optional int32 partition_dim = 30;
   // usually, the program will infer the param shape
   repeated int32 shape = 31;
 
@@ -185,15 +187,15 @@ message LayerProto {
   optional SplitProto split_conf = 42;
   // configuration for tanh layer
   optional TanhProto tanh_conf = 43;
-  // partition type which overrides the partition type for neural net
-  optional PartitionType partition_type = 59;
+
+
+  // overrides the partition dimension for neural net
+  optional int32 partition_dim =59 [default = -1];
   optional string datablob = 58 [default = "unknow"];
 
   // names of parameters shared from other layers
   repeated string share_param = 60;
-  // TODO(wangwei): make location ID an array
-  optional int32 locationid = 61 [default = 0];
-  optional int32 partitionid = 62 [default = 0];
+  optional int32 partition_id = 62 [default = 0];
 }
 
 message RGBImageProto {
@@ -246,9 +248,7 @@ message ConvolutionProto {
 
 message ConcateProto {
   // on which dimension, starts from 0
-  required int32 concate_dimension = 1;
-  // concatenate offset
-  optional int32 concate_num = 30;
+  required int32 concate_dim = 1;
 }
 
 message DataProto {
@@ -328,8 +328,7 @@ message PoolingProto {
 }
 
 message SliceProto{
-  required int32 slice_dimension=1;
-  required int32 slice_num=2;
+  required int32 slice_dim = 1;
 }
 
 message ReLUProto {

--- a/src/trainer/server.cc
+++ b/src/trainer/server.cc
@@ -36,7 +36,7 @@ void Server::Run(){
   ping->add_frame("PING", 4);
   ping->set_type(kConnect);
   dealer_->Send(&ping);
-  vector<shared_ptr<Param>> master_params;
+  vector<Param*> master_params;
   size_t syncEntry=0;
   //start recv loop and process requests
   while (true){
@@ -121,13 +121,13 @@ void Server::Run(){
 Msg* Server::HandlePut(Msg **msg){
   int version=(*msg)->trgt_third();
   int pid=(*msg)->trgt_second();
-  shared_ptr<Param> param=nullptr;
+  Param* param=nullptr;
   if(shard_->find(pid)!=shard_->end()){
     LOG(ERROR)<<"Param ("<<pid<<") is put more than once";
     param=shard_->at(pid);
   }else{
     auto factory=Singleton<Factory<Param>>::Instance();
-    param=shared_ptr<Param>(factory ->Create("Param"));
+    param=factory ->Create("Param");
     (*shard_)[pid]=param;
   }
   auto response=param->HandlePutMsg(msg);
@@ -147,7 +147,7 @@ Msg* Server::HandlePut(Msg **msg){
   return response;
 }
 
-Msg* Server::HandleGet(shared_ptr<Param> param, Msg **msg){
+Msg* Server::HandleGet(Param* param, Msg **msg){
   if(param->version()<(*msg)->trgt_third())
     return *msg;
   else{
@@ -158,7 +158,7 @@ Msg* Server::HandleGet(shared_ptr<Param> param, Msg **msg){
   }
 }
 
-Msg* Server::HandleUpdate(shared_ptr<Param> param, Msg **msg) {
+Msg* Server::HandleUpdate(Param* param, Msg **msg) {
   auto* tmp=static_cast<Msg*>((*msg)->CopyAddr());
   tmp->SwapAddr();
   int paramid=(*msg)->trgt_first();
@@ -174,7 +174,7 @@ Msg* Server::HandleUpdate(shared_ptr<Param> param, Msg **msg) {
   return response;
 }
 
-Msg* Server::HandleSyncRequest(shared_ptr<Param> param, Msg **msg){
+Msg* Server::HandleSyncRequest(Param* param, Msg **msg){
   Msg* response=nullptr;
   auto shape=Shape1(param->size());
   CHECK_EQ((*msg)->frame_size(), param->size()*sizeof(float));

--- a/src/trainer/worker.cc
+++ b/src/trainer/worker.cc
@@ -8,8 +8,10 @@
 #include "utils/factory.h"
 #include "trainer/worker.h"
 #include "proto/model.pb.h"
-using std::thread;
 namespace singa {
+using std::thread;
+using std::make_shared;
+
 Worker::Worker(int thread_id, int group_id, int worker_id):
   thread_id_(thread_id), group_id_(group_id), worker_id_(worker_id){
 }
@@ -52,7 +54,7 @@ void Worker::Run(){
   dealer_=make_shared<Dealer>(2*thread_id_);
   ConnectStub(dealer_, kWorkerParam);
   for(auto layer: train_net_->layers())
-    if(layer->partitionid()==worker_id_)
+    if(layer->partition_id()==worker_id_)
       if(layer->is_bridgedstlayer()||layer->is_bridgesrclayer()){
         layer_dealer_=make_shared<Dealer>(2*thread_id_+1);
         ConnectStub(layer_dealer_, kWorkerLayer);
@@ -61,7 +63,7 @@ void Worker::Run(){
   step_=modelproto_.step();
   // init params
   for(auto layer: train_net_->layers()){
-    if(layer->partitionid()==worker_id_)
+    if(layer->partition_id()==worker_id_)
       for(auto param: layer->GetParams()){
         // only owners fill the memory of parameter values.
         // others share the memory with owners hence do not need to put/get.
@@ -79,7 +81,7 @@ void Worker::Run(){
     for(step_=0;step_<modelproto_.warmup_steps();step_++)
       RunOneBatch(step_, &perf);
     for(auto layer: train_net_->layers()){
-      if(layer->partitionid()==worker_id_)
+      if(layer->partition_id()==worker_id_)
         for(auto param: layer->GetParams())
           if(param->owner()==param->id())
             Put(param, step_);
@@ -107,7 +109,7 @@ void Worker::Stop(){
   msg->set_type(kStop);
   dealer_->Send(&msg); // use param dealer to send the stop msg
 }
-int Worker::Put(shared_ptr<Param> param, int step){
+int Worker::Put(Param* param, int step){
   Msg* msg=new Msg();
   msg->set_src(group_id_, worker_id_, kWorkerParam);
   msg->set_dst(-1, -1, kStub);
@@ -116,7 +118,7 @@ int Worker::Put(shared_ptr<Param> param, int step){
   dealer_->Send(&msg);
   return 1;
 }
-int Worker::Get(shared_ptr<Param> param, int step){
+int Worker::Get(Param* param, int step){
   Msg* msg=new Msg();
   msg->set_src(group_id_, worker_id_, kWorkerParam);
   msg->set_dst(-1, -1, kStub);
@@ -125,7 +127,7 @@ int Worker::Get(shared_ptr<Param> param, int step){
   dealer_->Send(&msg);
   return 1;
 }
-int Worker::Update(shared_ptr<Param> param, int step){
+int Worker::Update(Param* param, int step){
   param->set_local_version(param->version());
   if(updater_){
     updater_->Update(step, param);
@@ -144,30 +146,29 @@ int Worker::Update(shared_ptr<Param> param, int step){
 int Worker::CollectAll(shared_ptr<NeuralNet> net, int step){
   auto& layers=net->layers();
   for(auto& layer: layers){
-    if(layer->partitionid()==worker_id_)
-      for(shared_ptr<Param> p: layer->GetParams()){
+    if(layer->partition_id()==worker_id_)
+      for(Param* p: layer->GetParams()){
         Collect(p, step);
       }
   }
   return 1;
 }
-int Worker::Collect(shared_ptr<Param> param, int step){
+int Worker::Collect(Param* param, int step){
   while(param->version()<=param->local_version()){
     std::this_thread::sleep_for(std::chrono::milliseconds(kCollectSleepTime));
   }
   return 1;
 }
-const void Worker::DisplayPerformance(const Metric & perf, const string& prefix){
+void Worker::DisplayPerformance(const string& prefix, const Metric & perf) {
   Msg* msg=new Msg();
   msg->set_src(group_id_, worker_id_, kWorkerParam);
   msg->set_dst(-1,-1, kStub);
   msg->set_type(kMetric);
   msg->set_trgt(step_,0,0);
-  const string disp=perf.ToString();
   msg->add_frame(prefix.c_str(), prefix.length());
+  const string disp = perf.ToString();
   msg->add_frame(disp.c_str(), disp.length());
   dealer_->Send(&msg);
-  //LOG(ERROR)<<prefix<<" "<<perf.ToString();
 }
 
 void Worker::RunOneBatch(int step, Metric* perf){
@@ -184,10 +185,8 @@ void Worker::RunOneBatch(int step, Metric* perf){
   TrainOneBatch(step, perf);
   //LOG(ERROR)<<"Train "<<step;
   if(perf!=nullptr){
-    perf->Inc();
     if(DisplayNow(step)){
-      //perf->Avg();
-      DisplayPerformance(*perf, "Train");
+      DisplayPerformance("Train", *perf);
       perf->Reset();
     }
   }
@@ -208,13 +207,12 @@ void Worker::Test(int nsteps, Phase phase, shared_ptr<NeuralNet> net){
   Metric perf;
   for(int step=0;step<nsteps;step++){
     TestOneBatch(step, phase, net, &perf);
-    perf.Inc();
   }
   //perf.Avg();
   if(phase==kValidation)
-    DisplayPerformance(perf, "Validation");
+    DisplayPerformance("Validation", perf);
   else if (phase==kTest)
-    DisplayPerformance(perf, "Test");
+    DisplayPerformance("Test", perf);
 }
 
 /****************************BPWorker**********************************/
@@ -223,19 +221,20 @@ BPWorker::BPWorker(int thread_id, int group_id, int worker_id):
   Worker(thread_id, group_id, worker_id){
 }
 
-void BPWorker::Forward(int step, Phase phase, shared_ptr<NeuralNet> net){
+void BPWorker::Forward(int step, Phase phase, shared_ptr<NeuralNet> net,
+    Metric* perf){
   auto& layers=net->layers();
   for(auto& layer: layers){
-    if(layer->partitionid()==worker_id_){
+    if(layer->partition_id()==worker_id_){
       if(layer->is_bridgedstlayer()){
-        auto* dst=static_cast<BridgeDstLayer*>(layer.get());
+        auto* dst=static_cast<BridgeDstLayer*>(layer);
         while(!dst->ready()){
           auto msg=layer_dealer_->Receive();
           CHECK_EQ(msg->src_first(), group_id_);
           string name((char*)msg->frame_data(), msg->frame_size());
           auto tmp=net->name2layer(name);
           CHECK(tmp->is_bridgedstlayer());
-          auto* dstlayer=static_cast<BridgeDstLayer*>(tmp.get());
+          auto* dstlayer=static_cast<BridgeDstLayer*>(tmp);
           auto data=dstlayer->mutable_data(nullptr);
           msg->next_frame();
           memcpy(data->mutable_cpu_data(), msg->frame_data(), msg->frame_size());
@@ -244,28 +243,25 @@ void BPWorker::Forward(int step, Phase phase, shared_ptr<NeuralNet> net){
         }
       }
       if(phase==kTrain){
-        for(shared_ptr<Param> p: layer->GetParams()){
+        for(Param* p: layer->GetParams()){
           Collect(p, step);
         }
       }
       //clock_t s=clock();
-      layer->ComputeFeature(phase);
+      layer->ComputeFeature(phase, perf);
       //LOG(ERROR)<<layer->name()<<":"<<(clock()-s)*1.0/CLOCKS_PER_SEC;
       if(layer->is_bridgesrclayer()){
         auto dst=layer->dstlayers().at(0);
         Msg *msg=new Msg();
         msg->set_src(group_id_, worker_id_, kWorkerLayer);
-        msg->set_dst(group_id_, dst->partitionid(), kWorkerLayer);
+        msg->set_dst(group_id_, dst->partition_id(), kWorkerLayer);
         msg->add_frame(dst->name().c_str(), dst->name().length());
         auto const & blob=layer->data(nullptr);
         msg->add_frame(blob.cpu_data(), blob.count()*sizeof(float));
         layer_dealer_->Send(&msg);
       }
-      if(phase==kTrain&&DisplayDebugInfo(step)
-          &&layer->mutable_data(nullptr)!=nullptr){
-        LOG(INFO)<<StringPrintf("Forward layer  %10s data norm1 %13.9f",
-            layer->name().c_str(), layer->data(nullptr).asum_data());
-      }
+      if(phase == kTrain && DisplayDebugInfo(step))
+        LOG(INFO) << layer->DebugString(step, kForward);
     }
   }
 }
@@ -273,25 +269,17 @@ void BPWorker::Forward(int step, Phase phase, shared_ptr<NeuralNet> net){
 void BPWorker::Backward(int step, shared_ptr<NeuralNet> net){
   auto& layers=net->layers();
   for (auto it = layers.rbegin(); it != layers.rend(); it++){
-    shared_ptr<Layer> layer=*it;
-    if(layer->partitionid()==worker_id_){
+    Layer* layer=*it;
+    if(layer->partition_id()==worker_id_){
       if(layer->is_bridgesrclayer()){
         //auto* src=static_cast<BridgeSrcLayer*>(layer.get());
         // receive grad blobs
       }
-      layer->ComputeGradient();
-      if(layer->mutable_grad(nullptr)!=nullptr&&DisplayDebugInfo(step)){
-        LOG(INFO)<<StringPrintf("Backward layer %10s grad norm1 %13.9f\t",
-            layer->name().c_str(), layer->grad(nullptr).asum_data());
-        for(shared_ptr<Param> p: layer->GetParams())
-          LOG(INFO)<<StringPrintf("param id %2d, name %10s,\
-              value norm1 %13.9f, grad norm1 %13.9f",
-              p->id(), p->name().c_str(),
-              p->data().asum_data(), p->grad().asum_data());
-      }
-      for(shared_ptr<Param> p: layer->GetParams()){
+      layer->ComputeGradient(kTrain);
+      if(DisplayDebugInfo(step))
+        LOG(INFO) << layer->DebugString(step, kBackward);
+      for(Param* p: layer->GetParams())
         Update(p, step);
-      }
       if(layer->is_bridgedstlayer()){
         // send grad blobs
       }
@@ -300,38 +288,14 @@ void BPWorker::Backward(int step, shared_ptr<NeuralNet> net){
 }
 
 void BPWorker::TrainOneBatch(int step, Metric* perf){
-  Forward(step, kTrain, train_net_);
+  Forward(step, kTrain, train_net_, perf);
   Backward(step, train_net_);
   auto losslayers=train_net_->losslayers();
-  for(auto layer: losslayers){
-      if(layer->partitionid()==worker_id_){
-        const float * ptr=layer->metric().cpu_data();
-        /*
-        for(int j=0;j<layer->metric().count();j++)
-          perf->AddMetric(std::to_string(j)+"#"+layer->name(), ptr[j]);
-        */
-        // hard code display info
-        perf->AddMetric(std::to_string(0)+"#loss", ptr[0]);
-        perf->AddMetric(std::to_string(1)+"#accuracy", ptr[1]);
-      }
-    }
 }
 
-void BPWorker::TestOneBatch(int step, Phase phase, shared_ptr<NeuralNet> net, Metric* perf){
-  Forward(step, phase, net);
-  const auto& losslayers=net->losslayers();
-  for(auto layer: losslayers){
-      if(layer->partitionid()==worker_id_){
-        const float * ptr=layer->metric().cpu_data();
-        /*
-        for(int j=0;j<layer->metric().count();j++)
-          perf.AddMetric(std::to_string(j)+"#"+layer->name(), ptr[j]);
-        */
-        // hard code display info
-        perf->AddMetric(std::to_string(0)+"#loss", ptr[0]);
-        perf->AddMetric(std::to_string(1)+"#accuracy", ptr[1]);
-      }
-    }
+void BPWorker::TestOneBatch(int step, Phase phase,
+    shared_ptr<NeuralNet> net, Metric* perf){
+  Forward(step, phase, net, perf);
 }
 
 }  // namespace singa

--- a/src/utils/param.cc
+++ b/src/utils/param.cc
@@ -27,8 +27,7 @@ void Param::AddSlice(int slice_id, int size){
     //must be added in order
     CHECK_EQ(slice_start_+num_slices_, slice_id);
     offset=slice_offset_.back()+slice_size_.back();
-  }
-  else{
+  } else {
     slice_start_=slice_id;
     offset=0;
   }

--- a/src/utils/updater.cc
+++ b/src/utils/updater.cc
@@ -64,7 +64,7 @@ void SGDUpdater::Init(const UpdaterProto& proto){
   weight_decay_=proto.weight_decay();
 }
 
-void SGDUpdater::Update(int step, shared_ptr<Param> param, float grad_scale){
+void SGDUpdater::Update(int step, Param* param, float grad_scale){
   Shape<1> s=Shape1(param->size());
   Tensor<cpu, 1> data(param->mutable_cpu_data(), s);
   Tensor<cpu, 1> grad(param->mutable_cpu_grad(), s);
@@ -92,7 +92,7 @@ void NesterovUpdater::Init(const UpdaterProto& proto){
   weight_decay_=proto.weight_decay();
 }
 
-void NesterovUpdater::Update(int step, shared_ptr<Param> param, float grad_scale){
+void NesterovUpdater::Update(int step, Param* param, float grad_scale){
   Shape<1> s=Shape1(param->size());
   Tensor<cpu, 1> data(param->mutable_cpu_data(), s);
   Tensor<cpu, 1> grad(param->mutable_cpu_grad(), s);
@@ -118,7 +118,7 @@ void AdaGradUpdater::Init(const UpdaterProto& proto){
   weight_decay_=proto.weight_decay();
 }
 
-void AdaGradUpdater::Update(int step, shared_ptr<Param> param, float grad_scale){
+void AdaGradUpdater::Update(int step, Param* param, float grad_scale){
   Shape<1> s=Shape1(param->size());
   Tensor<cpu, 1> data(param->mutable_cpu_data(), s);
   Tensor<cpu, 1> grad(param->mutable_cpu_grad(), s);
@@ -143,7 +143,7 @@ void RMSPropUpdater::Init(const UpdaterProto& proto){
   weight_decay_=proto.weight_decay();
 }
 
-void RMSPropUpdater::Update(int step, shared_ptr<Param> param, float grad_scale){
+void RMSPropUpdater::Update(int step, Param* param, float grad_scale){
   Shape<1> s=Shape1(param->size());
   Tensor<cpu, 1> data(param->mutable_cpu_data(), s);
   Tensor<cpu, 1> grad(param->mutable_cpu_grad(), s);
@@ -166,7 +166,7 @@ void AdaDeltaUpdater::Init(const UpdaterProto& proto){
   weight_decay_=proto.weight_decay();
 }
 
-void AdaDeltaUpdater::Update(int step, shared_ptr<Param> param, float grad_scale){
+void AdaDeltaUpdater::Update(int step, Param* param, float grad_scale){
   Shape<1> s=Shape1(param->size());
   Tensor<cpu, 1> data(param->mutable_cpu_data(), s);
   Tensor<cpu, 1> grad(param->mutable_cpu_grad(), s);


### PR DESCRIPTION
1. Clean the code for NeuralNet and Graph classes.
   Graph class only provides functions about Node and Edge management, e.g., add, remove and toplogy sort.
   NeuralNet provides one function (CreateGraph) to convert net configuration into a Graph. Net partitioning
   is done in CreateGraph function. The CreateNetFromGraph function create and connect layers from the graph.
2. Users can customize the partition for whole net and for a specific layer through field partition_dim of LayerProto and NetProto.
   the configuration of LayerProto overwrites that of NetProto.

Tested on single process with non-distributed training, shared-memory hogwild, one worker group with 2 workers.
Tested with two processes for downpour and distributed hogwild. Downpour has similar performance as shared-memory hoglwild; while Distributed hogwild does not perform as good non-distributed training.