### PR TITLE
SINGA-47 Fix a bug in data layers that leads to out-of-memory when group size is too large

### DIFF
--- a/include/neuralnet/layer.h
+++ b/include/neuralnet/layer.h
@@ -335,10 +335,12 @@ class ShardDataLayer: public DataLayer{
  public:
   using Layer::ComputeFeature;
 
+  ~ShardDataLayer();
   void Setup(const LayerProto& proto, int npartitions) override;
   void ComputeFeature(Phase phase, Metric *perf) override;
+
  private:
-  shared_ptr<DataShard> shard_;
+  DataShard* shard_;
 };
 
 /**

--- a/include/neuralnet/optional_layer.h
+++ b/include/neuralnet/optional_layer.h
@@ -9,6 +9,8 @@ class LMDBDataLayer: public DataLayer{
  public:
   using Layer::ComputeFeature;
 
+  ~LMDBDataLayer();
+  void OpenLMDB(const std::string& path);
   void Setup(const LayerProto& proto, int npartitions) override;
   void ComputeFeature(Phase phase, Metric *perf) override;
   void ConvertCaffeDatumToRecord(const CaffeDatum& datum,

--- a/src/neuralnet/neuralnet.cc
+++ b/src/neuralnet/neuralnet.cc
@@ -3,6 +3,9 @@
 
 #include "neuralnet/neuralnet.h"
 #include "utils/singleton.h"
+#ifdef USE_OPTIONAL_LAYER
+#include "neuralnet/optional_layer.h"
+#endif
 
 namespace singa {
 // macros to shorten the code


### PR DESCRIPTION
The bug is fixed by closing the data source (e.g., lmdb or datashard) after reading a sample record in the Setup function.
The data source would cache memory which eat up all memory if there are many data layers.