### PR TITLE
SINGA-49 Fix a bug in HandlePutMsg func that sets param fields to invalid values

### DIFF
--- a/Makefile.example
+++ b/Makefile.example
@@ -18,7 +18,7 @@ LDFLAGS := $(foreach librarydir, $(LIBRARY_DIRS), -L$(librarydir))\
 BUILD_DIR := .libs
 MSHADOW_FLAGS :=-DMSHADOW_USE_CUDA=0 -DMSHADOW_USE_CBLAS=1 -DMSHADOW_USE_MKL=0
 ZK_FLAGS :=-DTHREADED -fpermissive
-CXXFLAGS := -O3 -Wall -pthread -fPIC -std=c++11 -Wno-unknown-pragmas \
+CXXFLAGS := -O2 -msse3 -Wall -pthread -fPIC -std=c++11 -Wno-unknown-pragmas \
 	$(MSHADOW_FLAGS) -DCPU_ONLY=1 $(ZK_FLAGS)\
 	-funroll-loops $(foreach includedir, $(INCLUDE_DIRS), -I$(includedir))
 

--- a/examples/cifar10/job.conf
+++ b/examples/cifar10/job.conf
@@ -140,7 +140,7 @@ model {
     type: kPooling
     srclayers: "relu2"
     pooling_conf {
-      pool: MAX
+      pool: AVE
       kernel: 3
       stride: 2
     }

--- a/src/utils/param.cc
+++ b/src/utils/param.cc
@@ -18,7 +18,7 @@ void Param::Setup(const ParamProto& proto, const vector<int>& shape){
   data_=std::make_shared<Blob<float>>(shape);
   grad_.Reshape(shape);
   history_.Reshape(shape);
-  proto_=proto;
+  proto_.CopyFrom(proto);
 }
 
 void Param::AddSlice(int slice_id, int size){
@@ -146,10 +146,10 @@ Msg* Param::HandlePutMsg(Msg** msg, bool reserve) {
   float lr, wc;
   float* ptr;
   (*msg)->ParseFormatFrame("iffp", &size, &lr, &wc, &ptr);
-  proto_.set_learning_rate_multiplier(lr);
-  proto_.set_weight_decay_multiplier(wc);
-  vector<int> shape{size};
   ParamProto proto;
+  proto.set_learning_rate_multiplier(lr);
+  proto.set_weight_decay_multiplier(wc);
+  vector<int> shape{size};
   Setup(proto, shape);
   if (ptr == nullptr) {
     CHECK((*msg)->NextFrame());


### PR DESCRIPTION
The Param::HandlePutMsg doesn't set the weight decay multiplier and learning rate multiplier correctly.
The previous code doesn't use the values from the received messages.
Fixed the bug using the correct multipliers.