### PR TITLE
SINGA-38 Support concurrent jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@
 *.pb.h
 *.pb.cc
 *.hosts
+*.id
+*.tmp
 *.out
 tool/pb2/*
 src/test/data/*

--- a/bin/singa-env.sh
+++ b/bin/singa-env.sh
@@ -19,42 +19,39 @@
 # * See the License for the specific language governing permissions and
 # * limitations under the License.
 # */
-# 
-# clean up singa processes and zookeeper metadata
+#
+# set Singa environment variables, includes:
+#   * SINGA_HOME
+#   * SINGA_BIN
+#   * SINGA_CONF
+#   * ZK_HOME
+#   * SINGA_MANAGES_ZK
 #
 
-# usage="Usage: \n \
-#       (local process): singa-stop.sh \n \
-#       (distributed): singa-stop.sh HOST_FILE"
-# 
-# if [ $# -gt 1 ]; then
-#   echo -e $usage
-#   exit 1
-# fi
+# set SINGA_BIN
+if [ -z $SINGA_BIN ]; then
+  SINGA_BIN=`dirname "${BASH_SOURCE-$0}"`
+  SINGA_BIN=`cd "$SINGA_BIN">/dev/null; pwd`
+fi
 
-# get environment variables
-. `dirname "${BASH_SOURCE-$0}"`/singa-env.sh
+# set SINGA_HOME
+if [ -z $SINGA_HOME ]; then
+  SINGA_HOME=`cd "$SINGA_BIN/..">/dev/null; pwd`
+fi
 
-# kill singa processes
-host_file=$SINGA_CONF/hostfile
-ssh_options="-oStrictHostKeyChecking=no \
-             -oUserKnownHostsFile=/dev/null \
-             -oLogLevel=quiet"
-hosts=`cat $host_file |cut -d ' ' -f 1`
-singa_kill="killall -s SIGKILL -r singa"
-for i in ${hosts[@]}; do
-  echo kill singa @ $i ...
-  if [ $i == localhost ]; then
-    $singa_kill
-  else
-    ssh $ssh_options $i $singa_kill
-  fi
-done
-# wait for killall command
-sleep 2
+# set SINGA_CONF
+if [ -z $SINGA_CONF ]; then
+  SINGA_CONF=$SINGA_HOME/conf
+fi
 
-# remove zk data
-# singatool need global conf under SINGA_HOME
-echo cleanning metadata in zookeeper ...
-cd $SINGA_HOME
-./singatool || exit 1
+# set ZK_HOME
+if [ -z $ZK_HOME ]; then
+  ZK_HOME=$SINGA_HOME/thirdparty/zookeeper-3.4.6
+  SINGA_MANAGES_ZK=true
+fi
+
+# set SINGA_MANAGES_ZK
+if [ -z $SINGA_MANAGES_ZK ]; then
+  SINGA_MANAGES_ZK=false
+fi
+

--- a/bin/zk-service.sh
+++ b/bin/zk-service.sh
@@ -20,59 +20,55 @@
 # * limitations under the License.
 # */
 # 
-# Manage a zookeeper service
+# manage ZooKeeper service
 #
 
 usage="Usage: zk-service.sh [start|stop]"
 
-if [ $# -le 0 ]; then
+if [ $# != 1 ]; then
   echo $usage
   exit 1
 fi
 
-BIN=`dirname "${BASH_SOURCE-$0}"`
-BIN=`cd "$BIN">/dev/null; pwd`
-BASE=`cd "$BIN/..">/dev/null; pwd`
-ZKBASE=$BASE/thirdparty/zookeeper-3.4.6
+# get environment variables
+. `dirname "${BASH_SOURCE-$0}"`/singa-env.sh
 
-if [ -z $SINGA_MANAGES_ZK ]; then
-  SINGA_MANAGES_ZK=true
+# check if singa manages zookeeper service
+if [ $SINGA_MANAGES_ZK != true ]; then
+  echo "Singa does not manage a valid zookeeper service (SINGA_MANAGES_ZK != true)"
+  exit 1
 fi
 
-if [ $SINGA_MANAGES_ZK = true ]; then
-  # check zookeeper installation
-  if [ ! -d $ZKBASE ]; then
-    echo "zookeeper not found, please install zookeeper first:"
-    echo "$./SINGA_BASE/thirdparty/install.sh zookeeper"
-    exit 1
-  fi
+# check zookeeper installation
+if [ ! -d $ZK_HOME ]; then
+  echo "zookeeper not found at $ZK_HOME"
+  echo "if you do not have zookeeper service, please install:"
+  echo "    $SINGA_HOME/thirdparty/install.sh zookeeper"
+  echo "otherwise, please set ZK_HOME correctly"
+  exit 1
 fi
 
-# get argument
-cmd=$1
-
-case $cmd in
-
-(start)
-  # start zk service
-  if [ $SINGA_MANAGES_ZK = true ]; then
-    # check zoo,cfg
-    if [ ! -f $ZKBASE/conf/zoo.cfg ]; then
+# get command
+case $1 in
+  start)
+    # start zk service
+    # check zoo.cfg
+    if [ ! -f $ZK_HOME/conf/zoo.cfg ]; then
       echo "zoo.cfg not found, create from sample.cfg"
-      cp $ZKBASE/conf/zoo_sample.cfg $ZKBASE/conf/zoo.cfg
+      cp $ZK_HOME/conf/zoo_sample.cfg $ZK_HOME/conf/zoo.cfg
     fi
-    # echo 'starting zookeeper service...'
-    $ZKBASE/bin/zkServer.sh start
-  fi
-  ;;
+    # cd to SINGA_HOME as zookeeper.out will be here
+    cd $SINGA_HOME
+    $ZK_HOME/bin/zkServer.sh start 2>/dev/null
+    ;;
 
-(stop)
-  # stop zk service
-  if [ $SINGA_MANAGES_ZK = true ]; then
-    # echo 'stopping zookeeper service...'
-    $ZKBASE/bin/zkServer.sh stop
-  fi
-  ;;
-
+  stop)
+    # stop zk service
+    $ZK_HOME/bin/zkServer.sh stop 2>/dev/null
+    ;;
+  
+  *)
+    echo $usage
+    exit 1
 esac
 

--- a/include/trainer/trainer.h
+++ b/include/trainer/trainer.h
@@ -34,8 +34,8 @@ class Trainer{
    * @param globalconf global singa configuration
    * @param cconf cluster configuration
    */
-  void Start(bool resume, int job, ModelProto& mconf,
-    const GlobalProto& gconf, const ClusterProto& cconf);
+  void Start(ModelProto& mconf, const GlobalProto& gconf,
+             const ClusterProto& cconf, int job, bool resume);
 
  protected:
   /**

--- a/include/utils/cluster.h
+++ b/include/utils/cluster.h
@@ -24,8 +24,8 @@ namespace singa {
 class Cluster {
  public:
   static shared_ptr<Cluster> Get();
-  static shared_ptr<Cluster> Get(const GlobalProto& global,
-                                 const ClusterProto& cluster, int procs_id=0);
+  static shared_ptr<Cluster> Get(const GlobalProto& global, 
+                                 const ClusterProto& cluster, int job_id);
 
   const int nserver_groups()const{ return cluster_.nserver_groups(); }
   const int nworker_groups()const { return cluster_.nworker_groups(); }
@@ -125,10 +125,10 @@ class Cluster {
   const string hostip() const {
     return hostip_;
   }
-  void Register(const string& endpoint);
+  void Register(const string& endpoint, int pid);
 
  private:
-  Cluster(const GlobalProto& global, const ClusterProto &cluster, int procs_id) ;
+  Cluster(const GlobalProto& global, const ClusterProto &cluster, int job_id);
   void SetupFolders(const ClusterProto &cluster);
   int Hash(int gid, int id, int flag);
 

--- a/include/utils/cluster_rt.h
+++ b/include/utils/cluster_rt.h
@@ -63,7 +63,7 @@ const std::string kZKPathJobPLock = "/proc-lock";
 
 inline std::string GetZKJobWorkspace(int job_id) {
   char buf[kZKBufSize];
-  sprintf(buf, "%010d", job_id);
+  snprintf(buf, kZKBufSize, "%010d", job_id);
   return kZKPathJob + buf;
 }
 
@@ -122,14 +122,14 @@ class ZKClusterRT : public ClusterRuntime {
   inline std::string workerPath(int gid, int wid) {
     return "/g" + std::to_string(gid) + "_w" + std::to_string(wid);
   }
-  
+
   int timeout_ = 30000;
   std::string host_ = "";
   ZKService zk_;
   std::string workspace_ = "";
   std::string group_path_ = "";
   std::string proc_path_ = "";
-  std::string proc_lock_path_ = ""; 
+  std::string proc_lock_path_ = "";
   std::vector<RTCallback*> cb_vec_;
 };
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -18,10 +18,9 @@
  * easily, e.g., AddLayer(layer_type, source_layers, meta_data).
  */
 
-// Job ID is not used now, TODO passing job id from singa-run script and
-// re-organize ClusterProto, GlobalProto and ModelProto.
-DEFINE_int32(job, -1, "Job ID");  // not used now
-DEFINE_bool(resume, false, "resume from checkpoint");
+// TODO: re-organize ClusterProto, GlobalProto and ModelProto.
+DEFINE_int32(job, -1, "Unique job ID");
+DEFINE_bool(resume, false, "Resume from checkpoint");
 DEFINE_string(cluster, "examples/mnist/cluster.conf", "Cluster config file");
 DEFINE_string(model, "examples/mnist/conv.conf", "Model config file");
 DEFINE_string(global, "conf/singa.conf", "Global config file");
@@ -54,6 +53,6 @@ int main(int argc, char **argv) {
 
   RegisterClasses(model);
   singa::Trainer trainer;
-  trainer.Start(FLAGS_resume, FLAGS_job, model, global, cluster);
+  trainer.Start(model, global, cluster, FLAGS_job, FLAGS_resume);
   return 0;
 }

--- a/src/trainer/worker.cc
+++ b/src/trainer/worker.cc
@@ -183,7 +183,7 @@ void Worker::Run() {
   msg->set_type(kStop);
   dealer_->Send(&msg);  // use param dealer to send the stop msg
 
-  LOG(ERROR) << "Worker (group = " <<grp_id_ << ", id = " << id_ << ") stop";
+  LOG(ERROR) << "Worker (group = " <<grp_id_ << ", id = " << id_ << ") stops";
 }
 
 

--- a/src/utils/cluster_rt.cc
+++ b/src/utils/cluster_rt.cc
@@ -167,7 +167,8 @@ void ZKService::WatcherGlobal(zhandle_t * zh, int type, int state,
   }
 }
 
-ZKClusterRT::ZKClusterRT(const string& host, int job_id) : ZKClusterRT(host, job_id, 30000) {}
+ZKClusterRT::ZKClusterRT(const string& host, int job_id)
+    : ZKClusterRT(host, job_id, 30000) {}
 
 ZKClusterRT::ZKClusterRT(const string& host, int job_id, int timeout) {
   host_ = host;
@@ -321,16 +322,15 @@ bool JobManager::ListJobProcs(int job, vector<string>* procs) {
     return false;
   }
   char buf[singa::kZKBufSize];
-  for (string pname : vt){
+  for (string pname : vt) {
     pname = proc_path + "/" + pname;
     if (!zk_.GetNode(pname.c_str(), buf)) continue;
     std::string proc = "";
     for (int i = 0; buf[i] != '\0'; ++i) {
       if (buf[i] == ':') {
         buf[i] = '\0';
-        proc += buf; 
-      }
-      else if (buf[i] == '|') {
+        proc += buf;
+      } else if (buf[i] == '|') {
         proc += buf + i;
       }
     }
@@ -358,7 +358,7 @@ bool JobManager::ListJobs(vector<JobInfo>* jobs) {
     job.id = atoi(jid.c_str());
     job.procs = procs.size();
     jobs->push_back(job);
-    //may need to delete it
+    // may need to delete it
     if (!job.procs && (i + kJobsNotRemoved < size))
         CleanPath(kZKPathApp + "/" + vt[i], true);
   }

--- a/src/utils/cluster_rt.cc
+++ b/src/utils/cluster_rt.cc
@@ -106,7 +106,7 @@ bool ZKService::Exist(const char* path) {
   int ret = zoo_exists(zkhandle_, path, 0, &stat);
   if (ret == ZOK) return true;
   else if (ret == ZNONODE) return false;
-  LOG(ERROR) << "Unhandled ZK error code: " << ret << " (zoo_exists)";
+  //LOG(ERROR) << "Unhandled ZK error code: " << ret << " (zoo_exists)";
   return false;
 }
 

--- a/src/utils/tool.cc
+++ b/src/utils/tool.cc
@@ -33,12 +33,11 @@ int main(int argc, char **argv) {
     LOG(ERROR) << usage;
     return 1;
   }
-  if (!mng.Init()) return 1; 
+  if (!mng.Init()) return 1;
   if (!strcmp(argv[1], "create")) {
     int id = mng.GenerateJobID();
     printf("%d\n", id);
-  }
-  else if (!strcmp(argv[1], "list")) {
+  } else if (!strcmp(argv[1], "list")) {
     std::vector<singa::JobInfo> jobs;
     if (!mng.ListJobs(&jobs)) return 1;
     printf("JOB ID    |NUM PROCS  \n");
@@ -47,8 +46,7 @@ int main(int argc, char **argv) {
       if (!job.procs) continue;
       printf("job-%-6d|%-10d\n", job.id, job.procs);
     }
-  }
-  else if (!strcmp(argv[1], "listall")) {
+  } else if (!strcmp(argv[1], "listall")) {
     std::vector<singa::JobInfo> jobs;
     if (!mng.ListJobs(&jobs)) return 1;
     printf("JOB ID    |NUM PROCS  \n");
@@ -56,8 +54,7 @@ int main(int argc, char **argv) {
     for (singa::JobInfo job : jobs) {
       printf("job-%-6d|%-10d\n", job.id, job.procs);
     }
-  }
-  else if (!strcmp(argv[1], "view")) {
+  } else if (!strcmp(argv[1], "view")) {
     if (argc <= 2) {
       LOG(ERROR) << usage;
       return 1;
@@ -68,22 +65,19 @@ int main(int argc, char **argv) {
     for (std::string s : procs) {
       printf("%s\n", s.c_str());
     }
-  }
-  else if (!strcmp(argv[1], "clean")) {
+  } else if (!strcmp(argv[1], "clean")) {
     if (argc <= 2) {
       LOG(ERROR) << usage;
       return 1;
     }
     int id = atoi(argv[2]);
     if (!mng.Clean(id)) return 1;
-  }
-  else if (!strcmp(argv[1], "cleanup")) {
+  } else if (!strcmp(argv[1], "cleanup")) {
     if (!mng.Cleanup()) return 1;
-  }
-  else{
+  } else {
     LOG(ERROR) << usage;
     return 1;
   }
-  
+
   return 0;
 }

--- a/src/utils/tool.cc
+++ b/src/utils/tool.cc
@@ -1,5 +1,7 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
+#include <iostream>
+#include <fstream>
 #include "proto/cluster.pb.h"
 #include "utils/cluster_rt.h"
 #include "utils/common.h"
@@ -20,9 +22,68 @@ int main(int argc, char **argv) {
   LOG(INFO) << "The global config is \n" << global.DebugString();
 
   singa::JobManager mng(global.zookeeper_host());
-  int ret = 0;
-  if (!mng.Init()) ret = 1;
-  if (!mng.Clean()) ret = 1;
-  if (ret) LOG(ERROR) << "errors in SingaTool!";
-  return ret;
+  std::string usage = "singatool usage:\n"
+      "./singatool create       :  generate a unique job id\n"
+      "./singatool list         :  list running singa jobs\n"
+      "./singatool view JOB_ID  :  view procs of a singa job\n"
+      "./singatool clean JOB_ID :  clean a job path in zookeeper\n"
+      "./singatool cleanup      :  clean all singa data in zookeeper\n"
+      "./singatool listall      :  list all singa jobs\n";
+  if (argc <= 1) {
+    LOG(ERROR) << usage;
+    return 1;
+  }
+  if (!mng.Init()) return 1; 
+  if (!strcmp(argv[1], "create")) {
+    int id = mng.GenerateJobID();
+    printf("%d\n", id);
+  }
+  else if (!strcmp(argv[1], "list")) {
+    std::vector<singa::JobInfo> jobs;
+    if (!mng.ListJobs(&jobs)) return 1;
+    printf("JOB ID    |NUM PROCS  \n");
+    printf("----------|-----------\n");
+    for (singa::JobInfo job : jobs) {
+      if (!job.procs) continue;
+      printf("job-%-6d|%-10d\n", job.id, job.procs);
+    }
+  }
+  else if (!strcmp(argv[1], "listall")) {
+    std::vector<singa::JobInfo> jobs;
+    if (!mng.ListJobs(&jobs)) return 1;
+    printf("JOB ID    |NUM PROCS  \n");
+    printf("----------|-----------\n");
+    for (singa::JobInfo job : jobs) {
+      printf("job-%-6d|%-10d\n", job.id, job.procs);
+    }
+  }
+  else if (!strcmp(argv[1], "view")) {
+    if (argc <= 2) {
+      LOG(ERROR) << usage;
+      return 1;
+    }
+    int id = atoi(argv[2]);
+    std::vector<std::string> procs;
+    if (!mng.ListJobProcs(id, &procs)) return 1;
+    for (std::string s : procs) {
+      printf("%s\n", s.c_str());
+    }
+  }
+  else if (!strcmp(argv[1], "clean")) {
+    if (argc <= 2) {
+      LOG(ERROR) << usage;
+      return 1;
+    }
+    int id = atoi(argv[2]);
+    if (!mng.Clean(id)) return 1;
+  }
+  else if (!strcmp(argv[1], "cleanup")) {
+    if (!mng.Cleanup()) return 1;
+  }
+  else{
+    LOG(ERROR) << usage;
+    return 1;
+  }
+  
+  return 0;
 }

--- a/tool/gen_hosts.py
+++ b/tool/gen_hosts.py
@@ -9,8 +9,8 @@ from pb2.cluster_pb2 import ClusterProto
 # parse command line
 parser = argparse.ArgumentParser(description='Generate host list from host file for a SINGA job')
 parser.add_argument('-conf', dest='conf', metavar='CONF_FILE', required=True, help='cluster.conf file')
-parser.add_argument('-src', dest='src', metavar='SRC_FILE', required=True, help='global host file')
-parser.add_argument('-dst', dest='dst', metavar='DST_FILE', required=True, help='generated list')
+parser.add_argument('-hosts', dest='hosts', metavar='HOST_FILE', required=True, help='global host file')
+parser.add_argument('-output', dest='output', metavar='OUTPUT_FILE', required=True, help='generated list')
 args = parser.parse_args();
 
 # read from .conf file
@@ -27,21 +27,22 @@ else:
 fd_conf.close()
 
 # read from source host file
-fd_src = open(args.src, 'r')
+fd_hosts = open(args.hosts, 'r')
 hosts = []
-for line in fd_src:
+for line in fd_hosts:
   line = line.strip()
   if len(line) == 0 or line[0] == '#':
     continue
   hosts.append(line)
-fd_src.close()
+fd_hosts.close()
 
-# write to dst file
+# write to output file
 num_hosts = len(hosts)
 if (num_hosts == 0):
-  print 'ERROR: source host file is empty'
-  sys.exit()
-fd_dst = open(args.dst, 'w')
+  print "contains no valid host %s" % args.hosts
+  sys.exit(1)
+fd_output = open(args.output, 'w')
 for i in range(nprocs):
-  fd_dst.write(hosts[i % num_hosts] + '\n')
-fd_dst.close()
+  fd_output.write(hosts[i % num_hosts] + '\n')
+fd_output.close()
+print 'generate host list at %s' % args.output


### PR DESCRIPTION
After supporting concurrent jobs, SINGA could be used in following ways:

1. Quick Run
  This is for whose who just want to test singa or run a single job.
  * start a singa job
    $./bin/singa-run.sh -conf=CONF_DIR
  * stop singa
    $./bin/singa-stop.sh
  * remove all singa-related data
    $./bin/singa-cleanup.sh

2. Multi-Job Management
  This is for whose who want to manage multiple jobs in a cluster.
  In this case you should first:
    - edit host file in conf/hostfile
    - edit zookeeper host in conf/singa.conf
    - make your ssh command password-free
  * start a singa job
    $./bin/singa-run.sh -conf=CONF_DIR
  * list/view/kill singa jobs
    $./bin/singa-console.sh list
    $./bin/singa-console.sh view JOB_ID
    $./bin/singa-console.sh kill JOB_ID
  * stop entire singa
    $./bin/singa-stop.sh
  * remove all singa-related data
    $./bin/singa-cleanup.sh

3. Zookeeper Management
  If you do not have a zookeeper, please install via thirdparty/install.sh
  If you want to manage zookeeper externally, please ensure it is running, and
    $export ZK_HOME=your_zookeeper_path
    $export SINGA_MANAGES_ZK=false