### PR TITLE
SINGA-45 Set openblas num threads in job configuration

### DIFF
--- a/include/singa.h
+++ b/include/singa.h
@@ -2,6 +2,7 @@
 #define SINGA_SINGA_H_
 #include <gflags/gflags.h>
 #include <glog/logging.h>
+#include <cblas.h>
 
 #include "utils/common.h"
 #include "proto/job.pb.h"
@@ -24,9 +25,13 @@ void SubmitJob(int job, bool resume, const JobProto& jobConf) {
   if (singaConf.has_log_dir())
     SetupLog(singaConf.log_dir(),
         std::to_string(job) + "-" + jobConf.model().name());
+  if (jobConf.num_openblas_threads() != 1)
+    LOG(WARNING) << "openblas is set with " << jobConf.num_openblas_threads()
+      << " threads";
+  openblas_set_num_threads(jobConf.num_openblas_threads());
   Trainer trainer;
   trainer.Start(job, resume, jobConf, singaConf);
 }
-} /* singa */
+}  // namespace singa
 #endif  //  SINGA_SINGA_H_
 

--- a/src/proto/job.proto
+++ b/src/proto/job.proto
@@ -3,6 +3,7 @@ package singa;
 message JobProto {
   required ClusterProto cluster = 1;
   required ModelProto model = 2;
+  optional int32 num_openblas_threads = 3 [default = 1];
 }
 
 message ClusterProto {


### PR DESCRIPTION
Add a configuration field (openblas_num_threads) in JobProto which specifies the num of threads used by openblas, default to 1.
If multiple workers/servers are launched in one process, this field must be set to 1 (according to openblas wiki page).