### PR TITLE
SINGA-44 Fix a bug in reseting metric values

### DIFF
--- a/src/utils/common.cc
+++ b/src/utils/common.cc
@@ -175,7 +175,7 @@ void Metric::Add(const string& name, float value) {
 }
 
 void Metric::Reset() {
-  for(auto e : entry_) {
+  for(auto& e : entry_) {
     e.second.first = 0;
     e.second.second = 0;
   }


### PR DESCRIPTION
When reseting the values of Metric object, we didn't use reference which made the resetting invalid.
Fixed the bug by using reference.