### PR TITLE
SINGA-42 Issue when loading checkpoints

### DIFF
--- a/src/neuralnet/layer.cc
+++ b/src/neuralnet/layer.cc
@@ -385,7 +385,7 @@ void LabelLayer::ParseRecords(Phase phase, const vector<Record>& records,
   float *label= blob->mutable_cpu_data() ;
   for(const Record& record: records){
     label[rid++]=record.image().label();
-    CHECK_LT(record.image().label(),10);
+    //  CHECK_LT(record.image().label(),10);
   }
   CHECK_EQ(rid, blob->shape()[0]);
 }
@@ -738,7 +738,7 @@ void SoftmaxLossLayer::ComputeFeature(Phase phase, Metric* perf) {
   float loss=0, precision=0;
   for(int n=0;n<batchsize_;n++){
     int ilabel=static_cast<int>(label[n]);
-    CHECK_LT(ilabel,10);
+    //  CHECK_LT(ilabel,10);
     CHECK_GE(ilabel,0);
     float prob_of_truth=probptr[ilabel];
     loss-=log(std::max(prob_of_truth, FLT_MIN));

--- a/src/proto/job.proto
+++ b/src/proto/job.proto
@@ -95,7 +95,7 @@ message ModelProto {
   // checkpoint files
   repeated string checkpoint = 66;
   // reset the version of params loaded from checkpoint file to step
-  optional bool reset_param_version = 67 [default = false];
+  optional bool reset_param_version = 67 [default = true];
   //number of steps for gibbs sampling
   optional int32 pcd_k=69 [default=15];
 }


### PR DESCRIPTION
Fixbug this bug arising from calling Worker::Put() in Worker::InitLocalParam().
Previously, the version/step passed to Put() is step_ which starts from ModelProto::step.
Hence, the params in the servers are put with version step_. When the params are load from checkpoint files and their param versions are not reset, then the trainining may get stuck after one iteration. Because if the start step is small (usually 0), parame version at the server side is small (i.e., 0), while the local_version() (assigned from version()) is the one from last checkpoint, which is large. Hence the Worker::Collect() function will get stuck. To fix this bug, just pass the current param->version() to Worker::Put().


Update default value for ModelProto::reset_param_version to true. It will reset all parameter version to ModelProto::step. For resuming training from checkpoints, if users do not set it, the Trainer::Resume() function will set it to false. Hence the parameter versions will continue from last checkpoint.
If users set it to true, then all parameters will be reset to the version as ModelProto::step.
If using the checkpoint as pre-training to initalize new model parameters, users better use the default value (i.e., true), otherwise some parameters' version would be much larger than others.