### PR TITLE
SINGA-9 Add Support for Restricted Boltzman Machine (RBM) model

### DIFF
--- a/include/neuralnet/base_layer.h
+++ b/include/neuralnet/base_layer.h
@@ -56,8 +56,8 @@ class Layer {
    *
    * @param phase kTrain, kTest, kPositive, etc.
    */
+  virtual void ComputeLoss(Metric* perf) {}
   virtual void ComputeGradient(Phase phase) = 0;
-
   /**
    * For print debug info about each layer, e.g., norm of feature vector,
    * norm of parameters.
@@ -140,10 +140,10 @@ class Layer {
   /**
    * @return a const ref for Blob storing neuron values of this layer for BP
    */
-  virtual const Blob<float>& data(const Layer* from) const {
+  virtual const Blob<float>& data(const Layer* from, Phase = kPositive) const {
     return data_;
   }
-  virtual Blob<float>* mutable_data(const Layer* from) {
+  virtual Blob<float>* mutable_data(const Layer* from, Phase = kPositive) {
     return &data_;
   }
 
@@ -207,6 +207,12 @@ class Layer {
   virtual bool is_bridgelayer() const {
     return false;
   }
+  virtual bool is_vislayer() const {
+    return false;
+  }
+  virtual bool is_hidlayer() const {
+    return false;
+  }
 
  protected:
   LayerProto layer_proto_;
@@ -244,10 +250,10 @@ class BridgeSrcLayer: public BridgeLayer {
     ready_ = false;
   }
 
-  const Blob<float>& data(const Layer* from) const override {
+  const Blob<float>& data(const Layer* from, Phase phase) const override {
     return srclayers_[0]->data(this);
   }
-  Blob<float>* mutable_data(const Layer* from) override {
+  Blob<float>* mutable_data(const Layer* from, Phase phase) override {
     return srclayers_[0]->mutable_data(this);
   }
   const Blob<float>& grad(const Layer* from) const override {
@@ -308,7 +314,7 @@ class DataLayer: public Layer{
   bool is_datalayer() const override {
     return true;
   }
-  Blob<float>* mutable_data(const Layer* layer) override {
+  Blob<float>* mutable_data(const Layer* layer, Phase phase) override {
     return nullptr;
   }
   Blob<float>* mutable_grad(const Layer* layer) override {
@@ -353,8 +359,8 @@ class PrefetchLayer : public Layer {
   void ComputeFeature(Phase phase, Metric* perf) override;
   void ComputeGradient(Phase phase) override {};
 
-  const Blob<float>& data(const Layer* from) const override;
-  Blob<float>* mutable_data(const Layer* layer) override;
+  const Blob<float>& data(const Layer* from, Phase phase) const override;
+  Blob<float>* mutable_data(const Layer* layer, Phase phase) override;
 
   Blob<float>* mutable_grad(const Layer* layer) override {
     return nullptr;
@@ -387,9 +393,9 @@ class SliceLayer: public Layer {
   ConnectionType dst_layer_connection() const override {
     return kOneToMany;
   }
-  const Blob<float>& data(const Layer* layer) const override;
+  const Blob<float>& data(const Layer* layer, Phase phase) const override;
   const Blob<float>& grad(const Layer* layer) const override;
-  Blob<float>* mutable_data(const Layer* layer) override;
+  Blob<float>* mutable_data(const Layer* layer, Phase phase) override;
   Blob<float>* mutable_grad(const Layer* layer) override;
 
  protected:

--- a/include/neuralnet/layer.h
+++ b/include/neuralnet/layer.h
@@ -105,6 +105,7 @@ class RBMVisLayer: public Layer {
     vector<Param*> params{weight_, bias_};
     return params;
   }
+  ~RBMVisLayer();
 
 
  private:
@@ -158,7 +159,7 @@ class RBMHidLayer: public Layer {
     vector<Param*> params{weight_, bias_};
     return params;
   }
-
+  ~RBMHidLayer();
 
  private:
   //! dimension of the hidden layer

--- a/include/neuralnet/layer.h
+++ b/include/neuralnet/layer.h
@@ -68,7 +68,110 @@ class DropoutLayer: public Layer {
    */
   Blob<float> mask_;
 };
+/**
+  * RBM visible layer
+  */
+class RBMVisLayer: public Layer {
+ public:
+  using Layer::ComputeFeature;
+  using Layer::ComputeGradient;
 
+  virtual void Setup(const LayerProto& proto,
+      int npartitions) override;
+  virtual bool is_vislayer() const {
+    return true;
+  }
+
+  virtual void ComputeFeature(Phase phase,
+     Metric *perf) override;
+  virtual void ComputeGradient(Phase phase) override;
+  virtual void ComputeLoss(Metric* perf);
+  virtual Blob<float>* mutable_data(const Layer* from, Phase phase) {
+    if (phase == kPositive){
+      return &data_;
+    }
+    else
+      return &vis_sample_;
+  }
+  virtual const Blob<float>& data(const Layer* from, Phase phase) const {
+    if (phase == kPositive){
+      return data_;
+    }
+    else
+      return vis_sample_;
+  }
+  // virtual void ToProto(LayerProto *layer_proto, bool copyData);
+  const vector<Param*> GetParams() const override {
+    vector<Param*> params{weight_, bias_};
+    return params;
+  }
+
+
+ private:
+  //! dimension of the hidden layer
+  int hdim_;
+  //! dimension of the visible layer
+  int vdim_;
+  int batchsize_;
+  // batchsize of negative phase
+  int neg_batchsize_;
+  bool is_first_iteration_vis_;
+  float scale_;
+  //srclayer index
+  int data_idx_;
+  int hid_idx_;
+  Param* weight_, *bias_;
+  // data to store sampling result
+  Blob<float> vis_sample_;
+  // in order to implement Persistent Contrastive Divergence,
+};
+/**
+  * RBM hidden layer
+  */
+class RBMHidLayer: public Layer {
+ public:
+  using Layer::ComputeFeature;
+  using Layer::ComputeGradient;
+
+  virtual void Setup(const LayerProto& proto,
+      int npartitions) override;
+  virtual bool is_hidlayer() const {
+    return true;
+  }
+
+  virtual void ComputeFeature(Phase phase,
+     Metric *perf) override;
+  virtual void ComputeGradient(Phase phase) override;
+  virtual Blob<float>* mutable_data(const Layer* from, Phase phase) {
+    if (phase == kPositive)
+      return &data_;
+    else
+      return &hid_sample_;
+  }
+  virtual const Blob<float>& data(const Layer* from, Phase phase) const {
+    if (phase == kPositive)
+      return data_;
+    else
+      return hid_sample_;
+  }
+  const vector<Param*> GetParams() const override {
+    vector<Param*> params{weight_, bias_};
+    return params;
+  }
+
+
+ private:
+  //! dimension of the hidden layer
+  int hdim_;
+  int vdim_; //dimension of visible layer
+  int batchsize_;
+  // batchsize of negative phase
+  int neg_batchsize_;
+  bool is_first_iteration_hid_;
+  float scale_;
+  Blob<float> hid_sample_;
+  Param* weight_, *bias_;
+};
 /**
   * fully connected layer
   */

--- a/include/trainer/worker.h
+++ b/include/trainer/worker.h
@@ -191,6 +191,19 @@ class BPWorker: public Worker{
   void Backward(int step, shared_ptr<NeuralNet> net);
 };
 
+class CDWorker: public Worker{
+ public:
+  CDWorker(int thread_id, int group_id, int worker_id);
+  ~CDWorker() {}
+  virtual void TrainOneBatch(int step, Metric* perf);
+  virtual void TestOneBatch(int step, Phase phase,
+       shared_ptr<NeuralNet> net, Metric* perf);
+  void PositivePhase(int step, shared_ptr<NeuralNet> net, Metric* perf);
+  void NegativePhase(int step, shared_ptr<NeuralNet> net, Metric* perf);
+  void GradientPhase(int step, shared_ptr<NeuralNet> net);
+  void LossPhase(int step, shared_ptr<NeuralNet> net, Metric* perf);
+};
+
 inline int BlobTrgt(int grp, int layer) {
   return (grp << 16) | layer;
 }

--- a/src/neuralnet/base_layer.cc
+++ b/src/neuralnet/base_layer.cc
@@ -124,7 +124,7 @@ void PrefetchLayer::Setup(const LayerProto& proto, int npartitions) {
       datablobs_[layer->name()]=Blob<float>(layer->data(this).shape());
 }
 
-const Blob<float>& PrefetchLayer::data(const Layer* from) const {
+const Blob<float>& PrefetchLayer::data(const Layer* from, Phase phase) const {
   if(from!=nullptr){
     return datablobs_.at(from->datablob());
   }else{
@@ -133,7 +133,7 @@ const Blob<float>& PrefetchLayer::data(const Layer* from) const {
   }
 }
 
-Blob<float>* PrefetchLayer::mutable_data(const Layer* from) {
+Blob<float>* PrefetchLayer::mutable_data(const Layer* from, Phase phase) {
   if(from!=nullptr){
     return &(datablobs_.at(from->datablob()));
   }else{
@@ -183,7 +183,7 @@ int SliceLayer::SliceID(const Layer* layer) const {
   return -1;
 }
 
-const Blob<float>& SliceLayer::data(const Layer* layer) const {
+const Blob<float>& SliceLayer::data(const Layer* layer, Phase phase) const {
   if(layer==nullptr)
     return data_;
   return datavec_[SliceID(layer)];
@@ -193,7 +193,7 @@ const Blob<float>& SliceLayer::grad(const Layer* layer) const {
     return grad_;
   return gradvec_[SliceID(layer)];
 }
-Blob<float>* SliceLayer::mutable_data(const Layer* layer) {
+Blob<float>* SliceLayer::mutable_data(const Layer* layer, Phase phase) {
   if(layer==nullptr)
     return &data_;
   return &datavec_[SliceID(layer)];

--- a/src/neuralnet/layer.cc
+++ b/src/neuralnet/layer.cc
@@ -163,6 +163,10 @@ void DropoutLayer::ComputeGradient(Phase phase)  {
   gsrc = grad * mask;
 }
 /**************** Implementation for RBMVisLayer********************/
+RBMVisLayer::~RBMVisLayer() {
+  delete weight_;
+  delete bias_;
+}
 void RBMVisLayer::Setup(const LayerProto& proto,
       int npartitions) {
   Layer::Setup(proto, npartitions);
@@ -193,8 +197,6 @@ void RBMVisLayer::Setup(const LayerProto& proto,
 }
 
 void RBMVisLayer::ComputeFeature(Phase phase, Metric* perf) {
-  float matrix_norm = (weight_->data()).sum_data();
-  float bias_norm = (bias_->data()).sum_data();
   if (phase == kPositive) { /*positive phase*/
         auto data = Tensor2(&data_);
         CHECK_EQ(srclayers_[data_idx_]->data(this).count(), batchsize_*vdim_);
@@ -260,6 +262,10 @@ void RBMVisLayer::ComputeLoss(Metric* perf) {
   perf->Add("reconstruct_error", loss);
 }
 /**************** Implementation for RBMHidLayer********************/
+RBMHidLayer::~RBMHidLayer() {
+  delete weight_;
+  delete bias_;
+}
 void RBMHidLayer::Setup(const LayerProto& proto,
       int npartitions) {
   Layer::Setup(proto, npartitions);
@@ -312,13 +318,9 @@ void RBMHidLayer::ComputeGradient(Phase phase) {
   auto data = Tensor2(&data_);
   auto hid_sample = Tensor2(&hid_sample_);
   auto gbias = Tensor1(bias_->mutable_grad());
-  auto gweight = Tensor2(weight_->mutable_grad());
   gbias = sum_rows(hid_sample);
   gbias-=sum_rows(data);
   gbias*=scale_/(1.0f*batchsize_);
-  float* gweight_dptr = gweight.dptr;
-  for (int i = 0; i < vdim_*hdim_; i++)
-    gweight_dptr[i] = 0.0f;
 }
 /*********** Implementation for InnerProductLayer**********/
 InnerProductLayer::~InnerProductLayer() {

--- a/src/neuralnet/layer.cc
+++ b/src/neuralnet/layer.cc
@@ -162,7 +162,164 @@ void DropoutLayer::ComputeGradient(Phase phase)  {
   auto gsrc = Tensor1(srclayers_[0]->mutable_grad(this));
   gsrc = grad * mask;
 }
+/**************** Implementation for RBMVisLayer********************/
+void RBMVisLayer::Setup(const LayerProto& proto,
+      int npartitions) {
+  Layer::Setup(proto, npartitions);
+  CHECK_EQ(srclayers_.size(), 2);
+  // hid_idx_: index indicating which srclayer is is hidden layer
+  // data_idx_: index indicating which srclayer is data layer
+  for (int i = 0; i < srclayers_.size(); i++)
+    for (int j = 0; j < (srclayers_[i]-> dstlayers()).size(); j++)
+      if (strcmp(((srclayers_[i]->dstlayers()).at(j)->name().c_str()), (this->name()).c_str()) == 0)
+        hid_idx_ = i;
+  for (int i = 0; i < srclayers_.size(); i++)
+    if (i != hid_idx_)
+      data_idx_ = i;
+  const auto& src = srclayers_[data_idx_]->data(this);
+  is_first_iteration_vis_ = true;
+  batchsize_ = src.shape()[0];
+  neg_batchsize_ = batchsize_;
+  /*gibbs sampling size and input have the same size*/
+  vdim_ = src.count()/batchsize_;
+  hdim_ = proto.rbmvis_conf().num_output();
+  data_.Reshape(vector<int>{batchsize_, vdim_});  // this is visible dimension
+  vis_sample_.Reshape(vector<int>{neg_batchsize_, vdim_});
+  Factory<Param>* factory = Singleton<Factory<Param>>::Instance();
+  weight_ = factory->Create("Param");
+  bias_ = factory->Create("Param");
+  weight_->Setup(proto.param(0), vector<int>{vdim_, hdim_});
+  bias_->Setup(proto.param(1), vector<int>{vdim_});
+}
 
+void RBMVisLayer::ComputeFeature(Phase phase, Metric* perf) {
+  float matrix_norm = (weight_->data()).sum_data();
+  float bias_norm = (bias_->data()).sum_data();
+  if (phase == kPositive) { /*positive phase*/
+        auto data = Tensor2(&data_);
+        CHECK_EQ(srclayers_[data_idx_]->data(this).count(), batchsize_*vdim_);
+        auto src = Tensor2(srclayers_[data_idx_]->mutable_data(this));
+        Copy(data, src);
+  }
+  else if (phase == kNegative) {   /*negative phase*/
+        if (is_first_iteration_vis_) {
+          CHECK_EQ(srclayers_[data_idx_]->data(this).count(), batchsize_*vdim_);
+          auto src = Tensor2(srclayers_[data_idx_]->mutable_data(this));
+          auto vis_sample = Tensor2(&vis_sample_);
+          Copy(vis_sample, src);
+          is_first_iteration_vis_ = false;
+        }
+        else {
+            auto hid_sample = Tensor2(srclayers_[hid_idx_]->mutable_data(this, kNegative));  
+            // fetch sampling results from hidden layer
+            auto vis_sample = Tensor2(&vis_sample_);
+            auto weight = Tensor2(weight_->mutable_data());
+            auto bias= Tensor1(bias_->mutable_data());
+            vis_sample = dot(hid_sample, weight.T());
+            vis_sample+=repmat(bias, neg_batchsize_);
+            vis_sample = F<op::sigmoid>(vis_sample);
+            TSingleton<Random<cpu>>::Instance()->SampleBinary(vis_sample);
+        }
+  }
+}
+
+void RBMVisLayer::ComputeGradient(Phase phase) {
+  auto data = Tensor2(&data_);
+  auto hid_data = Tensor2(srclayers_[hid_idx_]->mutable_data(this, kPositive));
+  auto vis_sample = Tensor2(&vis_sample_);
+  auto hid_sample = Tensor2(srclayers_[hid_idx_]->mutable_data(this, kNegative));  // fetch sampling results from hidden layer
+  auto gweight = Tensor2(weight_->mutable_grad());
+  auto gbias = Tensor1(bias_->mutable_grad());
+  gbias = sum_rows(vis_sample);
+  gbias-=sum_rows(data);
+  gweight = dot(vis_sample.T(), hid_sample);
+  gweight-=dot(data.T(), hid_data);
+  gbias*=(1.0f)/(1.0f*batchsize_);
+  gweight*=(1.0f)/(1.0f*batchsize_);
+}
+
+void RBMVisLayer::ComputeLoss(Metric* perf) {
+  float loss = (0.0f);
+  CHECK_EQ(srclayers_[data_idx_]->data(this).count(), batchsize_*vdim_);
+  auto src = Tensor2(srclayers_[data_idx_]->mutable_data(this));
+  auto hid_data = Tensor2(srclayers_[hid_idx_]->mutable_data(this, kPositive));  //gibbs using u
+  auto weight = Tensor2(weight_->mutable_data());
+  auto bias = Tensor1(bias_->mutable_data());
+  Tensor<cpu, 2> reconstruct(Shape2(batchsize_, vdim_)); /*reconstruct error*/
+  AllocSpace(reconstruct);
+  reconstruct = dot(hid_data, weight.T());
+  reconstruct+=repmat(bias, batchsize_);
+  reconstruct = F<op::sigmoid>(reconstruct);
+  float *src_dptr = src.dptr;
+  float *reconstruct_dptr = reconstruct.dptr;
+  for (int i = 0; i < vdim_*batchsize_; i++)
+    loss += -(src_dptr[i]*log(reconstruct_dptr[i])+(1-src_dptr[i])*log(1-reconstruct_dptr[i]));
+  loss/=batchsize_;
+  FreeSpace(reconstruct);
+  perf->Reset();
+  perf->Add("reconstruct_error", loss);
+}
+/**************** Implementation for RBMHidLayer********************/
+void RBMHidLayer::Setup(const LayerProto& proto,
+      int npartitions) {
+  Layer::Setup(proto, npartitions);
+  CHECK_EQ(srclayers_.size(), 1);
+  const auto& src_data = srclayers_[0]->data(this, kPositive);
+  const auto& src_sample = srclayers_[0]->data(this, kNegative);
+  is_first_iteration_hid_ = true;
+  scale_ = static_cast<float> (1.0f);
+  batchsize_ = src_data.shape()[0];
+  neg_batchsize_ = src_sample.shape()[0];
+  vdim_ = src_data.count()/batchsize_;
+  hdim_ = proto.rbmhid_conf().hid_dim();
+  data_.Reshape(vector<int>{batchsize_, hdim_});
+  hid_sample_.Reshape(vector<int>{neg_batchsize_, hdim_});
+  Factory<Param>* factory = Singleton<Factory<Param>>::Instance();
+  bias_ = factory->Create("Param");
+  weight_ = factory->Create("Param");
+  bias_->Setup(proto.param(1), vector<int>{hdim_});
+  weight_->Setup(proto.param(0), vector<int>{vdim_, hdim_});
+}
+
+void RBMHidLayer::ComputeFeature(Phase phase, Metric* perf) {
+  if (phase == kPositive) {  /*postive phase*/
+    auto data = Tensor2(&data_);
+    CHECK_EQ(srclayers_[0]->data(this, kPositive).count(), batchsize_*vdim_);
+    auto src = Tensor2(srclayers_[0]->mutable_data(this, kPositive));
+    auto weight = Tensor2(weight_->mutable_data());
+    auto bias = Tensor1(bias_->mutable_data());
+    data = dot(src, weight);
+    data+=repmat(bias, batchsize_);
+    data = F<op::sigmoid>(data);
+  }
+  else if (phase == kNegative) {   /*negative phase*/
+    CHECK_EQ(srclayers_[0]->data(this, kNegative).count(), neg_batchsize_*vdim_);
+    auto src_sample = Tensor2(srclayers_[0]->mutable_data(this, kNegative));
+    auto hid_sample = Tensor2(&hid_sample_);
+    auto bias = Tensor1(bias_->mutable_data());
+    auto weight = Tensor2(weight_->mutable_data());
+    hid_sample = dot(src_sample, weight);
+    hid_sample += repmat(bias, neg_batchsize_);
+    hid_sample = F<op::sigmoid>(hid_sample);
+    TSingleton<Random<cpu>>::Instance()->SampleBinary(hid_sample);
+  }
+  else if (phase == kLoss) {   /*test phase*/
+     auto data = Tensor2(&data_);  // data: sigmoid(Wv+b)
+     TSingleton<Random<cpu>>::Instance()->SampleBinary(data);
+  }
+}
+void RBMHidLayer::ComputeGradient(Phase phase) {
+  auto data = Tensor2(&data_);
+  auto hid_sample = Tensor2(&hid_sample_);
+  auto gbias = Tensor1(bias_->mutable_grad());
+  auto gweight = Tensor2(weight_->mutable_grad());
+  gbias = sum_rows(hid_sample);
+  gbias-=sum_rows(data);
+  gbias*=scale_/(1.0f*batchsize_);
+  float* gweight_dptr = gweight.dptr;
+  for (int i = 0; i < vdim_*hdim_; i++)
+    gweight_dptr[i] = 0.0f;
+}
 /*********** Implementation for InnerProductLayer**********/
 InnerProductLayer::~InnerProductLayer() {
   delete weight_;

--- a/src/neuralnet/neuralnet.cc
+++ b/src/neuralnet/neuralnet.cc
@@ -34,6 +34,8 @@ void NeuralNet::RegisterLayers() {
   RegisterLayer(factory, SoftmaxLoss);
   RegisterLayer(factory, Split);
   RegisterLayer(factory, Tanh);
+  RegisterLayer(factory, RBMVis);
+  RegisterLayer(factory, RBMHid);
 }
 
 shared_ptr<NeuralNet> NeuralNet::Create(
@@ -131,6 +133,7 @@ void NeuralNet::CreateNetFromGraph(Graph* graph, int npartitions) {
   for (Node* node : graph->nodes()) {
     auto layer = name2layer_[node->name];
     layer->Setup(*(static_cast<LayerProto*>(node->proto)), npartitions);
+    LOG(INFO) << "constructing graph: " << layer->name();
     layerinfo[layer->name()] = IntVecToString(layer->data(nullptr).shape());
     string param_name = "$";
     for (auto param : layer->GetParams()) {

--- a/src/proto/model.proto
+++ b/src/proto/model.proto
@@ -9,6 +9,7 @@ enum Phase {
   kNegative = 4;
   kForward = 5;
   kBackward = 6;
+  kLoss = 7;
 }
 
 message ModelProto {
@@ -40,6 +41,8 @@ message ModelProto {
   optional int32 test_frequency = 33 [default = 0];
   // frequency of checkpoint
   optional int32 checkpoint_frequency = 34 [default = 0];
+  //frequency of visualization
+  optional int32 visualization_frequency = 37 [default=5000];
   // send parameters to servers after training for this num of steps
   optional int32 warmup_steps = 35 [default = 0];
   // checkpoint path
@@ -61,6 +64,8 @@ message ModelProto {
   repeated string checkpoint = 66;
   // reset the version of params loaded from checkpoint file to step
   optional bool reset_param_version = 67 [default = false];
+  //number of steps for gibbs sampling
+  optional int32 pcd_k=69 [default=15];
 }
 
 message NetProto {
@@ -151,6 +156,8 @@ message LayerProto {
     kSlice = 12;
     kSplit = 13;
     kTanh = 14;
+    kRBMVis = 23;
+    kRBMHid = 24;
   }
   // source layer names
   repeated string srclayers = 3;
@@ -194,6 +201,10 @@ message LayerProto {
   optional SplitProto split_conf = 42;
   // configuration for tanh layer
   optional TanhProto tanh_conf = 43;
+  // configuration for rbmvis layer
+  optional RBMVisProto rbmvis_conf = 48;
+  // configuration for rbmhid layer
+  optional RBMHidProto rbmhid_conf = 49;
 
 
   // overrides the partition dimension for neural net
@@ -290,6 +301,16 @@ message MnistProto {
 message DropoutProto {
   // dropout ratio
   optional float dropout_ratio = 30 [default = 0.5];
+}
+
+message RBMVisProto {
+  optional int32 num_output = 1; // The number of outputs for the layer
+  optional bool bias_term = 2 [default = true]; // whether to have bias terms
+}
+
+message RBMHidProto {
+  optional int32 hid_dim = 1; // The number of outputs for the layer
+  optional bool bias_term = 2 [default = true]; // whether to have bias terms
 }
 
 // Message that stores parameters used by InnerProductLayer

--- a/src/proto/plot.py
+++ b/src/proto/plot.py
@@ -1,0 +1,157 @@
+""" This file contains different utility functions that are not connected
+in anyway to the networks presented in the tutorials, but rather help in
+processing the outputs into a more understandable way.
+
+For example ``tile_raster_images`` helps in generating a easy to grasp
+image from a set of samples or weights.
+"""
+
+
+import numpy
+import Image
+
+def scale_to_unit_interval(ndar, eps=1e-8):
+    """ Scales all values in the ndarray ndar to be between 0 and 1 """
+    ndar = ndar.copy()
+    ndar -= ndar.min()
+    ndar *= 1.0 / (ndar.max() + eps)
+    return ndar
+
+
+def tile_raster_images(X, img_shape, tile_shape, tile_spacing=(0, 0),
+                       scale_rows_to_unit_interval=True,
+                       output_pixel_vals=True):
+    """
+    Transform an array with one flattened image per row, into an array in
+    which images are reshaped and layed out like tiles on a floor.
+
+    This function is useful for visualizing datasets whose rows are images,
+    and also columns of matrices for transforming those rows
+    (such as the first layer of a neural net).
+
+    :type X: a 2-D ndarray or a tuple of 4 channels, elements of which can
+    be 2-D ndarrays or None;
+    :param X: a 2-D array in which every row is a flattened image.
+
+    :type img_shape: tuple; (height, width)
+    :param img_shape: the original shape of each image
+
+    :type tile_shape: tuple; (rows, cols)
+    :param tile_shape: the number of images to tile (rows, cols)
+
+    :param output_pixel_vals: if output should be pixel values (i.e. int8
+    values) or floats
+
+    :param scale_rows_to_unit_interval: if the values need to be scaled before
+    being plotted to [0,1] or not
+
+
+    :returns: array suitable for viewing as an image.
+    (See:`Image.fromarray`.)
+    :rtype: a 2-d array with same dtype as X.
+
+    """
+
+    assert len(img_shape) == 2
+    assert len(tile_shape) == 2
+    assert len(tile_spacing) == 2
+
+    # The expression below can be re-written in a more C style as
+    # follows :
+    #
+    # out_shape    = [0,0]
+    # out_shape[0] = (img_shape[0]+tile_spacing[0])*tile_shape[0] -
+    #                tile_spacing[0]
+    # out_shape[1] = (img_shape[1]+tile_spacing[1])*tile_shape[1] -
+    #                tile_spacing[1]
+    out_shape = [
+        (ishp + tsp) * tshp - tsp
+        for ishp, tshp, tsp in zip(img_shape, tile_shape, tile_spacing)
+    ]
+
+    if isinstance(X, tuple):
+        assert len(X) == 4
+        # Create an output numpy ndarray to store the image
+        if output_pixel_vals:
+            out_array = numpy.zeros((out_shape[0], out_shape[1], 4),
+                                    dtype='uint8')
+        else:
+            out_array = numpy.zeros((out_shape[0], out_shape[1], 4),
+                                    dtype=X.dtype)
+
+        #colors default to 0, alpha defaults to 1 (opaque)
+        if output_pixel_vals:
+            channel_defaults = [0, 0, 0, 255]
+        else:
+            channel_defaults = [0., 0., 0., 1.]
+
+        for i in xrange(4):
+            if X[i] is None:
+                # if channel is None, fill it with zeros of the correct
+                # dtype
+                dt = out_array.dtype
+                if output_pixel_vals:
+                    dt = 'uint8'
+                out_array[:, :, i] = numpy.zeros(
+                    out_shape,
+                    dtype=dt
+                ) + channel_defaults[i]
+            else:
+                # use a recurrent call to compute the channel and store it
+                # in the output
+                out_array[:, :, i] = tile_raster_images(
+                    X[i], img_shape, tile_shape, tile_spacing,
+                    scale_rows_to_unit_interval, output_pixel_vals)
+        return out_array
+
+    else:
+        # if we are dealing with only one channel
+        H, W = img_shape
+        Hs, Ws = tile_spacing
+
+        # generate a matrix to store the output
+        dt = X.dtype
+        if output_pixel_vals:
+            dt = 'uint8'
+        out_array = numpy.zeros(out_shape, dtype=dt)
+
+        for tile_row in xrange(tile_shape[0]):
+            for tile_col in xrange(tile_shape[1]):
+                if tile_row * tile_shape[1] + tile_col < X.shape[0]:
+                    this_x = X[tile_row * tile_shape[1] + tile_col]
+                    if scale_rows_to_unit_interval:
+                        # if we should scale values to be between 0 and 1
+                        # do this by calling the `scale_to_unit_interval`
+                        # function
+                        this_img = scale_to_unit_interval(
+                            this_x.reshape(img_shape))
+                    else:
+                        this_img = this_x.reshape(img_shape)
+                    # add the slice to the corresponding position in the
+                    # output array
+                    c = 1
+                    if output_pixel_vals:
+                        c = 255
+                    out_array[
+                        tile_row * (H + Hs): tile_row * (H + Hs) + H,
+                        tile_col * (W + Ws): tile_col * (W + Ws) + W
+                    ] = this_img * c
+        return out_array
+
+import model_pb2 as model
+import sys
+bp=model.BlobProto()
+fd=open(sys.argv[1], "rb")
+#fd=open("../../examples/mnistDBM/visualization/5000", "rb")
+bp.ParseFromString(fd.read())
+import numpy as np
+mat=np.array(bp.data).reshape((bp.height, bp.width))
+print bp.height
+print bp.width
+
+image = Image.fromarray(tile_raster_images(
+        X = mat.T,
+        img_shape=(28, 28), tile_shape=(10, 10),
+        tile_spacing=(1, 1)))
+image.save(sys.argv[2])
+#image.save('filters_RBM5000-1.png')

--- a/src/trainer/trainer.cc
+++ b/src/trainer/trainer.cc
@@ -185,7 +185,7 @@ vector<Worker*> Trainer::CreateWorkers(int nthreads, const ModelProto& mconf){
       if (mconf.alg() == ModelProto_GradCalcAlg_kBackPropagation)
         worker = new BPWorker(nthreads++,gid, wid);
       else {
-        // TODO add CDWorker and BPTTWorker
+        worker=new CDWorker(nthreads++,gid, wid);
       }
       workers.push_back(worker);
     }

--- a/src/trainer/worker.cc
+++ b/src/trainer/worker.cc
@@ -421,32 +421,6 @@ void CDWorker::LossPhase(int step, shared_ptr<NeuralNet> net, Metric* perf) {
     if (layer->is_vislayer())
       layer->ComputeLoss(perf);
   }
-  if (modelproto_.visualization_frequency() != 0) {
-    if (step % modelproto_.visualization_frequency() == 0 && step!= 0) { /*print weight matrix*/
-      BlobProto bp;
-      int rownum;
-      int colnum;
-      const float *dptr;
-      for (auto& layer : layers) {
-        if (layer->is_vislayer()) {
-          for (Param* p : layer->GetParams()) {
-            rownum = p->data().shape()[0];
-            colnum = p->data().shape()[1];
-            dptr = p->data().cpu_data();
-            for (int i = 0; i < p->data().count(); i++){
-              bp.add_data(static_cast<float>(dptr[i]));
-            }  
-            break;
-          }
-          bp.add_shape(rownum);
-          bp.add_shape(colnum);
-          auto cluster = Cluster::Get();
-          string filename = cluster->vis_folder() + "/" + std::to_string(static_cast<int>(step / modelproto_.visualization_frequency()));
-          WriteProtoToBinaryFile(bp, filename.c_str());
-        } 
-      }
-    }
-  }
 }
 
 void CDWorker::TrainOneBatch(int step, Metric* perf) {

--- a/src/utils/graph.cc
+++ b/src/utils/graph.cc
@@ -175,12 +175,27 @@ void Graph::Sort() {
     auto node = visiting_nodes.front();
     visiting_nodes.pop();
     bool visit = true;
-    for (auto src : node->srcnodes) {
-      // visit this node only if all srouce nodes have been visited
-      if (visited_set.find(src) == visited_set.end()) {
-        visit = false;
-        break;
-      }
+    bool bi_direction = false;
+    // check if a node has a bi-direction edge with its neighbour
+    for (auto src : node->srcnodes)
+      for (auto src_of_src : src->srcnodes)
+        if (strcmp((src_of_src->name).c_str(), (node->name).c_str()) == 0) {
+          bi_direction = true;
+          break;
+        }
+    // check whether its src nodes number greater than 1
+    if (bi_direction && (node->srcnodes).size() > 1) {
+        auto src =  node->srcnodes.at(0);  
+        if (visited_set.find(src) == visited_set.end()) {
+          visit = false;
+        }
+    }
+    else {
+      for (auto src : node->srcnodes)
+        if (visited_set.find(src) == visited_set.end()) {
+          visit = false;
+          break;
+        }
     }
     if (visit) {
       nodes_.push_back(node);
@@ -196,6 +211,10 @@ void Graph::Sort() {
       visiting_nodes.push(node);
     }
   }
+  for (auto node : nodes_) {
+    LOG(INFO) << "nodes: " << node->name;
+  }
+  LOG(INFO) << "finish printing nodes ";
   CHECK_EQ(nodes_.size(), n);
 }
 

--- a/src/utils/param.cc
+++ b/src/utils/param.cc
@@ -274,9 +274,10 @@ void Param::ParseResponseMsg(Msg* msg, int slice_idx) {
 
 void Param::ShareFrom(const Param& other) {
   proto_.set_owner(other.owner());
-  if(data_!=nullptr)
+  if(data_!=nullptr) {
     CHECK(std::equal(data_->shape().begin(), data_->shape().end(),
           other.data_->shape().begin()));
+  }
   data_ = other.data_;
   slice_offset_ = other.slice_offset_;
   slice_size_ = other.slice_size_;


### PR DESCRIPTION
This ticket is to implement RBM in SINGA.
To training RBM models, the Contrastive Divergence (CD) algorithm should be implemented. 
We have implemented a BPWorker to run the Back-Propagation algorithm. To implement the CD algorithm, we follow the same way to create a CDWorker whose RunOneBatch function controls the logic of the CD algorithm, including positive phase, negative phase and computing gradient phase.
RBM's layers are different to the layers for feed-forward neural networks, hence new layers for RBM models should be added.