### PR TITLE
SINGA-32  Implement AllReduce training framework

### DIFF
--- a/include/communication/socket.h
+++ b/include/communication/socket.h
@@ -43,6 +43,7 @@ class SocketInterface {
 class Poller {
  public:
   Poller();
+  Poller(SocketInterface* socket);
   /**
     * Add a socket for polling; Multiple sockets can be polled together by
     * adding them into the same poller.

--- a/include/neuralnet/neuralnet.h
+++ b/include/neuralnet/neuralnet.h
@@ -58,7 +58,7 @@ class NeuralNet {
   /**
    * Share memory of parameter values from other neuralnet
    */
-  void ShareParams(shared_ptr<NeuralNet> other);
+  void ShareParamsFrom(shared_ptr<NeuralNet> other);
 
   const std::vector<Layer*>& layers() {
     return layers_;

--- a/include/trainer/trainer.h
+++ b/include/trainer/trainer.h
@@ -1,9 +1,9 @@
 #ifndef INCLUDE_TRAINER_TRAINER_H_
 #define INCLUDE_TRAINER_TRAINER_H_
 #include <unordered_map>
+#include <queue>
 #include "proto/cluster.pb.h"
 #include "proto/model.pb.h"
-#include "utils/updater.h"
 #include "utils/param.h"
 #include "utils/singleton.h"
 #include "utils/factory.h"
@@ -14,66 +14,6 @@
 
 namespace singa {
 /**
- * Callback function for zookeeper
- */
-void HandleWorkerFinish(void * ctx);
-/**
- * Zookeeper handler context used by HandleWorkerFinish(void*)function.
- */
-typedef struct HandleContext_{
-  shared_ptr<Dealer> dealer;
-  int group_id, id;
-} HandleContext;
-/**
-  * ParamInfo is used to construct a parameter shard.
-  *
-  * For each worker group:
-  *   Every unique Param object is associated with a ParamCounter object whose
-  *   param field points the to Param object itself.
-  *
-  *   Param objects sharing the same values (due to data parallelism) are
-  *   associated with the same ParamCounter whose param field also shares the
-  *   same values.
-  *
-  *   Usage: we need to aggregate gradients from all workers for the shared
-  *   parameters before sending the update request. The nUpdate counter counts
-  *   the number.
-  *
-  * TODO test with different physical architectures.
-  */
-class ParamInfo{
-   public:
-  ParamInfo(Param* p,int local, int owner):
-    num_update(0), next_version(-1),num_local(local), num_total(1),
-    owner_procs(owner){
-      shares.push_back(p);
-    }
-
-  /**
-    * Associate the counter to a Param object.
-    *
-    * @param p
-    * @param local 1 if this Param object is used by workers in this procs, 0
-    *  otherwise
-    * @param owner the procs id of the worker who ownes this Param object
-    */
-  void AddParam(Param* p, bool local){
-    num_local+=local;
-    num_total+=1;
-    if(local)
-      shares.push_back(p);
-  }
-  int num_update, next_version; //!< all counters are atomic
-
-  int num_local; //!< # local workers uses the shared parameter
-  int num_total; //!< # total workers uses the shared parameter
-  int owner_procs; //!< the procs id of the worker that owns the parameter
-  vector<Param*> shares;
-};
-
-typedef std::map<int, shared_ptr<ParamInfo>> WorkerShard;
-
-/**
  * Every running process has a training object which launches one or more
  * worker (and server) threads.
  *
@@ -82,23 +22,56 @@ typedef std::map<int, shared_ptr<ParamInfo>> WorkerShard;
 
 class Trainer{
  public:
+  ~Trainer();
   /**
-   * Start the training in one process
+   * Entrance function which construct the workers and servers, and luanch
+   * one thread per worker/server. TODO rename variables about cluster config,
+   * job config, etc.
    *
-   * @param modelproto
-   * @param clusterproto
+   * @param mconf model configuration
+   * @param globalconf global singa configuration
+   * @param cconf cluster configuration
+   * @param job job ID
    */
-  void Start(const ModelProto& modelproto, const GlobalProto& globalproto, 
-             const ClusterProto& clusterproto, const int procs_id);
+  void Start(const ModelProto& mconf, const GlobalProto& globalconf,
+             const ClusterProto& cconf, const int job);
 
   // TODO add Resume() function to continue training from a previously stopped
   // point.
-
  protected:
-  vector<Server*> CreateServers(int nthread, const ModelProto& mproto,
-      const vector<int> slices, vector<HandleContext*>* ctx);
-  vector<Worker*> CreateWorkers(int nthread, const ModelProto& mproto,
-      vector<int> *slice_size);
+  /**
+   * Create server instances.
+   * @param nthread total num of threads in current procs which is used to
+   * assign each thread a local thread ID. The number of workers is extracted
+   * from Cluster
+   * @param model_conf
+   * @return server instances
+   */
+  vector<Server*> CreateServers(int nthread, const ModelProto& mproto);
+  /**
+   * Create workers instances.
+   * @param nthread total num of threads in current procs which is used to
+   * assign each thread a local thread ID. The number of workers is extracted
+   * from Cluster
+   * @param model_conf
+   * @return worker instances
+   */
+  vector<Worker*> CreateWorkers(int nthread, const ModelProto& mproto);
+
+  /**
+   * Setup workers and servers.
+   *
+   * For each worker, create and assign a neuralnet to it.
+   * For each server, create and assign the param shard to it.
+   * Create the partition map from slice ID to server
+   * @param model_conf
+   * @param workers
+   * @param servers
+   */
+  void SetupWorkerServer(
+    const ModelProto& model_conf,
+    const vector<Worker*>& workers,
+    const vector<Server*>& servers);
 
   void Run(const vector<Worker*>& workers, const vector<Server*>& servers);
   /**
@@ -111,37 +84,73 @@ class Trainer{
    * implementation class as the value, e.g., <"Updater" SGDUpdater>.
    */
   void RegisterDefaultClasses(const singa::ModelProto& proto);
-
   /**
-   * Workers from the same group resident in the same process share the same
-   * WorkerShard which contains ParamCounters for Param objects used/updated by
-   * these worekrs. Shared Param objects are associated with the same
-   * ParamCounter.
+   * Generate msg to trigger synchronization with other server groups.
+   *
+   * @param server the local server index whom the message is sent to
+   * @param servers all local servers
+   * @return sync msg
    */
+  Msg* GenSyncReminderMsg(int server, const vector<Server*>& servers);
+  /**
+   * Display metrics to log (standard output)
+   */
+  void DisplayMetric(Msg** msg);
+  /**
+   * Create a socket to send msg to the specified process
+   * @param dst_procs the dst process (logical) ID
+   * @return the newly created socket
+   */
+  Dealer* CreateInterProcsDealer(int dst_procs);
+  /**
+   * Handle messages to local servers and local stub
+   */
+  void HandleLocalMsg(std::queue<Msg*>* msg_queue, Msg** msg);
 
 	/**
 	 * Generate a request message to Get the parameter object.
 	 */
-	virtual const vector<Msg*> HandleGet(shared_ptr<ParamInfo>counter, Msg** msg);
-	virtual void HandleGetResponse(shared_ptr<ParamInfo>counter, Msg** msg);
+	const vector<Msg*> HandleGet(ParamEntry* entry, Msg** msg);
+	void HandleGetResponse(ParamEntry* entry, Msg** msg);
 
 	/**
 	 * Generate a request message to Update the parameter object.
 	 */
-	virtual const vector<Msg*> HandleUpdate(shared_ptr<ParamInfo>counter, Msg** msg);
-  virtual void HandleUpdateResponse(shared_ptr<ParamInfo>counter, Msg** msg);
+	const vector<Msg*> HandleUpdate(ParamEntry* entry, Msg** msg);
+  void HandleUpdateResponse(ParamEntry* entry, Msg** msg);
 
   /**
 	 * Generate a request message to Put the parameter object.
 	 */
-	virtual const vector<Msg*> HandlePut(shared_ptr<ParamInfo>counter, Msg** msg);
-	virtual Msg* HandleConnect(Msg** msg);
+	const vector<Msg*> HandlePut(ParamEntry* entry, Msg** msg);
+
+  /**
+   * Called by HandlePut, HandleUpdate and HandleGet functions
+   * @param type message type
+   * @param version param version
+   * @param entry
+   * @param msg
+   * @param ret generated messages
+   */
+  void GenMsgs(int type, int version, ParamEntry* entry,
+    Msg* msg, vector<Msg*> *ret);
+  /**
+   * Get a hash id for a Param object from a group.
+   *
+   * Simple multiple group_id with a large prime number 997 (assuming there are
+   * no more than 997 worker groups) and plus owner param id.
+   */
+  inline int Hash(int grp_id, int param_id) {
+    return grp_id * 997 + param_id;
+  }
 
  protected:
   int procs_id_;
-  shared_ptr<Router> router_;
-  std::unordered_map<int, shared_ptr<WorkerShard>> worker_shards_;
-  shared_ptr<ServerShard> server_shard_;
+  Router *router_;
+  std::unordered_map<int, ParamEntry*> worker_shard_;
+  //!< map from slice ID to slice, used by servers and deleted in the destructor
+  std::unordered_map<int, ParamEntry*> server_shard_;
+  //!< map from slice to the server that updates it
   vector<int> slice2server_;
 };
 } /* singa */

--- a/include/trainer/worker.h
+++ b/include/trainer/worker.h
@@ -1,46 +1,70 @@
-#ifndef INCLUDE_TRAINER_WORKER_H_
-#define INCLUDE_TRAINER_WORKER_H_
-#include <map>
-#include <exception>
+#ifndef SINGA_TRAINER_WORKER_H_
+#define SINGA_TRAINER_WORKER_H_
 #include "neuralnet/neuralnet.h"
 #include "proto/model.pb.h"
-#include "utils/cluster.h"
 #include "utils/updater.h"
 #include "communication/socket.h"
-#include "communication/msg.h"
 
 namespace singa {
-const int kCollectSleepTime=5;//milliseconds;
+//!< sleep 5 milliseconds if the Param is not updated to the expected version
+const int kCollectSleepTime=5;
 /**
  * The Worker class which runs the training algorithm.
  * The first worker group will initialize parameters of the Net,
  * and put them into the distributed memory/table.
+ * The virtual function TrainOneBatch and TestOneBatch implement the
+ * training and test algorithm for one mini-batch data.
+ *
+ * Child workers override the two functions to implement their training
+ * algorithms, e.g., the BPWorker/CDWorker/BPTTWorker implements the BP/CD/BPTT
+ * algorithm respectively.
  */
 class Worker {
  public:
-  Worker(int thread_id, int group_id, int worker_id);
-  virtual ~Worker(){}
-  void Setup(const ModelProto& model, shared_ptr<NeuralNet> train_net);
-  void set_test_net(shared_ptr<NeuralNet> test_net){
-    test_net_=test_net;
-  }
-  void set_validation_net(shared_ptr<NeuralNet> val_net){
-    validation_net_=val_net;
-  }
-
-  void Stop();
-  int Put(Param* param, int step);
-  int Get(Param* param, int step);
-  int Update(Param* param, int step);
-  int Collect(Param* param, int step);
-  int CollectAll(shared_ptr<NeuralNet> net, int step);
   /**
-    * check validation/test firstly, then TrainOneBatch
-    * Performance collects performance for the whole neuralnet.
-    * Hence, no need to collect performance in every thread.
-    * Only the main thread will pass none null perf.
+   * @param thread_id local thread index within the procs
+   * @param grp_id global worker group ID
+   * @param id worker ID within the group
+   */
+  Worker(int thread_id, int grp_id, int id);
+  virtual ~Worker();
+  /**
+   * Setup members
+   */
+  void Setup(const ModelProto& model, shared_ptr<NeuralNet> train_net,
+      shared_ptr<NeuralNet> valid_net, shared_ptr<NeuralNet> test_net);
+  /**
+    * Main function of Worker.
+    *
+    * Train the neuralnet step by step, test/validation is done periodically.
     */
-  void RunOneBatch(int step, Metric* perf=nullptr);
+  void Run();
+  /**
+   * Resume from snapshot
+   */
+  void Resume();
+  /**
+   * Init all local params (i.e., params from layers resident in this worker).
+   *
+   * If the param is owned by the worker, then init it and put it to servers.
+   * Otherwise call Get() to get the param. The Get may not send get request.
+   * Because the param's own is in the same procs. Once the owner initializes
+   * the param, its version is visiable to all shares.
+   * If the training starts from scrath, the params are initialzed using random
+   * distributions, e.g., Gaussian distribution. After that, the worker may
+   * train for a couple of steps to warmup the params before put
+   * them to servers (warmup of ModelProto controls this).
+   *
+   * TODO(wangwei) If the worker is resumed from checkpoint, the owner param's
+   * values are parsed from the checkpoint file instead of randomly initialized.
+   */
+  void InitLocalParams();
+  /**
+    * Test the perforance of the learned model on validation or test dataset.
+    * Test is done by the first group.
+    * @param net, neural network
+    */
+  void Test(int nsteps, Phase phase, shared_ptr<NeuralNet> net);
   /**
     * Train one mini-batch.
     * Test/Validation is done before training.
@@ -52,96 +76,104 @@ class Worker {
   virtual void TestOneBatch(int step, Phase phase, shared_ptr<NeuralNet> net,
       Metric* perf)=0;
   /**
-    * Test the perforance of the learned model on validation or test dataset.
-    * Test is done by the first group.
-    * @param net, neural network
-    */
-  void Test(int nsteps, Phase phase, shared_ptr<NeuralNet> net);
+   * Report performance to the stub.
+   *
+   * @param prefix display prefix, e.g., 'Train', 'Test'
+   * @param perf
+   */
+  void Report(const string& prefix, const Metric & perf);
 
   /**
-    * Main function of Worker.
-    * 1. Train the neuralnet step by step, test/validation is done periodically.
-    * 2. TODO Communicate with others, e.g., zookeeper, after every step.
-    */
-  virtual void Run();
+   * Put Param to server.
+   * @param param
+   * @param step used as current param version for the put request
+   */
+  int Put(Param* param, int step);
+  /**
+   * Get Param with specific version from server
+   * If the current version >= the requested version, then return.
+   * Otherwise send a get request to stub who would forwards it to servers.
+   * @param param
+   * @param step requested param version
+   */
+  int Get(Param* param, int step);
+  /**
+   * Update Param
+   * @param param
+   * @param step training step used for updating (e.g., deciding learning rate)
+   */
+  int Update(Param* param, int step);
+  /**
+   * Block until the param is updated since sending the update request
+   *
+   * @param param
+   * @param step not used
+   */
+  int Collect(Param* param, int step);
+  /**
+   * Call Collect for every param of net
+   */
+  int CollectAll(shared_ptr<NeuralNet> net, int step);
+  /**
+   * Receive blobs from other workers due to model partitions.
+   */
+  void ReceiveBlobs(
+    bool data, bool grad, BridgeLayer* layer, shared_ptr<NeuralNet> net);
+  /**
+   * Send blobs to other workers due to model partitions.
+   */
+  void SendBlobs(
+    bool data, bool grad, BridgeLayer* layer, shared_ptr<NeuralNet> net);
 
   /**
    * Check is it time to display training info, e.g., loss and precison.
    */
-  const bool DisplayNow(const int step) const {
-    return (modelproto_.display_frequency() > 0
-        && step >= modelproto_.display_after_steps()
-        && ((step - modelproto_.display_after_steps())
-          % modelproto_.display_frequency() == 0));
-  }
-
-  const bool DisplayDebugInfo(const int step) const {
-    return DisplayNow(step)&&modelproto_.debug()&&group_id_==0;
-  }
-  void DisplayPerformance(const string& prefix, const Metric & perf);
-
+  inline bool DisplayNow(int step) const;
   /**
-   * return true if the stop condition is satisfied, e.g., the maximum number
-   * of steps have been reached.
+   * Check is it time to display training info, e.g., loss and precison.
    */
-  const bool StopNow(const int step) const{
-    return (step >= modelproto_.train_steps());
-  }
+  inline bool DisplayDebugInfo(int step) const;
+  /**
+   * Check is it time to stop
+   */
+  inline bool StopNow(int step) const;
   /**
    * Check is it time to do checkpoint.
-   * @param step the ::Train() has been called this num times.
    */
-  const bool CheckpointNow(const int step) const{
-    return (group_id_==0
-        && modelproto_.checkpoint_frequency() > 0
-        && step >= modelproto_.checkpoint_after_steps()
-        && ((step - modelproto_.checkpoint_after_steps())
-          % modelproto_.checkpoint_frequency() == 0));
-  }
+  inline bool CheckpointNow(int step) const;
   /**
    * Check is it time to do test.
    * @param step the ::Train() has been called this num times.
    */
-  const bool TestNow(const int step) const{
-    return (group_id_==0
-        && modelproto_.test_frequency() > 0
-        && modelproto_.test_steps() > 0
-        && step >= modelproto_.test_after_steps()
-        && ((step - modelproto_.test_after_steps())
-          % modelproto_.test_frequency() == 0));
-  }
+  inline bool TestNow(int step) const;
   /**
    * Check is it time to do validation.
    * @param step the ::Train() has been called step times.
    */
-  const bool ValidateNow(const int step) {
-    return (group_id_==0
-        && modelproto_.validation_frequency() > 0
-        && modelproto_.validation_steps() > 0
-        && step >= modelproto_.validation_after_steps()
-        && ((step - modelproto_.validation_after_steps())
-          % modelproto_.validation_frequency() == 0));
-  }
+  inline bool ValidateNow(int step) const;
 
   /**
-   * TODO Resume from snapshot
-  void Resume();
+   * @return group ID
    */
-  void ReceiveBlobs(shared_ptr<NeuralNet> net);
-  void SendBlob();
-  void ConnectStub(shared_ptr<Dealer> dealer, EntityType type);
+  int grp_id() const { return grp_id_;}
+
+  /**
+   * @reutrn worker ID within the worker group.
+   */
+  int id() const { return id_;}
+
  protected:
-  int thread_id_, group_id_, worker_id_;
+  int thread_id_, grp_id_, id_;
   int step_;
   ModelProto modelproto_;
   shared_ptr<NeuralNet> train_net_, test_net_, validation_net_;
-  shared_ptr<Dealer> layer_dealer_, dealer_;
-  shared_ptr<Updater> updater_;
+  Dealer* layer_dealer_, *dealer_;
+  Updater* updater_;
 };
 
 class BPWorker: public Worker{
  public:
-  BPWorker(int thread_id, int group_id, int worker_id);
+  BPWorker(int thread_id, int grp_id, int id);
   ~BPWorker(){}
   void TrainOneBatch(int step, Metric* perf) override;
   void TestOneBatch(int step, Phase phase, shared_ptr<NeuralNet> net,
@@ -150,6 +182,19 @@ class BPWorker: public Worker{
   void Forward(int step, Phase phase, shared_ptr<NeuralNet> net, Metric* perf);
   void Backward(int step, shared_ptr<NeuralNet> net);
 };
+
+inline int BlobTrgt(int grp, int layer) {
+  return (grp << 16) | layer;
+}
+
+inline int BlobGrp(int blob_trgt) {
+  return blob_trgt >> 16;
+}
+
+inline int BlobLayer(int blob_trgt) {
+  static int mask = (1 << 16) -1;
+  return blob_trgt & mask;
+}
 }  // namespace singa
 
-#endif  // INCLUDE_TRAINER_WORKER_H_
+#endif  // SINGA_TRAINER_WORKER_H_

--- a/include/utils/common.h
+++ b/include/utils/common.h
@@ -10,6 +10,7 @@
 #include "proto/common.pb.h"
 
 namespace singa {
+using std::vector;
 
 std::string IntVecToString(const std::vector<int>& vec);
 std::string VStringPrintf(std::string fmt, va_list l);
@@ -25,6 +26,24 @@ void WriteProtoToBinaryFile(const google::protobuf::Message& proto,
 
 const std::string CurrentDateTime();
 void  CreateFolder(const std::string name);
+/**
+ * Slice a set of large Params into small pieces such that they can be roughtly
+ * equally partitioned into a fixed number of boxes.
+ *
+ * @param num total number of boxes to store the small pieces
+ * @param sizes size of all Params
+ * @return all slices for each Param
+ */
+const vector<vector<int>> Slice(int num, const vector<int>& sizes);
+/**
+ * Partition slices into boxes.
+ *
+ * @param num number of boxes
+ * @param slices slice sizes
+ * @return box id for each slice
+ */
+const vector<int> PartitionSlices(int num, const vector<int>& slices);
+
 /*
 inline void Sleep(int millisec=1){
   std::this_thread::sleep_for(std::chrono::milliseconds(millisec));
@@ -46,6 +65,8 @@ void SetupLog(const std::string& workspace, const std::string& model);
  */
 class Metric {
  public:
+  Metric() {}
+  explicit Metric(const std::string& str);
   /**
    * Add one metric.
    *
@@ -60,7 +81,7 @@ class Metric {
    */
   void Reset();
   /**
-   * Generate a one line string for logging
+   * Generate a one-line string for logging
    */
   const std::string ToLogString() const;
   /**
@@ -71,6 +92,7 @@ class Metric {
    * Parse the metric from a string
    */
   void ParseFrom(const std::string& msg);
+
  private:
   std::unordered_map<std::string, std::pair<int, float>> entry_;
 };

--- a/include/utils/param.h
+++ b/include/utils/param.h
@@ -2,17 +2,167 @@
 #define INCLUDE_UTILS_PARAM_H_
 #include <vector>
 #include <string>
-#include <map>
-#include <functional>
 #include "proto/model.pb.h"
 #include "utils/blob.h"
 #include "communication/msg.h"
-// Base paramter class.
+
+/**
+ * Base paramter class.
+ *
+ * The Param object is a set of parameters, e.g., the (sub) weight matrix or
+ * (sub) bias vector.
+ *
+ * It has at a gradient Blob and data Blob for gradients and parameter values.
+ * Since some layers (or neuralnet) share parameter values, the data Blob is a
+ * shared pointer which can be assigned to many Param objects' data field.
+ *
+ * It provides access methods like data(), grad(). It also provides functions
+ * for generating messages and parsing messages to transferring the Param
+ * objects among worker-worker, worker-server and server-server.
+ *
+ * Param objects are of different sizes, which makes it hard to acheive
+ * load-balance among servers. Hence, we slice large Param objects into small
+ * pieces. At the server side, one slice is a Param object.
+ */
 namespace singa {
 class Param {
  public:
   Param();
   virtual ~Param(){ }
+  /**
+   * Setup param object
+   *
+   * @param conf param configuration, include learning rate multiplier etc.
+   * @param shape one value per dimension
+   */
+  virtual void Setup(const ParamProto& conf, const std::vector<int>& shape);
+  /*
+   * Fill the values according to init method, e.g., gaussian distribution.
+   *
+   * @param version initial version
+   */
+  virtual void InitValues(int version=0);
+  /**
+   * Share the data blob from other Param objects.
+   *
+   * @param other the Param object whose owner owns the data blob
+   */
+  void ShareFrom(const Param& other);
+
+  /**
+   * Scale the learning rate when updating parameters in the Param object
+   */
+  float learning_rate_multiplier() {
+    return proto_.learning_rate_multiplier();
+  }
+  /**
+   * Scale the weight decay when updating parameters in the Param object
+   */
+  float weight_decay_multiplier() {
+    return proto_.weight_decay_multiplier();
+  }
+  /**
+   * Parameter name used for Param re-use in other model or sharing between
+   * layers
+   */
+  const std::string& name() {
+    return proto_.name();
+  }
+  /**
+   * If it shares data from others, then owner is the id of that Param,
+   * otherwise it is itself's id.
+   */
+  const int owner() const {
+    return proto_.owner();
+  }
+  /**
+   * ID start from 0 and ordered for all Param from the same neuralnet
+   */
+  int id() const {
+    return proto_.id();
+  }
+  /**
+   * Set ID
+   */
+  void set_id(int id) {
+    proto_.set_id(id);
+    proto_.set_owner(id);
+  }
+
+  /**
+   * Param version is stored inside the data blob to enable all Param objs
+   * sharing the same values have the same version.
+   * @return the param version
+   */
+  int version() const {
+    return data_->version();
+  }
+
+  void set_version(int v) {
+    data_->set_version(v);
+  }
+
+  /**
+   * @return the version of the parameter value local to a worker
+   */
+  int local_version() const {
+    return local_version_;
+  }
+
+  void set_local_version(int v) {
+    local_version_=v;
+  }
+   /**
+    * @return num of floats.
+    */
+  int size() const {
+    return data_->count();
+  }
+  const Blob<float> &data() {
+    return *data_;
+  }
+  Blob<float> *mutable_data() {
+    return data_.get();
+  }
+  /**
+   * Return gradient of this parameter
+   */
+  const Blob<float> &grad() {
+    return grad_;
+  }
+  Blob<float> *mutable_grad() {
+    return &grad_;
+  }
+  float* mutable_cpu_data(){
+    return data_->mutable_cpu_data();
+  }
+  float* mutable_cpu_grad(){
+    return grad_.mutable_cpu_data();
+  }
+  float* mutable_cpu_history(){
+    return history_.mutable_cpu_data();
+  }
+
+  /**
+   * @return slice start ID
+   */
+  int slice_start() const {
+    return slice_start_;
+  }
+
+  int num_slices() const {
+    return num_slices_;
+  }
+
+  /**
+   * Add a slice
+   *
+   * @param slice_id
+   * @param size num of floats for this slice
+   */
+  void AddSlice(int slice_id, int size);
+  /**********************Msg related functions***************************/
+
   /**
    * Generate the message for a get request, i.e., get parameters from a server
    *
@@ -41,185 +191,71 @@ class Param {
    * */
   virtual Msg* GenSyncMsg(int offset, int size);
   /**
-   * Generate the message to response the update request.
+   * Generate the messages to response the update requests.
    *
-   * This function is called at the server side, where the Param is actually a slice
-   * of an original Param object.
-   * @param copy if true copy the parameter value into the message, otherwise
-   * only transfer the pointer of the parameter values.
-   * @return response message pointer
+   * This function is called at the server side, where the Param is actually a
+   * slice of an original Param object.
+   *
+   * @param msgs for synchronous training, there would be multiple procs in
+   * which workers sharing the same Param (slice) objects. Their update requests
+   * is bufferred and handled together. For asynchrnous training, there is only
+   * request in msgs.
+   * @return response messages
    */
-  virtual Msg* GenUpdateResponseMsg(bool copy);
+  virtual const vector<Msg*> GenUpdateResponseMsgs(const vector<Msg*>& msgs);
 
   /**
    * Server handling function for get request.
    *
-   * @param msg  request message
+   * @param msg request
+   * @param reserve if true reserve the msg space for the calling function;
+   * otherwise the msg should be freed inside the function.
    * @return resposne message
    */
-  virtual Msg* HandleGetMsg(Msg** msg);
+  virtual Msg* HandleGetMsg(Msg** msg, bool reserve = false);
   /**
    * Server handling function for put request.
    *
-   * \copydetails HandleGetMsg(Msg**)
+   * \copydetails HandleGetMsg(Msg**, bool reserve)
    */
-  virtual Msg* HandlePutMsg(Msg** msg);
+  virtual Msg* HandlePutMsg(Msg** msg, bool reserve = false);
   /**
    * Server handling function for synchronization message
    *
-   * \copydetails HandleGetMsg(Msg**)
+   * \copydetails HandleGetMsg(Msg**, bool reserve)
    */
-  virtual Msg* HandleSyncMsg(Msg** msg);
-  /**
-   * Server parses update request message.
-   *
-   * @param msg
-   * @return 1 for copy, 0 for no copy
-   */
-  virtual int ParseUpdateMsg(Msg** msg);
+  virtual Msg* HandleSyncMsg(Msg** msg, bool reserve = false);
   /**
    * Worker/Stub parsing function for get response.
    *
    * @param msg
    * @param slice_idx index for the slice
    */
-  virtual int ParseGetResponseMsg(Msg** msg, int slice_idx);
+  virtual int ParseGetResponseMsg(Msg* msg, int slice_idx);
   /**
    * Worker/Server parsing function for update response
    *
    * \copydetails ParseGetResponseMsg(Msg**, int);
    */
-  virtual int ParseUpdateResponseMsg(Msg** msg, int slice_idx);
+  virtual int ParseUpdateResponseMsg(Msg* msg, int slice_idx);
+  /**
+   * Server parse update requests.
+   * \copydetails GenUpdateResponseMsgs(const vector<Msg*>& msgs);
+   */
+  virtual void ParseUpdateMsgs(const vector<Msg*>& msgs);
   /**
    * Server parsing function for synchronization response.
    *
    * \copydetails ParseGetResponseMsg(Msg** , int);
    */
-  virtual int ParseSyncResponseMsg(Msg** msg, int slice_idx);
-
-  /**
-   * Setup param object
-   *
-   * @param proto includes learning rate/weight decay multipliers
-   * @param shape
-   */
-  virtual void Setup(const ParamProto& proto, const std::vector<int>& shape);
-  /*
-   * Fill the values according to initmethod, e.g., gaussian distribution
-   *
-   * @param version initial version
-   */
-  virtual void InitValues(int version=0);
-  /**
-   * Share the data blob from other Param objects.
-   *
-   * @param other the Param object whose owner owns the data blob
-   */
-  void ShareData(Param* other){
-    proto_.set_owner(other->owner());
-    if(data_!=nullptr)
-      CHECK(std::equal(data_->shape().begin(), data_->shape().end(),
-          other->data_->shape().begin()));
-    data_=other->data_;
-  }
-  float learning_rate_multiplier() {
-    return proto_.learning_rate_multiplier();
-  }
-  float weight_decay_multiplier() {
-    return proto_.weight_decay_multiplier();
-  }
-  const std::string& name() {
-    return proto_.name();
-  }
-  /**
-   * if the Param shares data with others, then owner is the id of that param.
-   * otherwise it is itself's id.
-   */
-  const int owner() const{
-    return proto_.owner();
-  }
-  int id() const{
-    return proto_.id();
-  }
-  void set_id(int id){
-    proto_.set_id(id);
-    proto_.set_owner(id);
-  }
-
-  /**
-   * return the version of the parameter value shared by multiple workers
-   */
-  int version() const {
-    return data_->version();
-  }
-
-  void set_version(int v) {
-    data_->set_version(v); // TODO read version from data blob
-  }
-
-  /**
-   * return the version of the parameter value local to a worker
-   */
-  int local_version() const {
-    return local_version_;
-  }
-
-  void set_local_version(int v){
-    local_version_=v;
-  }
-   /**
-    * @return num of floats.
-    */
-  int size() const {
-    return data_->count();
-  }
-  /**
-   * Return const mem address for the content of this parameter
-   */
-  const Blob<float> &data() {
-    return *data_;
-  }
-  Blob<float> *mutable_data() {
-    return data_.get();
-  }
-  /**
-   * Return gradient of this parameter
-   */
-  const Blob<float> &grad() {
-    return grad_;
-  }
-  Blob<float> *mutable_grad() {
-    return &grad_;
-  }
-
-  const Blob<float> &history() {
-    return history_;
-  }
-  Blob<float> *mutable_history() {
-    return &history_;
-  }
-
-  float* mutable_cpu_data(){
-    return data_->mutable_cpu_data();
-  }
-  float* mutable_cpu_grad(){
-    return grad_.mutable_cpu_data();
-  }
-  float* mutable_cpu_history(){
-    return history_.mutable_cpu_data();
-  }
-  int slice_start() const {
-    return slice_start_;
-  }
-
-  int num_slices() const {
-    return num_slices_;
-  }
-
-  void AddSlice(int slice_id, int size);
+  virtual int ParseSyncResponseMsg(Msg* msg, int slice_idx);
 
  protected:
-  void ParseResponseMsg(Msg** msg, int slice_idx);
+  /**
+   * Implement the common code of ParseGetResponseMsg and ParseUpdateResponseMsg
+   * \copydetails ParseSyncResponseMsg(Msg* msg, int slice_idx);
+   */
+  void ParseResponseMsg(Msg* msg, int slice_idx);
 
  protected:
 
@@ -227,16 +263,61 @@ class Param {
    * name of the parameter used to share wights between neuralnets
    */
   std::string name_;
-  shared_ptr<Blob<float>> data_;
-  int slice_start_, num_slices_;
+  int local_version_;
+  //!< the ID of the first slice
+  int slice_start_;
+  int num_slices_;
+  //!< offset and size of each slice
   vector<int> slice_offset_, slice_size_;
+
+  //!< for debug checking
   vector<bool> pending_put_,pending_get_, pending_update_;
   int num_pending_requests_;
+
+  shared_ptr<Blob<float>> data_;
   //! gradient, history gradient of this parameter
   Blob<float> grad_, history_;
   ParamProto proto_;
-  int local_version_;
 };
+
+/**
+ * ParamEntry is used for aggregating gradients of Params shared by workers from
+ * the same group.
+ *
+ * For each worker group, every unique Param object has a ParamEntry object.
+ * Param objects sharing the same values are associated with the same
+ * ParamEntry.
+ */
+class ParamEntry{
+ public:
+  ParamEntry();
+  ParamEntry(int total, Param* p);
+  /**
+   * Associate the counter to a Param object.
+   *
+   * @param p
+   * @param local 1 if it is used by workers in this procs, 0 otherwise
+   */
+  void AddParam(bool local, Param* p);
+  int num_update, next_version;
+  int num_local; //!< # local workers using the shared parameter
+  int num_total; //!< # total workers using the shared parameter
+  //!< Shares are deleted by neuralnet's destructor
+  vector<Param*> shares;
+};
+
+inline int ParamTrgt(int param_id, int slice_id) {
+  return (param_id << 16) | slice_id;
+}
+
+inline int ParamID(int param_trgt) {
+  return param_trgt >> 16;
+}
+
+inline int SliceID(int param_trgt) {
+  static int mask = (1 << 16) -1;
+  return param_trgt & mask;
+}
 }  // namespace singa
 
 #endif  // INCLUDE_UTILS_PARAM_H_

--- a/include/utils/updater.h
+++ b/include/utils/updater.h
@@ -9,6 +9,7 @@ namespace singa{
  */
 class Updater{
  public:
+  virtual ~Updater() {}
   virtual void Init(const UpdaterProto &proto){
     proto_=proto;
   }

--- a/src/communication/msg.cc
+++ b/src/communication/msg.cc
@@ -1,62 +1,194 @@
+#include <glog/logging.h>
 #include "communication/msg.h"
 
 namespace singa {
 
 #ifdef USE_ZMQ
+Msg::~Msg() {
+  if (msg_ != nullptr)
+    zmsg_destroy(&msg_);
+  frame_ = nullptr;
+}
+
 Msg::Msg() {
   msg_ = zmsg_new();
 }
 
-Msg::Msg(const Msg& msg){
-  src_=msg.src_;
-  dst_=msg.dst_;
-  type_=msg.type_;
-  trgt_first_=msg.trgt_first_;
-  trgt_second_=msg.trgt_second_;
+Msg::Msg(const Msg& msg) {
+  src_ = msg.src_;
+  dst_ = msg.dst_;
+  type_ = msg.type_;
+  trgt_val_ = msg.trgt_val_;
+  trgt_version_ = msg.trgt_version_;
   msg_=zmsg_dup(msg.msg_);
 }
 
-Msg::~Msg() {
-  if (msg_ != nullptr)
-    zmsg_destroy(&msg_);
+Msg::Msg(int src, int dst) {
+  src_ = src;
+  dst_ = dst;
+  msg_ = zmsg_new();
 }
 
-int Msg::size() const{
+void Msg::SwapAddr() {
+  std::swap(src_, dst_);
+}
+
+int Msg::size() const {
   return zmsg_content_size(msg_);
 }
 
-void Msg::add_frame(const void* addr, int nBytes) {
+void Msg::AddFrame(const void* addr, int nBytes) {
   zmsg_addmem(msg_, addr, nBytes);
 }
 
-int Msg::frame_size() {
+int Msg::FrameSize() {
   return zframe_size(frame_);
 }
 
-void* Msg::frame_data() {
+void* Msg::FrameData() {
   return zframe_data(frame_);
 }
 
-bool Msg::next_frame() {
+char* Msg::FrameStr() {
+  return zframe_strdup(frame_);
+}
+bool Msg::NextFrame() {
   frame_ = zmsg_next(msg_);
   return frame_ != nullptr;
 }
 
+void Msg::FirstFrame() {
+  frame_ = zmsg_first(msg_);
+}
+
+void Msg::LastFrame() {
+  frame_ = zmsg_last(msg_);
+}
+
 void Msg::ParseFromZmsg(zmsg_t* msg) {
   char* tmp = zmsg_popstr(msg);
-  sscanf(tmp, "%d %d %d %d %d %d",
-         &src_, &dst_, &type_, &trgt_first_, &trgt_second_, &trgt_third_);
-  frame_ = zmsg_next(msg);
+  sscanf(tmp, "%d %d %d %d %d",
+         &src_, &dst_, &type_, &trgt_val_, &trgt_version_);
+  frame_ = zmsg_first(msg);
   msg_ = msg;
 }
 
 zmsg_t* Msg::DumpToZmsg() {
-  zmsg_pushstrf(msg_, "%d %d %d %d %d %d",
-      src_, dst_, type_, trgt_first_, trgt_second_, trgt_third_);
+  zmsg_pushstrf(msg_, "%d %d %d %d %d",
+      src_, dst_, type_, trgt_val_, trgt_version_);
   zmsg_t *tmp = msg_;
   msg_ = nullptr;
   return tmp;
 }
+
+// frame marker indicating this frame is serialize like printf
+#define FMARKER "*singa*"
+
+#define kMaxFrameLen 2048
+
+int Msg::AddFormatFrame(const char *format, ...) {
+  va_list argptr;
+  va_start(argptr, format);
+  int size = strlen(FMARKER);
+  char dst[kMaxFrameLen];
+  memcpy(dst, FMARKER, size);
+  dst[size++] = 0;
+  while (*format) {
+    if (*format == 'i') {
+      int x = va_arg(argptr, int);
+      dst[size++] = 'i';
+      memcpy(dst + size, &x, sizeof(x));
+      size += sizeof(x);
+    } else if (*format == 'f') {
+      float x = static_cast<float> (va_arg(argptr, double));
+      dst[size++] = 'f';
+      memcpy(dst + size, &x, sizeof(x));
+      size += sizeof(x);
+    } else if (*format == '1') {
+      uint8_t x = va_arg(argptr, int);
+      memcpy(dst + size, &x, sizeof(x));
+      size += sizeof(x);
+    } else if (*format == '2') {
+      uint16_t x = va_arg(argptr, int);
+      memcpy(dst + size, &x, sizeof(x));
+      size += sizeof(x);
+    } else if (*format == '4') {
+      uint32_t x = va_arg(argptr, uint32_t);
+      memcpy(dst + size, &x, sizeof(x));
+      size += sizeof(x);
+    } else if (*format == 's') {
+      char* x = va_arg(argptr, char *);
+      dst[size++] = 's';
+      memcpy(dst + size, x, strlen(x));
+      size += strlen(x);
+      dst[size++] = 0;
+    } else if (*format == 'p') {
+      void* x = va_arg(argptr, void *);
+      dst[size++] = 'p';
+      memcpy(dst + size, &x, sizeof(x));
+      size += sizeof(x);
+    } else {
+      LOG(ERROR) << "Unknown format " << *format;
+    }
+    format++;
+    CHECK_LE(size, kMaxFrameLen);
+  }
+  va_end(argptr);
+  zmsg_addmem(msg_, dst, size);
+  return size;
+}
+
+int Msg::ParseFormatFrame(const char *format, ...) {
+  va_list argptr;
+  va_start(argptr, format);
+  char* src = zframe_strdup(frame_);
+  CHECK_STREQ(FMARKER, src);
+  int size = strlen(FMARKER) + 1;
+  while (*format) {
+    if (*format == 'i') {
+      int *x = va_arg(argptr, int *);
+      CHECK_EQ(src[size++], 'i');
+      memcpy(x, src + size, sizeof(*x));
+      size += sizeof(*x);
+    } else if (*format == 'f') {
+      float *x = va_arg(argptr, float *);
+      CHECK_EQ(src[size++], 'f');
+      memcpy(x, src + size, sizeof(*x));
+      size += sizeof(*x);
+    }else if (*format == '1') {
+      uint8_t *x = va_arg(argptr, uint8_t *);
+      memcpy(x, src + size, sizeof(*x));
+      size += sizeof(*x);
+    } else if (*format == '2') {
+      uint16_t *x = va_arg(argptr, uint16_t *);
+      memcpy(x, src + size, sizeof(*x));
+      size += sizeof(*x);
+    } else if (*format == '4') {
+      uint32_t *x = va_arg(argptr, uint32_t *);
+      memcpy(x, src + size, sizeof(*x));
+      size += sizeof(*x);
+    } else if (*format == 's') {
+      char* x = va_arg(argptr, char *);
+      int len = strlen(src + size);
+      CHECK_EQ(src[size++], 's');
+      memcpy(x, src + size, len);
+      x[len] = 0;
+      size += len + 1;
+    } else if (*format == 'p') {
+      void** x = va_arg(argptr, void **);
+      CHECK_EQ(src[size++], 'p');
+      memcpy(x, src + size, sizeof(*x));
+      size += sizeof(*x);
+    } else {
+      LOG(ERROR) << "Unknown format type " << *format;
+    }
+    format++;
+  }
+  va_end(argptr);
+  delete src;
+  return size;
+}
+
 #endif
 
 }  // namespace singa

--- a/src/neuralnet/layer.cc
+++ b/src/neuralnet/layer.cc
@@ -235,7 +235,7 @@ void LabelLayer::ParseRecords(Phase phase, const vector<Record>& records,
 /*********************LMDBDataLayer**********************************/
 void LMDBDataLayer::ComputeFeature(Phase phase, Metric* perf){
   if(random_skip_){
-    int nskip=rand()%random_skip_;
+    int nskip = rand() % random_skip_;
     int n=0;
     CHECK_EQ(mdb_cursor_get(mdb_cursor_, &mdb_key_,
           &mdb_value_, MDB_FIRST), MDB_SUCCESS);
@@ -637,7 +637,7 @@ void RGBImageLayer::Setup(const LayerProto& proto, int npartitions) {
 /***************Implementation for ShardDataLayer**************************/
 void ShardDataLayer::ComputeFeature(Phase phase, Metric* perf){
   if(random_skip_){
-    int nskip=rand()%random_skip_;
+    int nskip = rand() % random_skip_;
     LOG(INFO)<<"Random Skip "<<nskip<<" records, there are "<<shard_->Count()
       <<" records in total";
     string key;

--- a/src/proto/model.proto
+++ b/src/proto/model.proto
@@ -42,6 +42,8 @@ message ModelProto {
   optional int32 checkpoint_frequency = 34 [default = 0];
   // send parameters to servers after training for this num of steps
   optional int32 warmup_steps = 35 [default = 0];
+  // checkpoint path
+  optional bool resume = 36 [default = false];
 
    // start display after this num steps
   optional int32 display_after_steps =  60[default = 0];
@@ -60,7 +62,7 @@ message ModelProto {
 message NetProto {
   repeated LayerProto layer = 1;
   // partitioning type for parallelism
-  optional int32 partition_dim = 2 [default = -1];
+  optional int32 partition_dim = 2 [default = 0];
 }
 
 // weight matrix should be defined before bias vector
@@ -209,7 +211,7 @@ message RGBImageProto {
   optional string meanfile = 4 [default = ""];
 }
 
-message PrefetchProto{
+message PrefetchProto {
   repeated LayerProto sublayers = 1;
 }
 

--- a/src/test/test_paramslicer.cc
+++ b/src/test/test_paramslicer.cc
@@ -6,6 +6,7 @@ using namespace singa;
 
 const int param_size[]={2400,32,25600,32, 51200,64,57600,10};
 
+/*
 class ParamSlicerTest : public ::testing::Test {
   public:
     ParamSlicerTest() {
@@ -45,3 +46,4 @@ TEST_F(ParamSlicerTest, MultipleBox){
   ASSERT_EQ(slicer.Get(3).size(),1);
   ASSERT_EQ(slicer.Get(nparams-1).back(), slices.size()-1);
 }
+*/

--- a/src/test/test_shard.cc
+++ b/src/test/test_shard.cc
@@ -17,7 +17,7 @@ std::string tuple[] = {"firsttuple",
 using namespace singa;
 
 TEST(DataShardTest, CreateDataShard) {
-  std::string path = "src/test/data/shard_test";
+  std::string path = "src/test/shard_test";
   mkdir(path.c_str(), 0755);
   DataShard shard(path, DataShard::kCreate, 50);
   shard.Insert(key[0], tuple[0]);
@@ -27,7 +27,7 @@ TEST(DataShardTest, CreateDataShard) {
 }
 
 TEST(DataShardTest, AppendDataShard) {
-  std::string path = "src/test/data/shard_test";
+  std::string path = "src/test/shard_test";
   DataShard shard(path, DataShard::kAppend, 50);
   shard.Insert(key[3], tuple[3]);
   shard.Insert(key[4], tuple[4]);
@@ -35,14 +35,14 @@ TEST(DataShardTest, AppendDataShard) {
 }
 
 TEST(DataShardTest, CountDataShard) {
-  std::string path = "src/test/data/shard_test";
+  std::string path = "src/test/shard_test";
   DataShard shard(path, DataShard::kRead, 50);
   int count = shard.Count();
   ASSERT_EQ(5, count);
 }
 
 TEST(DataShardTest, ReadDataShard) {
-  std::string path = "src/test/data/shard_test";
+  std::string path = "src/test/shard_test";
   DataShard shard(path, DataShard::kRead, 50);
   std::string k, t;
   ASSERT_TRUE(shard.Next(&k, &t));

--- a/src/trainer/server.cc
+++ b/src/trainer/server.cc
@@ -1,6 +1,5 @@
-#include <list>
-#include <tuple>
-#include <queue>
+#include <thread>
+#include <chrono>
 #include "mshadow/tensor.h"
 #include "trainer/server.h"
 #include "utils/param.h"
@@ -9,101 +8,93 @@
 #include "utils/cluster.h"
 #include "proto/common.pb.h"
 
-using namespace mshadow;
 namespace singa {
-Server::Server(int thread_id,int group_id, int server_id):
-  thread_id_(thread_id),group_id_(group_id), server_id_(server_id){}
+using namespace mshadow;
 
-void Server::Setup(const UpdaterProto& proto,
-    shared_ptr<ServerShard> shard, const vector<int>& slice2group){
-	//VLOG(3) << "Parsing config file for host "<<hosts[id_] << " server id = " <<id_;
-  updater_=shared_ptr<Updater>(Singleton<Factory<Updater>>::Instance()
-      ->Create("Updater"));
-  updater_->Init(proto);
-  shard_=shard;
-  slice2group_=slice2group;
+Server::Server(int thread_id,int group_id, int server_id):
+  thread_id_(thread_id),grp_id_(group_id), id_(server_id){
 }
 
-void Server::Run(){
-  LOG(ERROR)<<"Server (group_id = "<<group_id_
-    <<", id = "<<server_id_<<") starts";
-  dealer_=std::make_shared<Dealer>(2*thread_id_);
-  dealer_->Connect(kInprocRouterEndpoint);
-  auto cluster=Cluster::Get();
-  Msg* ping=new Msg();
-  ping->set_src(group_id_, server_id_, kServer);
-  ping->set_dst(-1,-1,kStub);
-  ping->add_frame("PING", 4);
+void Server::Setup(const UpdaterProto& proto,
+    std::unordered_map<int, ParamEntry*>* shard,
+    const vector<int>& slice2group) {
+  updater_ = Singleton<Factory<Updater>>::Instance()->Create("Updater");
+  updater_->Init(proto);
+  shard_ = shard;
+  slice2group_ = slice2group;
+}
+
+Server::~Server() {
+  delete updater_;
+}
+
+void Stop(void * running) {
+  *static_cast<bool *>(running) = false;
+}
+
+void Server::Run() {
+  LOG(ERROR) << "Server (group = " << grp_id_ <<", id = " << id_ << ") start";
+  auto dealer = new Dealer(2*thread_id_);
+  CHECK(dealer->Connect(kInprocRouterEndpoint));
+  Msg* ping = new Msg(Addr(grp_id_, id_, kServer), Addr(-1, -1, kStub));
   ping->set_type(kConnect);
-  dealer_->Send(&ping);
+  dealer->Send(&ping);
+
+  auto cluster = Cluster::Get();
+  bool running = true;
+  CHECK(cluster->runtime()->WatchSGroup(grp_id_, id_, Stop, &running));
+
+  int nserver_grps = cluster->nserver_groups();
   vector<Param*> master_params;
   size_t syncEntry=0;
-  //start recv loop and process requests
-  while (true){
-    Msg* msg=dealer_->Receive();
-    if (msg==nullptr)
-      break;
-    Msg* response=nullptr, *sync=nullptr;
+  Poller poll(dealer);
+  // start recv loop and process requests
+  while (running) {
+    auto *sock = poll.Wait(cluster->poll_time());
+    if (poll.Terminated()) {
+      LOG(ERROR) << "Connection broken!";
+      exit(0);
+    } else if (sock == nullptr) {
+      continue;
+    }
+    Msg* msg=dealer->Receive();
+    if (msg==nullptr) break;
+    Msg* response=nullptr;
     int type=msg->type();
-    if (type== kStop){
-      msg->set_src(group_id_, server_id_, kServer);
-      msg->set_dst(-1,-1, kStub);
-      dealer_->Send(&msg);
-      break;
-    }else if (type==kConnect){
-      // TODO remove receiving pong msg
-      string pong((char*)msg->frame_data(), msg->frame_size());
-      CHECK_STREQ("PONG", pong.c_str());
-      DeleteMsg(&msg);
-    }else if(type==kPut){
-      int pid = msg->trgt_second();
+    int slice_id = SliceID(msg->trgt_val());
+    if (type == kPut) {
       response = HandlePut(&msg);
-      if(slice2group_[pid]==group_id_)
-        master_params.push_back(shard_->at(pid));
-    }else{
-      int pid=msg->trgt_second();
-      if(shard_->find(pid)==shard_->end()){
+      if(slice2group_[slice_id] == grp_id_)
+        master_params.push_back(shard_->at(slice_id)->shares.at(0));
+    } else {
+      if (shard_->find(slice_id) == shard_->end()) {
         // delay the processing by re-queue the msg.
-        response=msg;
-        //LOG(INFO)<<"Requeue msg"<<type;
-      }else if(type == kSyncReminder){
+        response = msg;
+      } else if (type == kSyncReminder) {
         DeleteMsg(&msg);
-        if(syncEntry>=master_params.size())
+        if(syncEntry >= master_params.size())
           continue;
-        auto param=master_params.at(syncEntry);
+        auto param = master_params.at(syncEntry);
         // control the frequency of synchronization
         // currently sync is triggerred only when the slice is updated
         // by local worker or other workers for at least nserver_groups times.
         // TODO may optimize the trigger condition.
-        if(abs(param->local_version()-param->version())>=cluster->nserver_groups()){
-          // TODO replace the argument (0,0) to sync a chunk instead of a slice
-          sync=param->GenSyncMsg(0,0);
-          for(int i=0;i<cluster->nserver_groups();i++){
-            if(i!=group_id_) {
-              Msg* tmp=sync;
-              if(i<cluster->nserver_groups()-1)
-                tmp= new Msg(*sync);
-              // assume only one server per group, TODO generalize it
-              tmp->set_dst(i, 0, kServer);
-              tmp->set_src(group_id_, server_id_, kServer);
-              dealer_->Send(&tmp);
-              param->set_version(param->local_version());
-              //LOG(ERROR)<<"sync slice="<<param->id()<<" to procs "<<i;
-            }
-          }
-          syncEntry=(syncEntry+1)%master_params.size();
+        if (abs(param->local_version() - param->version()) >= nserver_grps) {
+          for (auto msg : GenSyncMsgs(param))
+            dealer->Send(&msg);
+          syncEntry = (syncEntry+1) % master_params.size();
         }
-      }else{
-        auto param=shard_->at(pid);
-        switch (type){
+      } else {
+        switch (type) {
           case kGet:
-            response=HandleGet(param, &msg);
+            response = HandleGet(&msg);
             break;
           case kUpdate:
-            response = HandleUpdate(param, &msg);
+            for (auto reply : HandleUpdate(&msg))
+              dealer->Send(&reply);
             break;
           case kSyncRequest:
-            response = HandleSyncRequest(param, &msg);
+            response = HandleSyncRequest(&msg);
             break;
           default:
             LOG(ERROR)<<"Unknown message type "<<type;
@@ -111,96 +102,149 @@ void Server::Run(){
         }
       }
     }
-    if (response!=nullptr)
-      dealer_->Send(&response);
+    if (response != nullptr)
+      dealer->Send(&response);
   }
-  LOG(ERROR)<<"Server (group_id = "<<group_id_
-    <<", id = "<<server_id_<<") stops";
+
+  // send stop msg to stub
+  Msg* msg = new Msg(Addr(grp_id_, id_, kServer), Addr(-1, -1, kStub));
+  msg->set_type(kStop);
+  dealer->Send(&msg);
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+  LOG(ERROR) << "Server (group = " << grp_id_ << ", id = " << id_ << ") stops";
+  delete dealer;
 }
 
-Msg* Server::HandlePut(Msg **msg){
-  int version=(*msg)->trgt_third();
-  int pid=(*msg)->trgt_second();
-  Param* param=nullptr;
-  if(shard_->find(pid)!=shard_->end()){
-    LOG(ERROR)<<"Param ("<<pid<<") is put more than once";
-    param=shard_->at(pid);
-  }else{
-    auto factory=Singleton<Factory<Param>>::Instance();
-    param=factory ->Create("Param");
-    (*shard_)[pid]=param;
+const vector<Msg*> Server::GenSyncMsgs(Param* param) {
+  vector<Msg*> ret;
+  // TODO replace the argument (0,0) to sync a chunk instead of a slice
+  auto msg = param->GenSyncMsg(0, 0);
+  auto cluster = Cluster::Get();
+  for (int i = 0; i < cluster->nserver_groups(); i++) {
+    if (i != grp_id_) {
+      Msg* tmp = msg;
+      if (i < cluster->nserver_groups() - 1)
+        tmp = new Msg(*msg);
+      // assume only one server per group, TODO generalize it
+      tmp->set_dst(Addr(i, 0, kServer));
+      tmp->set_src(Addr(grp_id_, id_, kServer));
+      ret.push_back(tmp);
+      param->set_version(param->local_version());
+      //LOG(ERROR)<<"sync slice="<<param->id()<<" to procs "<<i;
+    }
   }
-  auto response=param->HandlePutMsg(msg);
+  return ret;
+}
+
+Msg* Server::HandlePut(Msg **msg) {
+  int version = (*msg)->trgt_version();
+  int slice_id = SliceID((*msg)->trgt_val());
+  if (shard_->find(slice_id) != shard_->end())
+    LOG(FATAL) << "Param (" << slice_id << ") is put more than once";
+
+  auto  param = Singleton<Factory<Param>>::Instance()->Create("Param");
+  auto response = param->HandlePutMsg(msg, true);
+  // parse num of shares of this param from a worker group
+  int num_shares = 1;
+  if ((*msg)->NextFrame())
+    (*msg)->ParseFormatFrame("i", &num_shares);
+  DeleteMsg(msg);
+  (*shard_)[slice_id] = new ParamEntry(num_shares, param);
   // must set version after HandlePutMsg which allocates the memory
   param->set_version(version);
   param->set_local_version(version);
-  param->set_id(pid);
+  param->set_id(slice_id);
   //LOG(ERROR)<<"put norm "<<param->data().asum_data()<<", "<<pid;
-  if(Cluster::Get()->nserver_groups()>1 &&
-      slice2group_[pid]!=group_id_){
-    last_data_[pid]=std::make_shared<Blob<float>>();
-    last_data_[pid]->ReshapeLike(param->data());
-    last_data_[pid]->CopyFrom(param->data());
+  // allocate blob for param sync between groups.
+  if (Cluster::Get()->nserver_groups() > 1 && slice2group_[slice_id] != grp_id_) {
+    last_data_[slice_id] = std::make_shared<Blob<float>>();
+    last_data_[slice_id]->ReshapeLike(param->data());
+    last_data_[slice_id]->CopyFrom(param->data());
   }
-  LOG(INFO)<<"server ("<<group_id_<<", "<<server_id_
-    <<") put slice="<<pid<<" size="<<param->size();
+  LOG(INFO)<<"server (group = " << grp_id_ << ", id = " << id_ <<") put slice="
+    << slice_id << " size=" << param->size();
   return response;
 }
 
-Msg* Server::HandleGet(Param* param, Msg **msg){
-  if(param->version()<(*msg)->trgt_third())
+Msg* Server::HandleGet(Msg **msg) {
+  int val = (*msg)->trgt_val();
+  auto param = shard_->at(SliceID(val))->shares.at(0);
+  // re-queue the request if the param is not updated to the required version
+  if(param->version()<(*msg)->trgt_version())
     return *msg;
-  else{
-    auto reply= param->HandleGetMsg(msg);
-    int paramid=reply->trgt_first(), slice=reply->trgt_second();
-    reply->set_trgt(paramid, slice, param->version());
+  else {
+    // LOG(ERROR) << "get " << slice << " from "<<(*msg)->src_first();
+    auto reply = param->HandleGetMsg(msg);
+    reply->set_trgt(val, param->version());
     return reply;
   }
 }
 
-Msg* Server::HandleUpdate(Param* param, Msg **msg) {
-  auto* tmp=static_cast<Msg*>((*msg)->CopyAddr());
-  tmp->SwapAddr();
-  int paramid=(*msg)->trgt_first();
-  int sliceid=(*msg)->trgt_second();
-  int step=(*msg)->trgt_third();
-  bool copy=param->ParseUpdateMsg(msg);
-  updater_->Update(step, param);
-  param->set_local_version(param->local_version()+1);
-  auto response=param->GenUpdateResponseMsg(copy);
-  response->set_trgt(paramid, sliceid, param->local_version());
-  response->SetAddr(tmp);
-  delete tmp;
-  return response;
+const vector<Msg*> Server::HandleUpdate(Msg **msg) {
+  vector<Msg*> ret;
+  int sliceid = SliceID((*msg)->trgt_val());
+  auto entry = shard_->at(sliceid);
+  buffer_requests_[sliceid].push_back(*msg);
+  int num_update;
+  (*msg)->LastFrame();
+  (*msg)->ParseFormatFrame("i", &num_update);
+  (*msg)->FirstFrame();
+  entry->num_update += num_update;
+  // LOG(ERROR) << "update "<<sliceid<< " from "<<(*msg)->src_second()
+  //  << ", " << num_update << " total " << entry->num_total;
+  // do update until recv gradients from all shares of this param/slice
+  if (entry->num_update >= entry->num_total) {
+    CHECK_EQ(entry->num_update, entry->num_total);
+    auto& request = buffer_requests_.at(sliceid);
+    int step = (*msg)->trgt_version();
+    auto param = entry->shares.at(0);
+    // extract and aggregate gradients
+    param->ParseUpdateMsgs(request);
+    updater_->Update(step, param);
+    param->set_local_version(param->local_version() + 1);
+    // response to all shares of this param
+    for (auto response : param->GenUpdateResponseMsgs(request)) {
+      response->set_trgt((*msg)->trgt_val(), param->local_version());
+      ret.push_back(response);
+    }
+    request.clear();
+    entry->num_update = 0;
+  }
+  *msg = nullptr;
+  return ret;
 }
 
-Msg* Server::HandleSyncRequest(Param* param, Msg **msg){
+Msg* Server::HandleSyncRequest(Msg **msg) {
+  Msg* msgg = *msg;
+  int slice = SliceID(msgg->trgt_val());
+  auto param = shard_->at(slice)->shares.at(0);
   Msg* response=nullptr;
   auto shape=Shape1(param->size());
-  CHECK_EQ((*msg)->frame_size(), param->size()*sizeof(float));
-  Tensor<cpu, 1> tmp(static_cast<float*>((*msg)->frame_data()), shape);
+  CHECK_EQ(msgg->FrameSize(), param->size()*sizeof(float));
+  Tensor<cpu, 1> tmp(static_cast<float*>(msgg->FrameData()), shape);
   Tensor<cpu, 1> cur(param->mutable_cpu_data(), shape);
   //LOG(ERROR)<<"Recv sync for "<<param->id();
-  if(slice2group_[param->id()]==group_id_){
+  if (slice2group_[slice] == grp_id_) {
+    // recv sync msg on slice I am mastering
     cur+=tmp;
     param->set_local_version(param->local_version()+1);
-  }else{
+  } else {  // recv sync msg on slice mastered by others
     TensorContainer<cpu, 1> diff(shape);
     Tensor<cpu, 1> prev(last_data_[param->id()]->mutable_cpu_data(), shape);
     diff=cur-prev;
-    (*msg)->next_frame();
+    msgg->NextFrame();
     int bandwidth;
-    sscanf(static_cast<char*>((*msg)->frame_data()), "%d", &bandwidth);
-    if(bandwidth>0){
-      response=new Msg();
+    msgg->ParseFormatFrame("i", &bandwidth);
+    if (bandwidth > 0) {
+      // send back my updates to the server group mastering this param
+      response=new Msg(msgg->dst(), msgg->src());
       response->set_type(kSyncRequest);
-      response->set_trgt(-1, param->id(), param->version());
-      response->add_frame(diff.dptr, param->size()*sizeof(float));
-      (*msg)->SwapAddr();
-      response->SetAddr(*msg);
+      response->set_trgt(param->id(), param->version());
+      response->AddFrame(diff.dptr, param->size()*sizeof(float));
       prev=diff+tmp;
       Copy(cur, prev);
-    }else{
+    } else {  // no bandwidth, aggregate my updates for next sync
       Copy(prev, tmp);
       cur=tmp+diff;
     }

--- a/src/trainer/trainer.cc
+++ b/src/trainer/trainer.cc
@@ -1,9 +1,10 @@
 #include <thread>
 #include <vector>
 #include <map>
-#include <queue>
 #include <chrono>
 #include <glog/logging.h>
+#include "utils/cluster.h"
+#include "utils/common.h"
 #include "proto/common.pb.h"
 #include "trainer/trainer.h"
 #include "mshadow/tensor.h"
@@ -11,587 +12,486 @@
 namespace singa {
 using std::vector;
 using std::map;
+using std::queue;
 using namespace std::chrono;
 using std::make_shared;
 
-typedef std::chrono::milliseconds TimeT;
+/***********************Trainer****************************/
+Trainer::~Trainer() {
+  // free Params (i.e., slices) in server shard
+  for (auto entry : server_shard_)
+    for (auto param : entry.second->shares)
+      delete param;
+  delete router_;
+}
 
-void Trainer::RegisterDefaultClasses(const singa::ModelProto& proto){
-  // register all layers appearing in the neural net
+void Trainer::RegisterDefaultClasses(const singa::ModelProto& model_conf) {
+  // register all implemented layers
   singa::NeuralNet::RegisterLayers();
-  Singleton<Factory<singa::Param>>::Instance()->Register(
-      "Param", CreateInstance(singa::Param, singa::Param));
-  Singleton<Factory<singa::Updater>>::Instance() ->Register(
-      "Updater", CreateInstance(singa::SGDUpdater, singa::Updater));
+  auto param_factory = Singleton<Factory<singa::Param>>::Instance();
+  param_factory->Register("Param", CreateInstance(Param, Param));
+  auto updater_factory = Singleton<Factory<singa::Updater>>::Instance();
+  updater_factory->Register("Updater", CreateInstance(SGDUpdater, Updater));
 }
 
-void HandleWorkerFinish(void * ctx){
-  HandleContext* hctx=static_cast<HandleContext*> (ctx);
-  Msg* msg=new Msg();
-  msg->set_src(-1,-1, kRuntime);
-  msg->set_dst(hctx->group_id, hctx->id, kServer);
-  msg->set_type(kStop);
-  hctx->dealer->Send(&msg);
-}
+const vector<int> SliceParams(const vector<Param*>& params) {
+  // for load-balance among servers in a group and among server groups
+  int nserver_grps = Cluster::Get()->nserver_groups();
+  int nservers_per_grp = Cluster::Get()->nservers_per_group();
+  int lcm = LeastCommonMultiple(nserver_grps, nservers_per_grp);
 
-const std::unordered_map<int, vector<std::pair<int, int>>>
-SliceParams(int num, const vector<Param*>& params){
+  // collect sizes of unique Params
+  std::vector<int> paramsize;
+  for (auto param : params)
+    if (param->id() == param->owner())
+      paramsize.push_back(param->size());
+  // slice into lcm pieces to achieve good load-balance for both intra-group
+  // partition (among servers in a group) and inter-group partition (each group
+  // is assgined a sub-set of slices)
+  auto param_slice = Slice(lcm, paramsize);
+  // construct map from Param ID to its slices <slice id, len>
   std::unordered_map<int, vector<std::pair<int, int>>> paramid2slices;
-  if (num==0)
-    return paramid2slices;
-  vector<int> param_size;
-  int avg=0;
-  for(const auto& x:params){
-    if(x->owner()==x->id())
-      avg+=x->size();
+  vector<int> slices;
+  auto it = param_slice.begin();
+  int slice_id = 0;
+  for (auto param : params) {
+    if (param->id() == param->owner()) {
+      for (int len : *it) {
+        slices.push_back(len);
+        paramid2slices[param->id()].push_back(std::make_pair(slice_id++, len));
+      }
+      it++;
+    }
   }
-  avg=avg/num+avg%num;
-  int diff=avg/10;
-  LOG(INFO)<<"Slicer, param avg="<<avg<<", diff= "<<diff;
+  // add slice info for every Param
+  for (auto param : params)
+    for (auto entry : paramid2slices[param->owner()]) {
+      param->AddSlice(entry.first, entry.second);
+      LOG(INFO) << "param id " << param->id() << " owner=" << param->owner()
+        << ": " << entry.first << ", " << entry.second;
+    }
+  return slices;
+}
 
-  int capacity=avg, sliceid=0, nbox=0;
-  for(auto& param: params){
-    if(param->id()!=param->owner())
-      continue;
-    int x=param->size(), paramid=param->id();
-    LOG(INFO)<<"param id="<<paramid<<", total size="<<x;
-    while(x>0){
-      int size=0;
-      if(capacity>=x){
-        capacity-=x;
-        size=x;
-        x=0;
-      }else if(capacity+diff>=x){
-        size=x;
-        x=0;
-        capacity=0;
-      }else if(capacity>=diff){
-        x-=capacity;
-        size=capacity;
-        capacity=avg;
-        nbox++;
-      }else{
-        capacity=avg;
-        nbox++;
+void Trainer::SetupWorkerServer(
+    const ModelProto& model_conf,
+    const vector<Worker*>& workers,
+    const vector<Server*>& servers) {
+  auto cluster = Cluster::Get();
+  int grp_size = cluster->nworkers_per_group();
+  const auto& net_conf = model_conf.neuralnet();
+  auto net = NeuralNet::Create(net_conf, kTrain, grp_size);
+  // MUST do SliceParam before share param/net with others
+  auto slices = SliceParams(net->params());
+  shared_ptr<NeuralNet> train_net, test_net, valid_net;
+  int grp = workers.size() ? workers.at(0)->grp_id() : -1;
+  if (grp == 0 && model_conf.test_steps()) {
+    // test are performed only by the first group
+    test_net = NeuralNet::Create(net_conf, kTest, grp_size);
+    test_net->ShareParamsFrom(net);
+  }
+  if (grp == 0 && model_conf.validation_steps()) {
+    // validation are performed only by the first group
+    valid_net = NeuralNet::Create(net_conf, kValidation, grp_size);
+    valid_net->ShareParamsFrom(net);
+  }
+  bool prepare_param = true;
+  for (auto worker : workers) {
+    if (worker->grp_id() != grp) {
+      train_net = NeuralNet::Create(net_conf, kTrain, grp_size);
+      if(cluster->share_memory())
+        train_net->ShareParamsFrom(net);
+      valid_net = test_net = nullptr;
+      grp = worker->grp_id();
+      prepare_param = true;
+    } else {
+      train_net = net;
+    }
+    worker->Setup(model_conf, train_net, valid_net, test_net);
+    // Prepare ParamEntry
+    if (prepare_param) {
+      for (auto layer : train_net->layers()) {
+        bool local = layer->partition_id() >= workers.front()->id()
+          && layer->partition_id() <= workers.back()->id();
+        for (auto param : layer->GetParams()) {
+          int hash = Hash(grp, param->owner());
+          if (worker_shard_.find(hash) == worker_shard_.end())
+            worker_shard_[hash] = new ParamEntry();
+          worker_shard_[hash]->AddParam(local, param);
+        }
       }
-      if(size){
-        paramid2slices[paramid].push_back(std::make_pair(sliceid++, size));
-        LOG(INFO)<<"param id="<<paramid<<", slice size="<<size;
-      }
+      prepare_param = false;
     }
   }
-  CHECK_LE(nbox, num);
-  return paramid2slices;
+  // partition among server groups, each group maintains one sub-set for sync
+  auto slice2group = PartitionSlices(cluster->nserver_groups(), slices);
+  for (auto server : servers)
+    server->Setup(model_conf.updater(), &server_shard_, slice2group);
+  // partition within one server group, each server updates for one sub-set
+  slice2server_ = PartitionSlices(cluster->nservers_per_group(), slices);
 }
-const vector<int> PartitionSlice(int num, const vector<int>& slices){
-  int avg=0;
-  for(int x: slices)
-    avg+=x;
-  avg=avg/num+avg%num;
-  int box=avg, boxid=0, diff=avg/10;
-  vector<int> slice2box;
-  for(auto it=slices.begin(); it!=slices.end();){
-    int x=*it;
-    if(box>=x){
-      box-=x;
-      slice2box.push_back(boxid);
-      it++;
-    }else if(box+diff>=x){
-      slice2box.push_back(boxid);
-      it++;
-      box=0;
-    }else{
-      box=avg;
-      boxid++;
-    }
-  }
-//  CHECK_LT(slice2box.back(), num);
-  CHECK_EQ(slice2box.size(), slices.size());
-  int previd=slice2box[0];
-  std::string disp;
-  for(size_t i=0;i<slice2box.size();i++)
-    if(previd!=slice2box[i]){
-      disp+=", "+std::to_string(slices[i]);
-      previd=slice2box[i];
-    } else
-      disp+=" "+std::to_string(slices[i]);
-  LOG(INFO)<<"partition slice (avg ="<<avg<<", num="<<num<<"):"<<disp;
-  return slice2box;
-}
-vector<Server*> Trainer::CreateServers(int nthreads,
-    const ModelProto & mproto,
-    const vector<int> slices,
-    vector<HandleContext*>* ctx){
-  auto cluster=Cluster::Get();
+
+vector<Server*> Trainer::CreateServers(int nthreads, const ModelProto& mconf) {
+  auto cluster = Cluster::Get();
   vector<Server*> servers;
-  if(!cluster->has_server())
+  if (!cluster->has_server())
     return servers;
 
-  int pid=cluster->procs_id();
-  if(cluster->server_worker_separate())
-    pid-=cluster->nworker_procs();
-  int gid=pid*cluster->nservers_per_procs()/cluster->nservers_per_group();
-  int start=pid*cluster->nservers_per_procs()%cluster->nservers_per_group();
-  int end=start+cluster->nservers_per_procs();
-  // the ServerShard for servers consists of a dictionary of Param objects
-  server_shard_=make_shared<ServerShard>();
-  auto slice2group=PartitionSlice(cluster->nserver_groups(), slices);
-  if(start<end){
-    auto dealer=make_shared<Dealer>();
-    dealer->Connect(kInprocRouterEndpoint);
-    for(int sid=start;sid<end;sid++){
-      auto server=new Server(nthreads++, gid, sid);
-      server->Setup(mproto.updater(), server_shard_, slice2group);
-      servers.push_back(server);
-      auto *hc=new HandleContext{dealer, gid, sid};
-      ctx->push_back(hc);
-      CHECK(cluster->runtime()->WatchSGroup(gid, sid, HandleWorkerFinish,
-            ctx->back()));
-    }
+  int pid = cluster->procs_id();
+  // if true, server procs (logical) id starts after worker procs
+  if (cluster->server_worker_separate())
+    pid -= cluster->nworker_procs();
+  int procs_size = cluster->nservers_per_procs();
+  int grp_size = cluster->nservers_per_group();
+  int gid = pid *  procs_size / grp_size;
+  int start = pid * procs_size % grp_size;
+  int end = start + procs_size;
+  for (int sid = start; sid < end; sid++) {
+    auto server = new Server(nthreads++, gid, sid);
+    servers.push_back(server);
   }
   return servers;
 }
 
-vector<Worker*> Trainer::CreateWorkers(int nthreads,
-    const ModelProto& mproto, vector<int> *slice_size){
+vector<Worker*> Trainer::CreateWorkers(int nthreads, const ModelProto& mconf){
   auto cluster=Cluster::Get();
-  auto net=NeuralNet::Create(mproto.neuralnet(), kTrain,
-      cluster->nworkers_per_group());
-  int lcm=LeastCommonMultiple(cluster->nserver_groups(), cluster->nservers_per_group());
-  auto paramid2slices=SliceParams(lcm, net->params()); // sliceid, size
-  for(auto param: net->params()){
-    if(param->id() == param->owner())
-      for(auto entry: paramid2slices[param->id()])
-        slice_size->push_back(entry.second);
-  }
-
   vector<Worker*> workers;
   if(!cluster->has_worker())
     return workers;
-  //LOG(ERROR)<<net->ToString();
-  int pid=cluster->procs_id();
+  int pid = cluster->procs_id();
+  int grp_size = cluster->nworkers_per_group();
+  int procs_size = cluster->nworkers_per_procs();
   int gstart, gend, wstart, wend;
-  if(cluster->nworkers_per_group()>=cluster->nworkers_per_procs()){
+  if (grp_size >= procs_size) {
     // all workers in this procs are from the same group
-    gstart=pid*cluster->nworkers_per_procs()/cluster->nworkers_per_group();
-    gend=gstart+1;
-    wstart=pid*cluster->nworkers_per_procs()%cluster->nworkers_per_group();
-    wend=wstart+cluster->nworkers_per_group();
-  }else{
-    // there are multiple groups in this procs
-    CHECK_EQ(cluster->nworkers_per_procs()%cluster->nworkers_per_group(),0);
-    int groups_per_procs=
-      cluster->nworkers_per_procs()/cluster->nworkers_per_group();
-    gstart=pid*groups_per_procs;
-    gend=(pid+1)*groups_per_procs;
-    wstart=0;
-    wend=cluster->nworkers_per_group();
+    gstart = pid * procs_size / grp_size;
+    gend = gstart + 1;
+    wstart = pid * procs_size % grp_size;
+    wend = wstart + procs_size;
+  } else {
+    // there are multiple (complete) groups in this procs.
+    CHECK_EQ(procs_size % grp_size, 0);
+    int groups_per_procs = procs_size / grp_size;
+    gstart = pid * groups_per_procs;
+    gend = (pid+1) * groups_per_procs;
+    wstart = 0;
+    wend = grp_size;
   }
-  for(int gid=gstart;gid<gend;gid++){
-    shared_ptr<NeuralNet> train_net, test_net, validation_net;
-    if(gid==gstart)
-      train_net=net;
-    else{
-      train_net=NeuralNet::Create(mproto.neuralnet(), kTrain,
-          cluster->nworkers_per_group());
-      // the train net for other groups may share parameter values from the
-      // first group
-      if(cluster->share_memory())
-        train_net->ShareParams(net);
-    }
-    if(gid==0){
-      // validation and test are performed only by the first group
-      if(mproto.test_steps()){
-        test_net=NeuralNet::Create(mproto.neuralnet(), kTest,
-            cluster->nworkers_per_group());
-        if(test_net!=nullptr)
-          test_net->ShareParams(train_net);
-      }
-      if(mproto.validation_steps()){
-        validation_net=NeuralNet::Create(mproto.neuralnet(), kValidation,
-            cluster->nworkers_per_group());
-        if(validation_net!=nullptr)
-          validation_net->ShareParams(train_net);
-      }
-    }
-    // create ServerShard for the workers
-    auto shard=make_shared<WorkerShard>();
-    worker_shards_[gid]=shard;
-    for(auto layer: train_net->layers()){
-      int procsid=cluster->ProcsIDOf(gid, layer->partition_id(), kWorkerLayer);
-      bool local=procsid==cluster->procs_id();
-      for(auto param: layer->GetParams()){
-        for(auto entry :paramid2slices[param->owner()]){
-          param->AddSlice(entry.first,  entry.second);
-        }
-        int owner_procs=param->owner()==param->id()?procsid:procs_id_;
-        if(shard->find(param->owner())==shard->end())
-          (*shard)[param->owner()]=
-            make_shared<ParamInfo>(param, local, owner_procs);
-        else
-          shard->at(param->owner())->AddParam(param, local);
-      }
-    }
-    for(int wid=wstart;wid<wend;wid++){
+  for (int gid = gstart; gid < gend; gid++) {
+    for (int wid = wstart; wid < wend; wid++) {
       Worker* worker=nullptr;
-      if(mproto.alg()==ModelProto_GradCalcAlg_kBackPropagation)
+      if (mconf.alg() == ModelProto_GradCalcAlg_kBackPropagation)
         worker = new BPWorker(nthreads++,gid, wid);
-      else{
-        // TODO add CDWorker
+      else {
+        // TODO add CDWorker and BPTTWorker
       }
-      worker->Setup(mproto, train_net);
-      worker->set_test_net(test_net);
-      worker->set_validation_net(validation_net);
       workers.push_back(worker);
     }
   }
   return workers;
 }
 
-void Trainer::Start(const ModelProto& mproto, const GlobalProto& gproto, 
-                    const ClusterProto& cproto,
-    int procs_id){
-  // procs_id is only used for resume training
-  CHECK_EQ(procs_id, -1);
-  RegisterDefaultClasses(mproto);
+void Trainer::Start(const ModelProto& mconf, const GlobalProto& gconf,
+                    const ClusterProto& cconf, int job){
+  RegisterDefaultClasses(mconf);
 
-  auto cluster=Cluster::Get(gproto, cproto, procs_id);
-  router_=make_shared<Router>();
+  // register job to zookeeper
+  auto cluster=Cluster::Get(gconf, cconf, job);
+  if (mconf.resume()) {
+    // TODO(wangwei) resume from checkpoint
+    // load param slices to server_shard_ and reset running step of worker
+    // mproto.set_step(step);
+  }
+
+  router_ = new Router();
   router_->Bind(kInprocRouterEndpoint);
-  if(cluster->nprocs()>1){
-    const string hostip=cluster->hostip();
-    int port=router_->Bind("tcp://"+hostip+":*");
-    cluster->Register(hostip+":"+std::to_string(port));
-  }else
+  if (cluster->nprocs() > 1) {
+    const string hostip = cluster->hostip();
+    int port = router_->Bind("tcp://" + hostip + ":*");
+    // register endpoint to zookeeper
+    cluster->Register(hostip + ":" + std::to_string(port));
+  } else {
     cluster->set_procs_id(0);
+  }
 
-  procs_id_ = cluster->procs_id();
-  int nthreads=1;
-  // create workers
-  vector<int> slices;
-  vector<Worker*> workers=CreateWorkers(nthreads, mproto, &slices);
-  if(cluster->nserver_groups()&&cluster->nservers_per_group())
-    slice2server_=PartitionSlice(cluster->nservers_per_group(), slices);
-  nthreads+=workers.size();
-  // create servers
-  vector<HandleContext*> ctx;
-  vector<Server*> servers=CreateServers(nthreads, mproto, slices,
-      &ctx);
+  int nthreads = 1;
+  const vector<Worker*> workers = CreateWorkers(nthreads, mconf);
+  nthreads += workers.size();
+  const vector<Server*> servers = CreateServers(nthreads, mconf);
+  SetupWorkerServer(mconf, workers, servers);
 
 #ifdef USE_MPI
-  for(int i=0;i<nSocket;i++){
+  for (int i = 0; i < nthreads; i++)
     MPIQueues.push_back(make_shared<SafeQueue>());
-  }
 #endif
   vector<std::thread> threads;
-  for(auto server: servers)
-    threads.push_back(std::thread(&Server::Run,server));
-  for(auto worker: workers)
-    threads.push_back(std::thread(&Worker::Run,worker));
+  for(auto server : servers)
+    threads.push_back(std::thread(&Server::Run, server));
+  for(auto worker : workers)
+    threads.push_back(std::thread(&Worker::Run, worker));
   Run(workers, servers);
-  for(auto& thread: threads)
+  for(auto& thread : threads)
     thread.join();
-  for(auto x: ctx)
-    delete x;
-  for(auto x : servers)
-    delete x;
-  for(auto x : workers)
-    delete x;
+  for(auto server : servers)
+    delete server;
+  for(auto worker : workers)
+    delete worker;
 }
 
-inline int bandwidth(int bytes, system_clock::time_point start){
+inline int bandwidth(int bytes, system_clock::time_point start) {
   auto now=system_clock::now();
-  auto duration=duration_cast<TimeT> (now - start);
+  auto duration=duration_cast<std::chrono::milliseconds> (now - start);
   return static_cast<int>(bytes*1000.f/duration.count());
 }
 
-void Trainer::Run(const vector<Worker*>& workers,
-    const vector<Server*>& servers){
-  auto cluster=Cluster::Get();
-  procs_id_=cluster->procs_id();
-  LOG(INFO)<<"Stub in process "<<procs_id_<<" starts";
-  map<int, shared_ptr<Dealer>> interprocs_dealers;
+void Trainer::Run(
+    const vector<Worker*>& workers,
+    const vector<Server*>& servers) {
+  int nworkers = workers.size(), nservers = servers.size();
+  auto cluster = Cluster::Get();
+  procs_id_ = cluster->procs_id();
+  LOG(INFO) << "Stub in process " << procs_id_ << " starts";
+
+  // for sync among server groups
+  auto start = std::chrono::system_clock::now();
+  float trans_size = 0.f;  // total size of msg transferred since start time
+  int sync_server_id = 0;
+  int max_bandwidth = cluster->bandwidth();
+  int nserver_grps = cluster->nserver_groups();
+
+  map<int, Dealer*> inter_dealers;  // for sending msg to other procs
+
   std::queue<Msg*> msg_queue;
+  Poller poll(router_);
   bool stop=false;
-  auto start=std::chrono::system_clock::now();
-  float amount=0.f;
-  Poller poll;
-  poll.Add(router_.get());
-  int sync_server=0, nworkers=workers.size(), nservers=servers.size();
-  while(!stop){
-    // if the poll time is large, then the poller may not expire
-    // if it is small, then many reminder messages will be sent which may
-    // slow done the process of other request. TODO tune it.
-    auto *sock=poll.Wait(cluster->poll_time());
-    if(poll.Terminated()){
-      LOG(ERROR)<<"Connection broken!";
-      exit(0);
-    }else if(sock==nullptr){
-      if(cluster->nserver_groups()>1&&
-          bandwidth(amount, start)<cluster->bandwidth()){
-        Msg* msg=new Msg();
-        msg->set_src(-1,-1, kStub);
-        msg->set_dst(servers[sync_server]->group_id(),
-            servers[sync_server]->server_id(), kServer);
-        msg->set_type(kSyncReminder);
-        sync_server=(sync_server+1)%servers.size();
+  while (!stop || !msg_queue.empty()) {
+    if (msg_queue.empty()) {
+      // if the poll time is large, then the poller may not expire
+      // if it is small, then many reminder messages will be sent which may
+      // slow done the process of other request. TODO tune it.
+      auto *sock = poll.Wait(cluster->poll_time());
+      if (poll.Terminated()) {
+        LOG(ERROR) << "Connection broken!";
+        exit(0);
+      } else if (sock == nullptr) {
+        if (nserver_grps > 1 && bandwidth(trans_size, start) < max_bandwidth) {
+          Msg* msg = GenSyncReminderMsg(sync_server_id, servers);
+          router_->Send(&msg);
+          sync_server_id = (sync_server_id + 1) % nservers;
+        }
+        continue;
+      }
+      Msg* msg = router_->Receive();
+      msg_queue.push(msg);
+    }
+    Msg* msg = msg_queue.front();
+    msg_queue.pop();
+    int type = msg->type(), dst = msg->dst(), flag = AddrType(dst);
+    if (flag == kStub && (AddrProc(dst) == procs_id_ || AddrGrp(dst) == -1)) {
+      if (type == kConnect) {
+        DeleteMsg(&msg);
+      } else if (type == kMetric) {
+        DisplayMetric(&msg);
+      } else if (type == kStop) {
+        int src_flag = AddrType(msg->src());
+        if (src_flag == kServer) nservers--;
+        else if (src_flag == kWorkerParam) nworkers--;
+        DeleteMsg(&msg);
+        if (nworkers == 0 && nservers == 0) break;
+      } else if (nserver_grps > 0) {
+        HandleLocalMsg(&msg_queue, &msg);
+      } else {
+        DeleteMsg(&msg);
+      }
+    } else {
+      int dst_procs = AddrProc(dst);
+      if (flag != kStub)
+        dst_procs = cluster->ProcsIDOf(AddrGrp(dst), AddrID(dst), flag);
+      if (dst_procs != procs_id_) {
+        if (bandwidth(trans_size, start) <= cluster->bandwidth()) {
+          start = std::chrono::system_clock::now();
+          trans_size = 0;
+        }
+        trans_size += msg->size();
+
+        if (inter_dealers.find(dst_procs) == inter_dealers.end())
+          inter_dealers[dst_procs] = CreateInterProcsDealer(dst_procs);
+        inter_dealers[dst_procs]->Send(&msg);
+      } else {
+        if (type == kSyncRequest)
+          msg->AddFormatFrame("i", max_bandwidth - bandwidth(trans_size, start));
         router_->Send(&msg);
       }
-      continue;
-    }
-    Msg* msg=router_->Receive();
-    if(msg==nullptr){
-      LOG(ERROR)<<"Connection broken!";
-      exit(0);
-    }
-    msg_queue.push(msg);
-    while(!msg_queue.empty()){
-      msg=msg_queue.front();
-      msg_queue.pop();
-      int dst_flag=msg->dst_flag();
-      int type=msg->type();
-      int dst_procs=msg->dst_first();
-      if(dst_flag == kStub&&(dst_procs==procs_id_||dst_procs==-1)){
-        if(type==kConnect){
-          msg_queue.push(HandleConnect(&msg));
-        }else if(type==kStop){
-          if(msg->src_flag()==kServer)
-            nservers--;
-          else if (msg->src_flag()==kWorkerParam)
-            nworkers--;
-          DeleteMsg(&msg);
-          if(nworkers==0&&nservers==0){
-            stop=true;
-            break;
-          }
-        }else if(type==kMetric){
-          if(msg->src_first()==0){
-            int step=msg->trgt_first();
-            string prefix((char*)msg->frame_data(), msg->frame_size());
-            msg->next_frame();
-            Metric cur;
-            cur.ParseFrom(string((char*)msg->frame_data(), msg->frame_size()));
-            LOG(ERROR)<<prefix<<" step-" <<step<<", "<<cur.ToLogString();
-          }
-          DeleteMsg(&msg);
-        }else if(cluster->nserver_groups()>0){
-          int group_id;
-          int paramid=msg->trgt_first();
-          shared_ptr<ParamInfo> entry;
-          switch (type){ // TODO process other requests, e.g. RESTful
-            case kUpdate:
-              group_id=msg->src_first();
-              entry=worker_shards_.at(group_id)->at(paramid);
-              for(auto x:HandleUpdate(entry, &msg))
-                msg_queue.push(x);
-              break;
-            case kRUpdate:
-              group_id=msg->dst_second();
-              entry=worker_shards_.at(group_id)->at(paramid);
-              HandleUpdateResponse(entry, &msg);
-              break;
-            case kGet:
-              group_id=msg->src_first();
-              entry=worker_shards_.at(group_id)->at(paramid);
-              for(auto x:HandleGet(entry, &msg))
-                msg_queue.push(x);
-              break;
-            case kRGet:
-              group_id=msg->dst_second();
-              entry=worker_shards_.at(group_id)->at(paramid);
-              HandleGetResponse(entry, &msg);
-              break;
-            case kPut:
-              group_id=msg->src_first();
-              entry=worker_shards_.at(group_id)->at(paramid);
-              for(auto x:HandlePut(entry, &msg))
-                msg_queue.push(x);
-              break;
-            default:
-              LOG(ERROR)<<"Unknow message type:"<<type;
-              break;
-          }
-        }else{
-          DeleteMsg(&msg);
-        }
-      }else{
-        int dst_procs_id;
-        if(dst_flag==kStub){
-          dst_procs_id=msg->dst_first();
-        }else{
-          dst_procs_id=cluster->ProcsIDOf(msg->dst_first(),
-              msg->dst_second(), msg->dst_flag());
-        }
-        if(dst_procs_id!=procs_id_){
-          // forward to other procs
-          if (interprocs_dealers.find(dst_procs_id)==interprocs_dealers.end()){
-            auto dealer=make_shared<Dealer>();
-            interprocs_dealers[dst_procs_id]=dealer;
-            while(cluster->endpoint(dst_procs_id)==""){
-              std::this_thread::sleep_for(
-                  std::chrono::milliseconds(3000));//kCollectSleepTime));
-              LOG(ERROR)<<"waiting for procs "<< dst_procs_id<<" to register";
-            }
-            dealer->Connect("tcp://"+cluster->endpoint(dst_procs_id));
-          }
-          if(bandwidth(amount, start) <=cluster->bandwidth()){
-            start=std::chrono::system_clock::now();
-            amount=0;
-          }
-          amount+=msg->size();
-          //LOG(ERROR)<<"send inter msg of type "<<msg->type();
-          interprocs_dealers[dst_procs_id]->Send(&msg);
-        }else{
-          if(type==kSyncRequest){
-            char buf[32];
-            sprintf(buf, "%d", cluster->bandwidth()-bandwidth(amount, start));
-            msg->add_frame(buf, strlen(buf));
-          }
-          router_->Send(&msg);
-        }
-      }
     }
   }
-  LOG(INFO)<<"Stub in process "<<procs_id_<<" stops";
-}
-Msg* Trainer::HandleConnect(Msg** msg){
-  string ping((char*)(*msg)->frame_data(), (*msg)->frame_size());
-  CHECK_STREQ("PING", ping.c_str());
-  // ping-pong for debug
-  (*msg)->SwapAddr();
-  Msg* reply=new Msg();
-  reply->SetAddr(*msg);
-  reply->add_frame("PONG", 4);
-  reply->set_type(kConnect);
-  DeleteMsg(msg);
-  return reply;
-}
-const vector<Msg*> Trainer::HandleGet(shared_ptr<ParamInfo> pi, Msg** msg){
-  Msg* msgg=*msg;
-  vector<Msg*> replies;
-  int version=msgg->trgt_third();
-  if(msgg->src_flag()==kStub){
-    LOG(FATAL)<<"Not implemented";
-    /*
-    if(version<=pi->shares.at(0)->version()){
-      replies.push_back(pi->shares.at(0)->HandleGetMsg(msg));
-    }else if(version>pi->next_version){
-      // reinsert into a msg queue.
-      replies.push_back(mmsg);
-    }
-    */
-  }else if(version>pi->next_version){
-    pi->next_version=version;
-    int gid=msgg->src_first();
-    int group=gid/Cluster::Get()->nworker_groups_per_server_group();
-    auto param=pi->shares.at(0);
-    for(int idx=0, id=param->slice_start();idx<param->num_slices();idx++){
-      int server=slice2server_[id+idx];
-      int procs=Cluster::Get()->ProcsIDOf(group, server, kServer);
-      auto x=param->GenGetMsg(procs!=procs_id_, idx);
-      x->set_trgt(param->owner(), id+idx, param->local_version()+1);
-      x->set_src(procs_id_, gid, kStub);
-      x->set_dst(group, server, kServer);
-      //LOG(ERROR)<<"stub handle get for "<<idx+id<<","<<group<<","<<server;
-      replies.push_back(x);
-    }
-  }
-  return replies;
+  LOG(ERROR) << "Stub in process " << procs_id_ << " stops";
+  for (auto& entry : inter_dealers)
+    delete entry.second;
 }
 
-const vector<Msg*> Trainer::HandleUpdate(shared_ptr<ParamInfo>pi, Msg** msg){
-  Msg* msgg=*msg ;
-  vector<Msg*> ret;
-  int step= msgg->trgt_third();
-  if(msgg->src_flag()==kStub){
-    if(pi->num_update<pi->num_local){
-      ret.push_back(*msg);
-      return ret; //wait unitl local updates are ready
-    }
-    int n; sscanf((char*)(*msg)->frame_data(), "%d", &n);
-    pi->num_update+=n;
-    auto it=pi->shares.begin();
-    auto shape=mshadow::Shape1((*it)->size());
-    mshadow::Tensor<mshadow::cpu,1> agg((*it)->mutable_cpu_grad(), shape);
-    mshadow::Tensor<mshadow::cpu,1> grad((*it)->mutable_cpu_grad(), shape);
-    agg+=grad;
-  }else if(++pi->num_update>=pi->num_local){
-    auto it=pi->shares.begin();
-    auto shape=mshadow::Shape1((*it)->size());
-    mshadow::Tensor<mshadow::cpu,1> agg((*it)->mutable_cpu_grad(), shape);
-    for(++it;it!=pi->shares.end();it++){
-      mshadow::Tensor<mshadow::cpu,1> grad((*it)->mutable_cpu_grad(), shape);
-      agg+=grad;
-    }
-    agg/=pi->num_total;
-    if(pi->num_local<pi->num_total){
-      /*
-      int gid=msgg->src_first();
-      for(auto update: pi->shares.at(0)->GenUpdateMsg(step)){
-        update->set_src(procs_id_, gid,kStub);
-        update->set_dst(pi->owner_procs, gid, kStub);
-        ret.push_back(update);
-      }
-      pi->num_update=0;
-      */
-    }
+Msg* Trainer::GenSyncReminderMsg(int server, const vector<Server*>& servers ) {
+  Msg* msg = new Msg();
+  msg->set_src(Addr(-1,-1, kStub));
+  msg->set_dst(Addr(servers[server]->grp_id(), servers[server]->id(), kServer));
+  msg->set_type(kSyncReminder);
+  return msg;
+}
+
+void Trainer::DisplayMetric(Msg** msg) {
+  Msg* msgg = *msg;
+  // only display metrics from the first group
+  if (AddrGrp(msgg->src()) == 0) {
+    int step = msgg->trgt_version();
+    char prefix[128];
+    msgg->ParseFormatFrame("s", prefix);
+    CHECK(msgg->NextFrame());
+    const string perf(static_cast<char*>(msgg->FrameData()), msgg->FrameSize());;
+    Metric cur(perf);
+    LOG(ERROR) << prefix << " step-" << step <<", " << cur.ToLogString();
   }
-  if(pi->num_update==pi->num_total){
-    auto param=pi->shares.at(0);
-    int group=msgg->src_first()/Cluster::Get()->nworker_groups_per_server_group();
-    int srcgid=msgg->src_first();
-    for(int idx=0, id=param->slice_start(); idx<param->num_slices();idx++){
-      int server=slice2server_[idx+id];
-      int procs=Cluster::Get()->ProcsIDOf(group, server, kServer);
-      auto x=param->GenUpdateMsg(procs!=procs_id_, idx);
-      x->set_trgt(param->owner(), id+idx, step);
-      x->set_src(procs_id_, srcgid, kStub);
-      x->set_dst(group, server, kServer);
-      ret.push_back(x);
+  DeleteMsg(msg);
+}
+
+Dealer* Trainer::CreateInterProcsDealer(int dst_procs) {
+  // forward to other procs
+  auto cluster = Cluster::Get();
+  auto dealer = new Dealer();
+  while(cluster->endpoint(dst_procs)=="") {
+    //kCollectSleepTime));
+    std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+    LOG(ERROR)<<"waiting for procs "<< dst_procs<<" to register";
+  }
+  dealer->Connect("tcp://"+cluster->endpoint(dst_procs));
+  return dealer;
+}
+
+void Trainer::HandleLocalMsg(queue<Msg*>* msg_queue, Msg** msg) {
+  Msg* msgg = *msg;
+  int paramid = ParamID(msgg->trgt_val());
+  int type = msgg->type();
+  int grp;
+  ParamEntry *entry = nullptr;
+  switch (type) {  // TODO process other requests, e.g. RESTful
+    case kUpdate:
+      grp = AddrGrp(msgg->src());
+      entry = worker_shard_.at(Hash(grp, paramid));
+      for(auto update_msg : HandleUpdate(entry, msg))
+        msg_queue->push(update_msg);
+      break;
+    case kRUpdate:
+      grp = AddrGrp(msgg->dst());
+      entry = worker_shard_.at(Hash(grp, paramid));
+      HandleUpdateResponse(entry, msg);
+      break;
+    case kGet:
+      grp = AddrGrp(msgg->src());
+      entry = worker_shard_.at(Hash(grp, paramid));
+      for(auto get_msg : HandleGet(entry, msg))
+        msg_queue->push(get_msg);
+      break;
+    case kRGet:
+      grp = AddrGrp(msgg->dst());
+      entry = worker_shard_.at(Hash(grp, paramid));
+      HandleGetResponse(entry, msg);
+      break;
+    case kPut:
+      grp = AddrGrp(msgg->src());
+      entry = worker_shard_.at(Hash(grp, paramid));
+      for(auto put_msg : HandlePut(entry, msg))
+        msg_queue->push(put_msg);
+      break;
+    default:
+      LOG(ERROR)<<"Unknow message type:"<<type;
+      break;
+  }
+}
+
+void Trainer::GenMsgs(int type, int version, ParamEntry* entry,
+    Msg* msg, vector<Msg*> *ret) {
+  int src_grp = AddrGrp(msg->src());
+  int dst_grp = src_grp / Cluster::Get()->nworker_groups_per_server_group();
+  auto param=entry->shares.at(0);
+  for (int idx = 0 ; idx < param->num_slices(); idx++) {
+    int slice_id =param->slice_start() + idx;
+    int server = slice2server_[slice_id];
+    int procs = Cluster::Get()->ProcsIDOf(dst_grp, server, kServer);
+    Msg* new_msg = nullptr;
+    if (type == kPut) {
+      CHECK_GT(entry->num_total, 0);
+      new_msg = param->GenPutMsg(procs != procs_id_, idx);
+      new_msg->AddFormatFrame("i", entry->num_total);
+    } else if (type == kGet) {
+      new_msg = param->GenGetMsg(procs != procs_id_, idx);
+    } else if (type == kUpdate) {
+      new_msg = param->GenUpdateMsg(procs != procs_id_, idx);
+      new_msg->AddFormatFrame("i", entry->num_local);
+    } else {
+      LOG(FATAL) << "Wrong type";
     }
-    pi->num_update=0;
+    new_msg->set_trgt(ParamTrgt(param->owner(), slice_id), version);
+    new_msg->set_src(Addr(src_grp, procs_id_, kStub));
+    new_msg->set_dst(Addr(dst_grp, server, kServer));
+    ret->push_back(new_msg);
+  }
+}
+
+const vector<Msg*> Trainer::HandleGet(ParamEntry* entry, Msg** msg) {
+  vector<Msg*> ret;
+  int version = (*msg)->trgt_version();
+  if (version > entry->next_version) {
+    entry->next_version = version;
+    GenMsgs(kGet, version, entry, *msg, &ret);
   }
   DeleteMsg(msg);
   return ret;
 }
 
-const vector<Msg*> Trainer::HandlePut(shared_ptr<ParamInfo>pi, Msg** msg){
+const vector<Msg*> Trainer::HandleUpdate(ParamEntry *entry, Msg** msg) {
   vector<Msg*> ret;
-  CHECK_NE((*msg)->src_flag(), kStub);
-  int gid=(*msg)->src_first();
-  int version=(*msg)->trgt_third();
-  auto param=pi->shares.at(0);
-  int group=gid/Cluster::Get()->nworker_groups_per_server_group();
-  for(int idx=0, start=param->slice_start();idx<param->num_slices(); idx++){
-    int server=slice2server_[start+idx];
-    int procs=Cluster::Get()->ProcsIDOf(group, server, kServer);
-    auto x=param->GenPutMsg(procs!=procs_id_, idx);
-    x->set_trgt(param->owner(), start+idx, version);
-    x->set_src(procs_id_, gid, kStub);
-    x->set_dst(group, server, kServer);
-    ret.push_back(x);
-    //LOG(ERROR)<<"stub handle put "<<start+idx<<"to "<<group<<","<<server;
+  entry->num_update++;
+  if (entry->num_update >= entry->num_local) {
+    // average local gradient
+    if (entry->num_local > 1) {
+      auto it = entry->shares.begin();
+      auto shape=mshadow::Shape1((*it)->size());
+      mshadow::Tensor<mshadow::cpu,1> sum((*it)->mutable_cpu_grad(), shape);
+      for (++it; it != entry->shares.end(); it++) {
+        mshadow::Tensor<mshadow::cpu,1> grad((*it)->mutable_cpu_grad(), shape);
+        sum += grad;
+      }
+      sum /= entry->num_total;
+    }
+    int step = (*msg)->trgt_version();
+    GenMsgs(kUpdate, step, entry, *msg, &ret);
+    entry->num_update = 0;
   }
   DeleteMsg(msg);
   return ret;
 }
 
-void Trainer::HandleGetResponse(shared_ptr<ParamInfo>pi, Msg** msg){
-  int version=(*msg)->trgt_third();
-  int sliceid=(*msg)->trgt_second();
-  auto param=pi->shares.at(0);
-  if(param->ParseGetResponseMsg(msg,sliceid-param->slice_start()))
-    param->set_version(version);
-  // process get requests in waiting queue
+const vector<Msg*> Trainer::HandlePut(ParamEntry* entry, Msg** msg) {
+  vector<Msg*> ret;
+  int version = (*msg)->trgt_version();
+  GenMsgs(kPut, version, entry, *msg, &ret);
+  DeleteMsg(msg);
+  return ret;
 }
 
-
-void Trainer::HandleUpdateResponse(shared_ptr<ParamInfo> pi, Msg** msg){
-  int sliceid=(*msg)->trgt_second();
-  int version=(*msg)->trgt_third();
-  auto param=pi->shares.at(0);
-  if(param->ParseUpdateResponseMsg(msg,sliceid-param->slice_start())){
+void Trainer::HandleGetResponse(ParamEntry* entry, Msg** msg) {
+  int version = (*msg)->trgt_version();
+  int sliceid = SliceID((*msg)->trgt_val());
+  auto param = entry->shares.at(0);
+  if (param->ParseGetResponseMsg(*msg, sliceid-param->slice_start()))
     param->set_version(version);
-  }
+  DeleteMsg(msg);
+}
+
+void Trainer::HandleUpdateResponse(ParamEntry* entry, Msg** msg) {
+  int version = (*msg)->trgt_version();
+  int sliceid = SliceID((*msg)->trgt_val());
+  auto param = entry->shares.at(0);
+  if (param->ParseUpdateResponseMsg(*msg, sliceid-param->slice_start()))
+    param->set_version(version);
+  DeleteMsg(msg);
 }
 } /* singa */

--- a/src/trainer/trainer.cc
+++ b/src/trainer/trainer.cc
@@ -345,7 +345,7 @@ void Trainer::DisplayMetric(Msg** msg) {
     char prefix[128];
     msgg->ParseFormatFrame("s", prefix);
     CHECK(msgg->NextFrame());
-    const string perf(static_cast<char*>(msgg->FrameData()), msgg->FrameSize());;
+    const string perf(static_cast<char*>(msgg->FrameData()), msgg->FrameSize());
     Metric cur(perf);
     LOG(ERROR) << prefix << " step-" << step <<", " << cur.ToLogString();
   }

--- a/src/trainer/worker.cc
+++ b/src/trainer/worker.cc
@@ -68,8 +68,7 @@ void Worker::InitLocalParams() {
   for (auto layer : train_net_->layers()) {
     if (layer->partition_id() == id_)
       for (auto param : layer->GetParams())
-        if (param->owner() != param->id())
-          Get(param, modelproto_.warmup_steps());
+        Get(param, modelproto_.warmup_steps());
   }
 }
 
@@ -114,7 +113,7 @@ void Worker::Run() {
       Test(modelproto_.test_steps(), kTest, test_net_);
     }
     TrainOneBatch(step_, &perf);
-    //LOG(ERROR)<<"Train "<<step;
+    // LOG(ERROR) << "Train " << step_;
     if (DisplayNow(step_)) {
       Report("Train", perf);
       perf.Reset();

--- a/src/utils/cluster.cc
+++ b/src/utils/cluster.cc
@@ -56,13 +56,14 @@ Cluster::Cluster(const GlobalProto & global, const ClusterProto &cluster,
   hostip_=GetHostIP();
 }
 
-void Cluster::Register(const string& endpoint){
+void Cluster::Register(const string& endpoint) {
   procs_id_=cluster_rt_->RegistProc(endpoint);
   CHECK_GE(procs_id_,0);
   CHECK_LT(procs_id_,nprocs());
   LOG(ERROR) << "proc #" << procs_id_ << " -> " << endpoint;
 }
-const string Cluster::endpoint(int procsid) const{
+
+const string Cluster::endpoint(int procsid) const {
   CHECK_LT(procsid, nprocs());
   CHECK_GE(procsid, 0);
   if(endpoints_.size())
@@ -70,6 +71,7 @@ const string Cluster::endpoint(int procsid) const{
   else
     return cluster_rt_->GetProcHost(procsid);
 }
+
 void Cluster::SetupFolders(const ClusterProto &cluster){
   // create visulization folder
   mkdir(vis_folder().c_str(),  S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);

--- a/src/utils/param.cc
+++ b/src/utils/param.cc
@@ -11,8 +11,8 @@ using std::vector;
 using std::string;
 namespace singa {
 
-Param::Param():data_(nullptr), slice_start_(0), num_slices_(0),
-  num_pending_requests_(0),local_version_(-1){
+Param::Param():local_version_(-1), slice_start_(0), num_slices_(0),
+  num_pending_requests_(0), data_(nullptr) {
 }
 void Param::Setup(const ParamProto& proto, const vector<int>& shape){
   data_=std::make_shared<Blob<float>>(shape);
@@ -82,96 +82,87 @@ void Param::InitValues(int version){
 }
 
 /**************Message related functions********/
-Msg* Param::GenPutMsg(bool copy, int idx){
+Msg* Param::GenPutMsg(bool copy, int idx) {
   CHECK_LT(idx, num_slices_);
   Msg* msg=new Msg();
   msg->set_type(kPut);
-  char buf[128];
-  sprintf(buf, "%d %f %f", slice_size_[idx],
-      learning_rate_multiplier(), weight_decay_multiplier());
   void *ptr=mutable_cpu_data()+slice_offset_[idx];
-  if(copy){
-    sprintf(buf+strlen(buf), " %p ", nullptr);
-    msg->add_frame(buf, strlen(buf));
-    msg->add_frame(ptr, slice_size_[idx]*sizeof(float));
-  }else{
-    sprintf(buf+strlen(buf), " %p ", ptr);
-    msg->add_frame(buf, strlen(buf));
+  void *p = ptr;
+  if (copy) p = nullptr;
+  msg->AddFormatFrame("iffp", slice_size_[idx],
+      learning_rate_multiplier(), weight_decay_multiplier(), p);
+  if (copy) {
+    msg->AddFrame(ptr, slice_size_[idx]*sizeof(float));
   }
   //pending_put_[idx]=true;
   //num_pending_requests_++;
 	return msg;
 }
 
-Msg* Param::GenGetMsg(bool copy, int idx){
+Msg* Param::GenGetMsg(bool copy, int idx) {
   CHECK_LT(idx, num_slices_);
   Msg* msg=new Msg();
   msg->set_type(kGet);
-  char buf[32]; sprintf(buf, " %d %p ", copy,
-      data_->cpu_data()+slice_offset_[idx]);
-  msg->add_frame(buf, sizeof(buf));
+  msg->AddFormatFrame("ip",  copy, data_->cpu_data()+slice_offset_[idx]);
   pending_get_[idx]=true;
   num_pending_requests_++;
   return msg;
 }
 
-Msg* Param::GenUpdateMsg(bool copy, int idx){
+Msg* Param::GenUpdateMsg(bool copy, int idx) {
   CHECK_LT(idx, num_slices_);
   Msg* msg=new Msg();
   msg->set_type(kUpdate);
-  char buf[8]; sprintf(buf, " %d ", copy);
-  msg->add_frame(buf, sizeof(buf));
+  msg->AddFormatFrame("i", copy);
   void* ptr=grad_.mutable_cpu_data()+slice_offset_[idx];
   if(copy){
     //LOG(ERROR)<<"Copy in gen update";
-    msg->add_frame(ptr, slice_size_[idx]*sizeof(float));
-  }
-  else{ // to share values of grad blob
-    char buf[32]; sprintf(buf, " %p ", ptr);
-    msg->add_frame(buf, strlen(buf));
+    msg->AddFrame(ptr, slice_size_[idx]*sizeof(float));
+  } else { // to share values of grad blob
+    msg->AddFormatFrame("p", ptr);
   }
   pending_update_[idx]=true;
   num_pending_requests_++;
   return msg;
 }
 
-Msg* Param::GenSyncMsg(int offset, int size){
+Msg* Param::GenSyncMsg(int offset, int size) {
   Msg* msg=new Msg();
   msg->set_type(kSyncRequest);
-  msg->set_trgt(-1, id(), local_version());
-  msg->add_frame(mutable_cpu_data(), data_->count()*sizeof(float));
+  msg->set_trgt(ParamTrgt(-1, id()), local_version());
+  // always copy data because syn is between server groups in diff procs
+  msg->AddFrame(mutable_cpu_data(), data_->count()*sizeof(float));
   return msg;
 }
 
-Msg* Param::HandlePutMsg(Msg** msg){
+Msg* Param::HandlePutMsg(Msg** msg, bool reserve) {
   int size;
   float lr, wc;
   float* ptr;
-  sscanf(static_cast<char*>((*msg)->frame_data()),
-      "%d %f %f %p ", &size, &lr, &wc, &ptr);
+  (*msg)->ParseFormatFrame("iffp", &size, &lr, &wc, &ptr);
   proto_.set_learning_rate_multiplier(lr);
   proto_.set_weight_decay_multiplier(wc);
   vector<int> shape{size};
   ParamProto proto;
   Setup(proto, shape);
-  if(ptr==nullptr){
-    CHECK((*msg)->next_frame());
-    CHECK_EQ(size* sizeof(float), (*msg)->frame_size());
-    memcpy(mutable_cpu_data(), (*msg)->frame_data(), size*sizeof(float));
+  if (ptr == nullptr) {
+    CHECK((*msg)->NextFrame());
+    CHECK_EQ(size* sizeof(float), (*msg)->FrameSize());
+    memcpy(mutable_cpu_data(), (*msg)->FrameData(), size*sizeof(float));
   }else{
     data_->set_cpu_data(ptr);
   }
-  DeleteMsg(msg);
+  if (!reserve)
+    DeleteMsg(msg);
   return nullptr;
 }
 
-Msg* Param::HandleGetMsg(Msg** msg){
+Msg* Param::HandleGetMsg(Msg** msg, bool reserve) {
   int copy;
   float* ptr;
-  sscanf(static_cast<char*>((*msg)->frame_data()), " %d %p ", &copy, &ptr);
-  (*msg)->next_frame();
+  (*msg)->ParseFormatFrame("ip", &copy, &ptr);
   if(copy)
-    (*msg)->add_frame(mutable_cpu_data(), sizeof(float)*size());
+    (*msg)->AddFrame(mutable_cpu_data(), sizeof(float)*size());
   else if(ptr!=data_->cpu_data()){
     memcpy(ptr, data_->cpu_data(), sizeof(float)*size());
     data_->set_cpu_data(ptr);
@@ -182,73 +173,127 @@ Msg* Param::HandleGetMsg(Msg** msg){
   return *msg;
 }
 
-int Param::ParseUpdateMsg(Msg** msg){
-  int copy;
-  sscanf(static_cast<char*>((*msg)->frame_data()), " %d ", &copy);
-  (*msg)->next_frame();
-  if(copy){
-    //LOG(ERROR)<<"Copy in parse update";
-    CHECK((*msg)->frame_size());
-    memcpy(mutable_cpu_grad(), (*msg)->frame_data(),(*msg)->frame_size());
-  }else {// use the same data field of the grad blob
-    float* ptr=nullptr;
-    sscanf(static_cast<char*>((*msg)->frame_data()), " %p ", &ptr);
-    grad_.set_cpu_data(ptr);
+void Param::ParseUpdateMsgs(const vector<Msg*>& msgs) {
+  bool reset = true;
+  vector<int> copies;
+  for (auto *msg : msgs) {
+    int copy;
+    msg->ParseFormatFrame("i", &copy);
+    reset = reset && copy;
+    copies.push_back(copy);
   }
-  DeleteMsg(msg);
-  return copy;
+  int idx = 0;
+  for (auto *msg : msgs) {
+    CHECK(msg->NextFrame());
+    if (copies.at(idx++)) {
+      float* server_grad = mutable_cpu_grad();
+      float* worker_grad = static_cast<float*> (msg->FrameData());
+      if (reset) {
+        memcpy(server_grad, worker_grad, sizeof(float) * size());
+        reset = false;
+      } else {
+        for (int i =0; i < size(); i++)
+          server_grad[i] += worker_grad[i];
+      }
+    } else {
+      float* ptr = nullptr;
+      msg->ParseFormatFrame("p", &ptr);
+      if (grad_.cpu_data() != ptr) {
+        memcpy(ptr, grad_.cpu_data(), msg->FrameSize());
+        grad_.set_cpu_data(ptr);
+      }
+    }
+  }
+
+  if (msgs.size() > 1) {
+    float* server_grad = mutable_cpu_grad();
+    for (int i = 0; i < size(); i++)
+      server_grad[i] /= msgs.size();
+  }
 }
 
-Msg* Param::GenUpdateResponseMsg(bool copy){
-  Msg* msg=new Msg();
-  msg->set_type(kRUpdate);
-  char buf[8]; sprintf(buf, " %d ", copy);
-  msg->add_frame(buf, sizeof(buf));
-  if(copy){
-    //LOG(ERROR)<<"Copy in gen";
-  //  LOG(ERROR)<<"gen copy resonse for "<<id()<<", "<<size();
-    msg->add_frame(mutable_cpu_data(), size()*sizeof(float));
+const vector<Msg*> Param::GenUpdateResponseMsgs(const vector<Msg*>& msgs) {
+  vector<Msg*> ret;
+  for (auto msg : msgs) {
+    msg->FirstFrame();
+    msg->SwapAddr();
+    msg->set_type(kRUpdate);
+    int copy;
+    msg->ParseFormatFrame("i", &copy);
+    if (copy) {
+      msg->NextFrame();
+      CHECK_EQ(msg->FrameSize(), sizeof(float) * size());
+      memcpy(msg->FrameData(), mutable_cpu_data(), msg->FrameSize());
+    }
+    ret.push_back(msg);
   }
-  //  LOG(ERROR)<<"gen share resonse for "<<id()<<", "<<size();
-
-  return msg;
+  return ret;
 }
 
-Msg* Param::HandleSyncMsg(Msg** msg){
-  DeleteMsg(msg);
+Msg* Param::HandleSyncMsg(Msg** msg, bool reserve) {
+  if (!reserve)
+    DeleteMsg(msg);
   return nullptr;
 }
 
-int Param::ParseSyncResponseMsg(Msg** msg, int slice_idx){
-  DeleteMsg(msg);
+int Param::ParseSyncResponseMsg(Msg* msg, int slice_idx) {
   return 1;
 }
 
-int Param::ParseGetResponseMsg(Msg **msg, int slice_idx){
+int Param::ParseGetResponseMsg(Msg *msg, int slice_idx) {
   CHECK_EQ(pending_get_[slice_idx], true);
   pending_get_[slice_idx]=false;
   ParseResponseMsg(msg, slice_idx);
   return (--num_pending_requests_)%num_slices_==0;
 }
 
-int Param::ParseUpdateResponseMsg(Msg **msg, int slice_idx){
+int Param::ParseUpdateResponseMsg(Msg *msg, int slice_idx) {
   CHECK_EQ(pending_update_[slice_idx], true);
   pending_update_[slice_idx]=false;
   ParseResponseMsg(msg, slice_idx);
-  return (--num_pending_requests_)%num_slices_==0;
+  return (--num_pending_requests_) % num_slices_==0;
 }
 
-void Param::ParseResponseMsg(Msg** msg, int slice_idx){
+void Param::ParseResponseMsg(Msg* msg, int slice_idx) {
   int copy;
-  sscanf(static_cast<char*>((*msg)->frame_data()), " %d ", &copy);
-  (*msg)->next_frame();
-  if(copy){
-        CHECK_EQ((*msg)->frame_size(), slice_size_[slice_idx]*sizeof(float));
+  msg->ParseFormatFrame("i", &copy);
+  msg->NextFrame();
+  if(copy) {
+    CHECK_EQ(msg->FrameSize(), slice_size_[slice_idx]*sizeof(float));
     memcpy(mutable_cpu_data()+slice_offset_[slice_idx],
-        (*msg)->frame_data(), (*msg)->frame_size());
+        msg->FrameData(), msg->FrameSize());
   }
   //LOG(ERROR)<<"parse response norm "<<data_->asum_data()<<" of "<<id();
-  DeleteMsg(msg);
+}
+
+void Param::ShareFrom(const Param& other) {
+  proto_.set_owner(other.owner());
+  if(data_!=nullptr)
+    CHECK(std::equal(data_->shape().begin(), data_->shape().end(),
+          other.data_->shape().begin()));
+  data_ = other.data_;
+  slice_offset_ = other.slice_offset_;
+  slice_size_ = other.slice_size_;
+  slice_start_ = other.slice_start_;
+  num_slices_ = other.num_slices_;
+  pending_get_ = other.pending_get_;
+  pending_put_ = other.pending_put_;
+  pending_update_ = other.pending_update_;
+}
+
+/************************ParamEntry***************************/
+ParamEntry::ParamEntry():
+  num_update(0), next_version(-1), num_local(0), num_total(0) {
+}
+
+ParamEntry::ParamEntry(int total, Param* p) : num_update(0), num_total(total) {
+  shares.push_back(p);
+}
+void ParamEntry::AddParam(bool local, Param* p) {
+  num_local += local;
+  num_total += 1;
+  if(local)
+    shares.push_back(p);
 }
 }
 


### PR DESCRIPTION
For the synchronous training frameworks, one worker group and one server group are launched.
Gradients for the same Param are aggregated locally at each process's stub.    The server conducts update until receive all gradients for the same Param (slice). After udpate, the server sends back new Param (slice) values to every process who has sent update request.    The worker_shard_ and server_shard consist of ParamEntrys, each of which stores the information of one unique Param (slice), e.g.,    the number of shares of each Param (slice), and the local shares for each Param (slice).
    
The Msg class is improved to have clean/simple API. The msg header now includes a src (int), a dst (int) and a trgt (int value and int version),    representing the source addr, destination addr and target of the msg. The address is constructed by the entity who creates the msg. Any addr is valid as long as it is unique for one entity.    Function Addr(int grp, int id_or_proc, int type) is provided to construct the addr using   group ID, worker/server ID (or procs ID) and entity type (kServer, kStub, etc.). Functions are also provided to extract    the group, worker/server ID from the addr (int). Similarly, the target field can be constructed using ParamTrgt function    which wraps the Param ID and Slice ID into a target value (int). ParamID() and SliceID() are to extract the info from target value.
