### PR TITLE
SINGA-9 Add Support for Restricted Boltzman Machine (RBM) model

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -95,9 +95,6 @@ singa_LDFLAGS = -I./include \
                 -lglog  \
                 -lprotobuf \
                 -lrt \
-                -lopencv_highgui \
-                -lopencv_imgproc \
-                -lopencv_core \
                 -lopenblas \
                 -lzmq \
                 -lczmq \

--- a/configure.ac
+++ b/configure.ac
@@ -44,15 +44,15 @@ if test x"$enable_lmdb" = x"yes"; then
 	AC_DEFINE(LMDB, 1, [Enable Option layer])
 fi
 
-AC_CHECK_LIB([opencv_imgproc], [main], [], [
-  AC_MSG_ERROR([unable to find opencv_imgproc lib])
-  ])
-AC_CHECK_LIB([opencv_highgui], [main], [], [
-  AC_MSG_ERROR([unable to find opencv_highgui lib])
-  ])
-AC_CHECK_LIB([opencv_core], [main], [], [
-  AC_MSG_ERROR([unable to find opencv_core lib])
-  ])
+#AC_CHECK_LIB([opencv_imgproc], [main], [], [
+#  AC_MSG_ERROR([unable to find opencv_imgproc lib])
+#  ])
+#AC_CHECK_LIB([opencv_highgui], [main], [], [
+#  AC_MSG_ERROR([unable to find opencv_highgui lib])
+#  ])
+#AC_CHECK_LIB([opencv_core], [main], [], [
+#  AC_MSG_ERROR([unable to find opencv_core lib])
+#  ])
 AC_CHECK_LIB([zookeeper_mt], [main], [], [
   AC_MSG_ERROR([unable to find zookeeper])
   ])

--- a/examples/cifar10/job.conf
+++ b/examples/cifar10/job.conf
@@ -3,7 +3,10 @@ train_steps: 1000
 test_steps: 100
 test_freq:300
 disp_freq:30
-alg: kBP
+debug: true
+train_one_batch {
+  alg: kBP
+}
 updater{
   type: kSGD
   weight_decay:0.004

--- a/examples/mnist/conv.conf
+++ b/examples/mnist/conv.conf
@@ -3,7 +3,9 @@ train_steps: 10000
 test_steps:100
 test_freq:500
 disp_freq:50
-alg: kBP
+train_one_batch {
+  alg: kBP
+}
 updater {
   momentum:0.9
   weight_decay:0.0005

--- a/examples/mnist/job.conf
+++ b/examples/mnist/job.conf
@@ -3,7 +3,9 @@ train_steps: 1000
 test_steps:10
 test_freq:60
 disp_freq:10
-alg: kBP
+train_one_batch {
+  alg: kBP
+}
 updater{
   type: kSGD
   learning_rate{
@@ -82,6 +84,10 @@ neuralnet {
   layer{
     name: "tanh1"
     type: kTanh
+    tanh_conf {
+      outer_scale: 1.7159047
+      inner_scale: 0.6666667
+    }
     srclayers:"fc1"
   }
   layer{
@@ -112,6 +118,11 @@ neuralnet {
   layer{
     name: "tanh2"
     type: kTanh
+    tanh_conf {
+      outer_scale: 1.7159047
+      inner_scale: 0.6666667
+    }
+
     srclayers:"fc2"
   }
   layer{
@@ -143,6 +154,11 @@ neuralnet {
   layer{
     name: "tanh3"
     type: kTanh
+    tanh_conf {
+      outer_scale: 1.7159047
+      inner_scale: 0.6666667
+    }
+
     srclayers:"fc3"
   }
   layer{
@@ -174,6 +190,11 @@ neuralnet {
   layer{
     name: "tanh4"
     type: kTanh
+    tanh_conf {
+      outer_scale: 1.7159047
+      inner_scale: 0.6666667
+    }
+
     srclayers:"fc4"
   }
   layer{
@@ -205,6 +226,11 @@ neuralnet {
   layer{
     name: "tanh5"
     type: kTanh
+    tanh_conf {
+      outer_scale: 1.7159047
+      inner_scale: 0.6666667
+    }
+
     srclayers:"fc5"
   }
   layer{

--- a/examples/rbm/autoencoder.conf
+++ b/examples/rbm/autoencoder.conf
@@ -1,15 +1,15 @@
-name: "deep-big-simple-mlp"
+name: "auto-encoder"
 train_steps: 12200
 test_steps:100
-test_freq:100
-disp_freq:20
-checkpoint_after: 1000
-checkpoint_freq: 1000
-checkpoint_path: "examples/rbm/checkpoint/rbm0/checkpoint/step6000-worker0.bin"
-checkpoint_path: "examples/rbm/checkpoint/rbm1/checkpoint/step6000-worker0.bin"
-checkpoint_path: "examples/rbm/checkpoint/rbm2/checkpoint/step6000-worker0.bin"
-checkpoint_path: "examples/rbm/checkpoint/rbm3/checkpoint/step6000-worker0.bin"
-alg: kBP
+test_freq:1000
+disp_freq:100
+checkpoint_path: "examples/rbm/rbm0/checkpoint/step6000-worker0.bin"
+checkpoint_path: "examples/rbm/rbm1/checkpoint/step6000-worker0.bin"
+checkpoint_path: "examples/rbm/rbm2/checkpoint/step6000-worker0.bin"
+checkpoint_path: "examples/rbm/rbm3/checkpoint/step6000-worker0.bin"
+train_one_batch{
+  alg: kBP
+}
 updater{
   type: kAdaGrad
   learning_rate{
@@ -23,7 +23,7 @@ neuralnet {
     name: "data"
     type: kShardData
     sharddata_conf {
-      path: "examples/rbm/mnist_train_shard"
+      path: "examples/mnist/mnist_train_shard"
       batchsize: 1000
     }
     exclude: kTest
@@ -33,7 +33,7 @@ neuralnet {
     name: "data"
     type: kShardData
     sharddata_conf {
-      path: "examples/rbm/mnist_test_shard"
+      path: "examples/mnist/mnist_test_shard"
       batchsize: 1000
     }
     exclude: kTrain
@@ -64,19 +64,9 @@ neuralnet {
     }
     param{
       name: "w1"
-      init{
-      type: kUniform
-      low:-0.05
-      high:0.05
-      }
     }
     param{
       name: "rb12"
-      init{
-      type: kUniform
-      low: -0.05
-      high:0.05
-      }
     }
   }
 
@@ -94,19 +84,9 @@ neuralnet {
     }
     param{
       name: "w2"
-      init{
-      type: kUniform
-      low:-0.05
-      high:0.05
-      }
     }
     param{
       name: "rb22"
-      init{
-      type: kUniform
-      low: -0.05
-      high:0.05
-      }
     }
   }
 
@@ -125,19 +105,9 @@ neuralnet {
     }
     param{
       name: "w3"
-      init{
-      type: kUniform
-      low:-0.05
-      high:0.05
-      }
     }
     param{
       name: "rb32"
-      init{
-      type: kUniform
-      low: -0.05
-      high:0.05
-      }
     }
   }
 
@@ -156,19 +126,10 @@ neuralnet {
     }
     param{
       name: "w4"
-      init{
-      type: kUniform
-      low:-0.05
-      high:0.05
-      }
     }
     param{
       name: "rb42"
-      init{
-      type: kUniform
-      low: -0.05
-      high:0.05
-      }
+
     }
   }
 
@@ -187,11 +148,6 @@ neuralnet {
     }
     param{
       name: "rb41"
-      init{
-      type: kUniform
-      low: -0.05
-      high:0.05
-      }
     }
   }
 
@@ -214,13 +170,7 @@ neuralnet {
     }
     param{
       name: "rb31"
-      init{
-      type: kUniform
-      low: -0.05
-      high:0.05
-      }
     }
-
   }
 
   layer{
@@ -242,11 +192,6 @@ neuralnet {
     }
     param{
       name: "rb21"
-      init{
-      type: kUniform
-      low: -0.05
-      high:0.05
-      }
     }
 
   }
@@ -270,13 +215,7 @@ neuralnet {
     }
     param{
       name: "rb11"
-      init{
-      type: kUniform
-      low: -0.05
-      high:0.05
-      }
     }
-
   }
 
   layer{
@@ -295,5 +234,5 @@ neuralnet {
 cluster {
   nworker_groups: 1
   nserver_groups: 1
-  workspace: "examples/rbm/checkpoint/autoencoder/"
+  workspace: "examples/rbm/autoencoder/"
 }

--- a/examples/rbm/autoencoder.conf
+++ b/examples/rbm/autoencoder.conf
@@ -1,0 +1,299 @@
+name: "deep-big-simple-mlp"
+train_steps: 12200
+test_steps:100
+test_freq:100
+disp_freq:20
+checkpoint_after: 1000
+checkpoint_freq: 1000
+checkpoint_path: "examples/rbm/checkpoint/rbm0/checkpoint/step6000-worker0.bin"
+checkpoint_path: "examples/rbm/checkpoint/rbm1/checkpoint/step6000-worker0.bin"
+checkpoint_path: "examples/rbm/checkpoint/rbm2/checkpoint/step6000-worker0.bin"
+checkpoint_path: "examples/rbm/checkpoint/rbm3/checkpoint/step6000-worker0.bin"
+alg: kBP
+updater{
+  type: kAdaGrad
+  learning_rate{
+  base_lr: 0.01
+  type: kFixed
+  }
+}
+
+neuralnet {
+  layer {
+    name: "data"
+    type: kShardData
+    sharddata_conf {
+      path: "examples/rbm/mnist_train_shard"
+      batchsize: 1000
+    }
+    exclude: kTest
+  }
+
+  layer {
+    name: "data"
+    type: kShardData
+    sharddata_conf {
+      path: "examples/rbm/mnist_test_shard"
+      batchsize: 1000
+    }
+    exclude: kTrain
+  }
+
+  layer{
+    name:"mnist"
+    type: kMnist
+    srclayers: "data"
+    mnist_conf {
+      norm_a: 255
+      norm_b: 0
+    }
+  }
+
+  layer{
+    name: "label"
+    type: kLabel
+    srclayers: "data"
+  }
+
+  layer{
+    name: "fc1"
+    type: kInnerProduct
+    srclayers:"mnist"
+    innerproduct_conf{
+      num_output: 1000
+    }
+    param{
+      name: "w1"
+      init{
+      type: kUniform
+      low:-0.05
+      high:0.05
+      }
+    }
+    param{
+      name: "rb12"
+      init{
+      type: kUniform
+      low: -0.05
+      high:0.05
+      }
+    }
+  }
+
+  layer{
+    name: "sigmoid1"
+    type: kSigmoid
+    srclayers:"fc1"
+  }
+  layer{
+    name: "fc2"
+    type: kInnerProduct
+    srclayers:"sigmoid1"
+    innerproduct_conf{
+      num_output: 500
+    }
+    param{
+      name: "w2"
+      init{
+      type: kUniform
+      low:-0.05
+      high:0.05
+      }
+    }
+    param{
+      name: "rb22"
+      init{
+      type: kUniform
+      low: -0.05
+      high:0.05
+      }
+    }
+  }
+
+  layer{
+    name: "sigmoid2"
+    type: kSigmoid
+    srclayers:"fc2"
+  }
+
+  layer{
+    name: "fc3"
+    type:  kInnerProduct
+    srclayers:"sigmoid2"
+    innerproduct_conf{
+      num_output: 250
+    }
+    param{
+      name: "w3"
+      init{
+      type: kUniform
+      low:-0.05
+      high:0.05
+      }
+    }
+    param{
+      name: "rb32"
+      init{
+      type: kUniform
+      low: -0.05
+      high:0.05
+      }
+    }
+  }
+
+  layer{
+    name: "sigmoid3"
+    type: kSigmoid
+    srclayers:"fc3"
+  }
+
+  layer{
+    name: "fc4"
+    type: kInnerProduct
+    srclayers:"sigmoid3"
+    innerproduct_conf{
+      num_output: 30
+    }
+    param{
+      name: "w4"
+      init{
+      type: kUniform
+      low:-0.05
+      high:0.05
+      }
+    }
+    param{
+      name: "rb42"
+      init{
+      type: kUniform
+      low: -0.05
+      high:0.05
+      }
+    }
+  }
+
+  layer{
+    name: "fc5"
+    type: kInnerProduct
+    #srclayers:"sigmoid4"
+    srclayers:"fc4"
+    innerproduct_conf{
+      num_output: 250
+      transpose: true
+    }
+    param{
+      name: "w5"
+      share_from: "w4"
+    }
+    param{
+      name: "rb41"
+      init{
+      type: kUniform
+      low: -0.05
+      high:0.05
+      }
+    }
+  }
+
+  layer{
+    name: "sigmoid5"
+    type: kSigmoid
+    srclayers:"fc5"
+  }
+  layer{
+    name: "fc6"
+    type: kInnerProduct
+    srclayers:"sigmoid5"
+    innerproduct_conf{
+      num_output: 500
+      transpose: true
+    }
+    param{
+      name: "w6"
+      share_from: "w3"
+    }
+    param{
+      name: "rb31"
+      init{
+      type: kUniform
+      low: -0.05
+      high:0.05
+      }
+    }
+
+  }
+
+  layer{
+    name: "sigmoid6"
+    type: kSigmoid
+    srclayers:"fc6"
+  }
+ layer{
+    name: "fc7"
+    type: kInnerProduct
+    srclayers:"sigmoid6"
+    innerproduct_conf{
+      num_output: 1000
+      transpose: true
+    }
+    param{
+      name: "w7"
+      share_from: "w2"
+    }
+    param{
+      name: "rb21"
+      init{
+      type: kUniform
+      low: -0.05
+      high:0.05
+      }
+    }
+
+  }
+
+  layer{
+    name: "sigmoid7"
+    type: kSigmoid
+    srclayers:"fc7"
+  }
+ layer{
+    name: "fc8"
+    type: kInnerProduct
+    srclayers:"sigmoid7"
+    innerproduct_conf{
+      num_output: 784
+      transpose: true
+    }
+    param{
+      name: "w8"
+      share_from: "w1"
+    }
+    param{
+      name: "rb11"
+      init{
+      type: kUniform
+      low: -0.05
+      high:0.05
+      }
+    }
+
+  }
+
+  layer{
+    name: "sigmoid8"
+    type: kSigmoid
+    srclayers:"fc8"
+  }
+
+  layer{
+    name: "loss"
+    type:kEuclideanLoss
+    srclayers:"sigmoid8"
+    srclayers:"mnist"
+  }
+}
+cluster {
+  nworker_groups: 1
+  nserver_groups: 1
+  workspace: "examples/rbm/checkpoint/autoencoder/"
+}

--- a/examples/rbm/rbm0.conf
+++ b/examples/rbm/rbm0.conf
@@ -1,11 +1,11 @@
-name: "deep-big-simple-dbm"
+name: "rbm0"
 train_steps: 6000
 test_steps:100
 test_freq:100
 disp_freq: 100
-alg: kCD
-checkpoint_after: 500
-checkpoint_freq: 1000
+train_one_batch{
+  alg: kCD
+}
 updater{
   type: kSGD
   momentum: 0.9
@@ -21,7 +21,7 @@ layer {
   name: "data"
   type: kShardData
   sharddata_conf {
-    path: "examples/rbm/mnist_train_shard"
+    path: "examples/mnist/mnist_train_shard"
     batchsize: 100
   }
   exclude: kTest
@@ -32,7 +32,7 @@ layer {
   name: "data"
   type: kShardData
   sharddata_conf {
-    path: "examples/rbm/mnist_test_shard"
+    path: "examples/mnist/mnist_test_shard"
     batchsize: 100
   }
   exclude: kTrain
@@ -54,22 +54,15 @@ layer{
   type: kRBMVis
   srclayers:"mnist"
   srclayers:"RBMHid"
-  rbmvis_conf{
-    num_output: 1000
-  }
   param{
-    name: "w1"
-    init{
-    type: kGaussian
-    mean: 0.0
-    std: 0.1
-    }
+    name: "w1_"
+    share_from: "w1"
   }
   param{
     name: "rb11"
     init{
-    type: kConstant
-    value: 0.0
+      type: kConstant
+      value: 0.0
     }
   }
 }
@@ -82,14 +75,18 @@ layer{
     hid_dim: 1000
   }
   param{
-    name: "w1_1"
-    share_from: "w1"
+    name: "w1"
+    init{
+      type: kGaussian
+      mean: 0.0
+      std: 0.1
+    }
   }
   param{
     name: "rb12"
     init{
-    type: kConstant
-    value: 0.0
+      type: kConstant
+      value: 0.0
     }
   }
 }
@@ -99,5 +96,5 @@ cluster {
   nserver_groups: 1
   nservers_per_group: 1
   nworkers_per_group: 1
-  workspace: "examples/rbm/checkpoint/rbm0/"
+  workspace: "examples/rbm/rbm0/"
 }

--- a/examples/rbm/rbm0.conf
+++ b/examples/rbm/rbm0.conf
@@ -1,0 +1,103 @@
+name: "deep-big-simple-dbm"
+train_steps: 6000
+test_steps:100
+test_freq:100
+disp_freq: 100
+alg: kCD
+checkpoint_after: 500
+checkpoint_freq: 1000
+updater{
+  type: kSGD
+  momentum: 0.9
+  weight_decay: 0.0002
+  learning_rate{
+    base_lr: 0.1
+    type: kFixed
+  }
+}
+
+neuralnet {
+layer {
+  name: "data"
+  type: kShardData
+  sharddata_conf {
+    path: "examples/rbm/mnist_train_shard"
+    batchsize: 100
+  }
+  exclude: kTest
+}
+
+
+layer {
+  name: "data"
+  type: kShardData
+  sharddata_conf {
+    path: "examples/rbm/mnist_test_shard"
+    batchsize: 100
+  }
+  exclude: kTrain
+}
+
+
+layer{
+  name:"mnist"
+  type: kMnist
+  srclayers: "data"
+  mnist_conf {
+    norm_a: 255
+    norm_b: 0
+  }
+}
+
+layer{
+  name: "RBMVis"
+  type: kRBMVis
+  srclayers:"mnist"
+  srclayers:"RBMHid"
+  rbmvis_conf{
+    num_output: 1000
+  }
+  param{
+    name: "w1"
+    init{
+    type: kGaussian
+    mean: 0.0
+    std: 0.1
+    }
+  }
+  param{
+    name: "rb11"
+    init{
+    type: kConstant
+    value: 0.0
+    }
+  }
+}
+
+layer{
+  name: "RBMHid"
+  type: kRBMHid
+  srclayers:"RBMVis"
+  rbmhid_conf{
+    hid_dim: 1000
+  }
+  param{
+    name: "w1_1"
+    share_from: "w1"
+  }
+  param{
+    name: "rb12"
+    init{
+    type: kConstant
+    value: 0.0
+    }
+  }
+}
+}
+cluster {
+  nworker_groups: 1
+  nserver_groups: 1
+  nservers_per_group: 1
+  nworkers_per_group: 1
+  workspace: "examples/rbm/checkpoint/rbm0/"
+}

--- a/examples/rbm/rbm1.conf
+++ b/examples/rbm/rbm1.conf
@@ -1,0 +1,135 @@
+name: "deep-big-simple-dbm"
+train_steps: 6000
+test_steps:100
+test_freq:500
+disp_freq: 100
+alg: kCD
+checkpoint_after: 500
+checkpoint_freq: 1000
+checkpoint_path: "examples/rbm/checkpoint/rbm0/checkpoint/step6000-worker0.bin"
+updater{
+  type: kSGD
+  momentum: 0.9
+  weight_decay: 0.0002
+  learning_rate{
+  base_lr: 0.1
+  type: kFixed
+  }
+}
+
+neuralnet {
+layer {
+  name: "data"
+  type: kShardData
+  sharddata_conf {
+    path: "examples/rbm/mnist_train_shard"
+    batchsize: 100
+  }
+  exclude: kTest
+}
+
+
+layer {
+  name: "data"
+  type: kShardData
+  sharddata_conf {
+    path: "examples/rbm/mnist_test_shard"
+    batchsize: 100
+  }
+  exclude: kTrain
+}
+
+
+layer{
+  name:"mnist"
+  type: kMnist
+  srclayers: "data"
+  mnist_conf {
+    norm_a: 255
+    norm_b: 0
+  }
+}
+
+layer{
+    name: "fc1"
+    type: kInnerProduct
+    srclayers:"mnist"
+    innerproduct_conf{
+      num_output: 1000
+    }
+    param{
+      name: "w1"
+      init{
+      type: kUniform
+      low:-0.05
+      high:0.05
+      }
+    }
+    param{
+      name: "rb12"
+      init{
+      type: kUniform
+      low: -0.05
+      high:0.05
+      }
+    }
+  }
+
+  layer{
+    name: "sigmoid1"
+    type: kSigmoid
+    srclayers:"fc1"
+  }
+
+layer{
+  name: "RBMVis"
+  type: kRBMVis
+  srclayers:"sigmoid1"
+  srclayers:"RBMHid"
+  rbmvis_conf{
+    num_output: 500
+  }
+  param{
+    name: "w2"
+    init{
+    type: kGaussian
+    mean: 0.0
+    std: 0.1
+    }
+  }
+  param{
+    name: "rb21"
+    init{
+    type: kConstant
+    value: 0.0
+    }
+  }
+}
+
+layer{
+  name: "RBMHid"
+  type: kRBMHid
+  srclayers:"RBMVis"
+  rbmhid_conf{
+    hid_dim: 500
+  }
+  param{
+    name: "w2_1"
+    share_from: "w2"
+  }
+  param{
+    name: "rb22"
+    init{
+    type: kConstant
+    value: 0.0
+    }
+  }
+}
+}
+cluster {
+  nworker_groups: 1
+  nserver_groups: 1
+  nservers_per_group: 1
+  nworkers_per_group: 1
+  workspace: "examples/rbm/checkpoint/rbm1/"
+}

--- a/examples/rbm/rbm1.conf
+++ b/examples/rbm/rbm1.conf
@@ -1,12 +1,12 @@
-name: "deep-big-simple-dbm"
+name: "rbm1"
 train_steps: 6000
 test_steps:100
-test_freq:500
+test_freq:1000
 disp_freq: 100
-alg: kCD
-checkpoint_after: 500
-checkpoint_freq: 1000
-checkpoint_path: "examples/rbm/checkpoint/rbm0/checkpoint/step6000-worker0.bin"
+train_one_batch{
+  alg: kCD
+}
+checkpoint_path: "examples/rbm/rbm0/checkpoint/step6000-worker0.bin"
 updater{
   type: kSGD
   momentum: 0.9
@@ -22,7 +22,7 @@ layer {
   name: "data"
   type: kShardData
   sharddata_conf {
-    path: "examples/rbm/mnist_train_shard"
+    path: "examples/mnist/mnist_train_shard"
     batchsize: 100
   }
   exclude: kTest
@@ -33,7 +33,7 @@ layer {
   name: "data"
   type: kShardData
   sharddata_conf {
-    path: "examples/rbm/mnist_test_shard"
+    path: "examples/mnist/mnist_test_shard"
     batchsize: 100
   }
   exclude: kTrain
@@ -51,51 +51,34 @@ layer{
 }
 
 layer{
-    name: "fc1"
-    type: kInnerProduct
-    srclayers:"mnist"
-    innerproduct_conf{
-      num_output: 1000
-    }
-    param{
-      name: "w1"
-      init{
-      type: kUniform
-      low:-0.05
-      high:0.05
-      }
-    }
-    param{
-      name: "rb12"
-      init{
-      type: kUniform
-      low: -0.05
-      high:0.05
-      }
-    }
+  name: "fc1"
+  type: kInnerProduct
+  srclayers:"mnist"
+  innerproduct_conf{
+    num_output: 1000
   }
+  param{
+    name: "w1"
+  }
+  param{
+    name: "rb12"
+  }
+}
 
-  layer{
-    name: "sigmoid1"
-    type: kSigmoid
-    srclayers:"fc1"
-  }
+layer{
+  name: "sigmoid1"
+  type: kSigmoid
+  srclayers:"fc1"
+}
 
 layer{
   name: "RBMVis"
   type: kRBMVis
   srclayers:"sigmoid1"
   srclayers:"RBMHid"
-  rbmvis_conf{
-    num_output: 500
-  }
   param{
-    name: "w2"
-    init{
-    type: kGaussian
-    mean: 0.0
-    std: 0.1
-    }
+    name: "w2_"
+    share_from: "w2"
   }
   param{
     name: "rb21"
@@ -114,14 +97,18 @@ layer{
     hid_dim: 500
   }
   param{
-    name: "w2_1"
-    share_from: "w2"
+    name: "w2"
+    init{
+      type: kGaussian
+      mean: 0.0
+      std: 0.1
+    }
   }
   param{
     name: "rb22"
     init{
-    type: kConstant
-    value: 0.0
+      type: kConstant
+      value: 0.0
     }
   }
 }
@@ -131,5 +118,5 @@ cluster {
   nserver_groups: 1
   nservers_per_group: 1
   nworkers_per_group: 1
-  workspace: "examples/rbm/checkpoint/rbm1/"
+  workspace: "examples/rbm/rbm1/"
 }

--- a/examples/rbm/rbm2.conf
+++ b/examples/rbm/rbm2.conf
@@ -1,0 +1,167 @@
+name: "deep-big-simple-dbm"
+train_steps: 6000
+test_steps:100
+test_freq:100
+disp_freq: 100
+alg: kCD
+checkpoint_after: 500
+checkpoint_freq: 1000
+checkpoint_path: "examples/rbm/checkpoint/rbm1/checkpoint/step6000-worker0.bin"
+
+updater{
+  type: kSGD
+  momentum: 0.9
+  weight_decay: 0.0002
+  learning_rate{
+    base_lr: 0.1
+    type: kFixed
+  }
+}
+
+
+neuralnet {
+layer {
+  name: "data"
+  type: kShardData
+  sharddata_conf {
+    path: "examples/rbm/mnist_train_shard"
+    batchsize: 100
+  }
+  exclude: kTest
+}
+
+
+layer {
+  name: "data"
+  type: kShardData
+  sharddata_conf {
+    path: "examples/rbm/mnist_test_shard"
+    batchsize: 100
+  }
+  exclude: kTrain
+}
+
+
+layer{
+  name:"mnist"
+  type: kMnist
+  srclayers: "data"
+  mnist_conf {
+    norm_a: 255
+    norm_b: 0
+  }
+}
+
+layer{
+    name: "fc1"
+    type: kInnerProduct
+    srclayers:"mnist"
+    innerproduct_conf{
+      num_output: 1000
+    }
+    param{
+      name: "w1"
+      init {
+      type: kUniform
+      low:-0.05
+      high:0.05
+      }
+    }
+    param{
+      name: "rb12"
+      init{
+      type: kUniform
+      low: -0.05
+      high:0.05
+      }
+    }
+  }
+
+  layer{
+    name: "sigmoid1"
+    type: kSigmoid
+    srclayers:"fc1"
+  }
+
+layer{
+    name: "fc2"
+    type: kInnerProduct
+    srclayers:"sigmoid1"
+    innerproduct_conf{
+      num_output: 500
+    }
+    param{
+      name: "w2"
+      init{
+      type: kUniform
+      low:-0.05
+      high:0.05
+      }
+    }
+    param{
+      name: "rb22"
+      init{
+      type: kUniform
+      low: -0.05
+      high:0.05
+      }
+    }
+  }
+
+  layer{
+    name: "sigmoid2"
+    type: kSigmoid
+    srclayers:"fc2"
+  }
+layer{
+  name: "RBMVis"
+  type: kRBMVis
+  srclayers:"sigmoid2"
+  srclayers:"RBMHid"
+  rbmvis_conf{
+    num_output: 250
+  }
+  param{
+    name: "w3"
+    init{
+    type: kGaussian
+    mean: 0.0
+    std: 0.1
+    }
+  }
+  param{
+    name: "rb31"
+    init{
+    type: kConstant
+    value: 0.0
+    }
+  }
+}
+
+layer{
+  name: "RBMHid"
+  type: kRBMHid
+  srclayers:"RBMVis"
+  rbmhid_conf{
+    hid_dim: 250
+  }
+  param{
+    name: "w3_1"
+    share_from: "w3"
+  }
+  param{
+    name: "rb32"
+    init{
+    type: kConstant
+    value: 0.0
+    }
+  }
+}
+}
+cluster {
+  nworker_groups: 1
+  nserver_groups: 1
+  nservers_per_group: 1
+  nworkers_per_group: 1
+  workspace: "examples/rbm/checkpoint/rbm2/"
+}

--- a/examples/rbm/rbm2.conf
+++ b/examples/rbm/rbm2.conf
@@ -1,12 +1,12 @@
-name: "deep-big-simple-dbm"
+name: "rbm2"
 train_steps: 6000
 test_steps:100
-test_freq:100
+test_freq:1000
 disp_freq: 100
-alg: kCD
-checkpoint_after: 500
-checkpoint_freq: 1000
-checkpoint_path: "examples/rbm/checkpoint/rbm1/checkpoint/step6000-worker0.bin"
+train_one_batch{
+  alg: kCD
+}
+checkpoint_path: "examples/rbm/rbm1/checkpoint/step6000-worker0.bin"
 
 updater{
   type: kSGD
@@ -24,7 +24,7 @@ layer {
   name: "data"
   type: kShardData
   sharddata_conf {
-    path: "examples/rbm/mnist_train_shard"
+    path: "examples/mnist/mnist_train_shard"
     batchsize: 100
   }
   exclude: kTest
@@ -35,7 +35,7 @@ layer {
   name: "data"
   type: kShardData
   sharddata_conf {
-    path: "examples/rbm/mnist_test_shard"
+    path: "examples/mnist/mnist_test_shard"
     batchsize: 100
   }
   exclude: kTrain
@@ -61,19 +61,9 @@ layer{
     }
     param{
       name: "w1"
-      init {
-      type: kUniform
-      low:-0.05
-      high:0.05
-      }
     }
     param{
       name: "rb12"
-      init{
-      type: kUniform
-      low: -0.05
-      high:0.05
-      }
     }
   }
 
@@ -92,19 +82,9 @@ layer{
     }
     param{
       name: "w2"
-      init{
-      type: kUniform
-      low:-0.05
-      high:0.05
-      }
     }
     param{
       name: "rb22"
-      init{
-      type: kUniform
-      low: -0.05
-      high:0.05
-      }
     }
   }
 
@@ -118,16 +98,9 @@ layer{
   type: kRBMVis
   srclayers:"sigmoid2"
   srclayers:"RBMHid"
-  rbmvis_conf{
-    num_output: 250
-  }
   param{
-    name: "w3"
-    init{
-    type: kGaussian
-    mean: 0.0
-    std: 0.1
-    }
+    name: "w3_"
+    share_from: "w3"
   }
   param{
     name: "rb31"
@@ -146,8 +119,12 @@ layer{
     hid_dim: 250
   }
   param{
-    name: "w3_1"
-    share_from: "w3"
+    name: "w3"
+    init{
+      type: kGaussian
+      mean: 0.0
+      std: 0.1
+    }
   }
   param{
     name: "rb32"
@@ -163,5 +140,5 @@ cluster {
   nserver_groups: 1
   nservers_per_group: 1
   nworkers_per_group: 1
-  workspace: "examples/rbm/checkpoint/rbm2/"
+  workspace: "examples/rbm/rbm2/"
 }

--- a/examples/rbm/rbm3.conf
+++ b/examples/rbm/rbm3.conf
@@ -1,12 +1,12 @@
-name: "deep-big-simple-dbm"
+name: "rbm3"
 train_steps: 6000
 test_steps: 100
-test_freq: 100
+test_freq: 1000
 disp_freq: 100
-alg: kCD
-checkpoint_after: 500
-checkpoint_freq: 1000
-checkpoint_path: "examples/rbm/checkpoint/rbm2/checkpoint/step6000-worker0.bin"
+train_one_batch{
+  alg: kCD
+}
+checkpoint_path: "examples/rbm/rbm2/checkpoint/step6000-worker0.bin"
 updater{
     type: kSGD
     momentum: 0.9
@@ -22,7 +22,7 @@ layer {
   name: "data"
   type: kShardData
   sharddata_conf {
-    path: "examples/rbm/mnist_train_shard"
+    path: "examples/mnist/mnist_train_shard"
     batchsize: 100
   }
   exclude: kTest
@@ -33,7 +33,7 @@ layer {
   name: "data"
   type: kShardData
   sharddata_conf {
-    path: "examples/rbm/mnist_test_shard"
+    path: "examples/mnist/mnist_test_shard"
     batchsize: 100
   }
   exclude: kTrain
@@ -59,19 +59,9 @@ layer{
     }
     param{
       name: "w1"
-      init{
-      type: kUniform
-      low:-0.05
-      high:0.05
-      }
     }
     param{
       name: "rb12"
-      init{
-      type: kUniform
-      low: -0.05
-      high:0.05
-      }
     }
   }
 
@@ -90,19 +80,9 @@ layer{
     }
     param{
       name: "w2"
-      init{
-      type: kUniform
-      low:-0.05
-      high:0.05
-      }
     }
     param{
       name: "rb22"
-      init{
-      type: kUniform
-      low: -0.05
-      high:0.05
-      }
     }
   }
 
@@ -121,19 +101,9 @@ layer{
     }
     param{
       name: "w3"
-      init{
-      type: kUniform
-      low:-0.05
-      high:0.05
-      }
     }
     param{
       name: "rb32"
-      init{
-      type: kUniform
-      low: -0.05
-      high:0.05
-      }
     }
   }
 
@@ -148,16 +118,10 @@ layer{
   type: kRBMVis
   srclayers:"sigmoid3"
   srclayers:"RBMHid"
-  rbmvis_conf{
-    num_output: 30
-  }
   param{
-    name: "w4"
-    init{
-    type: kGaussian
-    mean: 0.0
-    std: 0.1
-    }
+    name: "w4_"
+    share_from: "w4"
+
   }
   param{
     name: "rb41"
@@ -177,8 +141,12 @@ layer{
     gaussian: true
   }
   param{
-    name: "w4_1"
-    share_from: "w4"
+    name: "w4"
+    init{
+      type: kGaussian
+      mean: 0.0
+      std: 0.1
+    }
   }
   param{
     name: "rb42"
@@ -194,5 +162,5 @@ cluster {
   nserver_groups: 1
   nservers_per_group: 1
   nworkers_per_group: 1
-  workspace: "examples/rbm/checkpoint/rbm3/"
+  workspace: "examples/rbm/rbm3/"
 }

--- a/examples/rbm/rbm3.conf
+++ b/examples/rbm/rbm3.conf
@@ -1,0 +1,198 @@
+name: "deep-big-simple-dbm"
+train_steps: 6000
+test_steps: 100
+test_freq: 100
+disp_freq: 100
+alg: kCD
+checkpoint_after: 500
+checkpoint_freq: 1000
+checkpoint_path: "examples/rbm/checkpoint/rbm2/checkpoint/step6000-worker0.bin"
+updater{
+    type: kSGD
+    momentum: 0.9
+    weight_decay: 0.0002
+    learning_rate{
+      base_lr: 0.001
+      type: kFixed
+    }
+}
+
+neuralnet {
+layer {
+  name: "data"
+  type: kShardData
+  sharddata_conf {
+    path: "examples/rbm/mnist_train_shard"
+    batchsize: 100
+  }
+  exclude: kTest
+}
+
+
+layer {
+  name: "data"
+  type: kShardData
+  sharddata_conf {
+    path: "examples/rbm/mnist_test_shard"
+    batchsize: 100
+  }
+  exclude: kTrain
+}
+
+
+layer{
+  name:"mnist"
+  type: kMnist
+  srclayers: "data"
+  mnist_conf {
+    norm_a: 255
+    norm_b: 0
+  }
+}
+
+layer{
+    name: "fc1"
+    type: kInnerProduct
+    srclayers:"mnist"
+    innerproduct_conf{
+      num_output: 1000
+    }
+    param{
+      name: "w1"
+      init{
+      type: kUniform
+      low:-0.05
+      high:0.05
+      }
+    }
+    param{
+      name: "rb12"
+      init{
+      type: kUniform
+      low: -0.05
+      high:0.05
+      }
+    }
+  }
+
+  layer{
+    name: "sigmoid1"
+    type: kSigmoid
+    srclayers:"fc1"
+  }
+
+layer{
+    name: "fc2"
+    type: kInnerProduct
+    srclayers:"sigmoid1"
+    innerproduct_conf{
+      num_output: 500
+    }
+    param{
+      name: "w2"
+      init{
+      type: kUniform
+      low:-0.05
+      high:0.05
+      }
+    }
+    param{
+      name: "rb22"
+      init{
+      type: kUniform
+      low: -0.05
+      high:0.05
+      }
+    }
+  }
+
+  layer{
+    name: "sigmoid2"
+    type: kSigmoid
+    srclayers:"fc2"
+  }
+
+layer{
+    name: "fc3"
+    type: kInnerProduct
+    srclayers:"sigmoid2"
+    innerproduct_conf{
+      num_output: 250
+    }
+    param{
+      name: "w3"
+      init{
+      type: kUniform
+      low:-0.05
+      high:0.05
+      }
+    }
+    param{
+      name: "rb32"
+      init{
+      type: kUniform
+      low: -0.05
+      high:0.05
+      }
+    }
+  }
+
+  layer{
+    name: "sigmoid3"
+    type: kSigmoid
+    srclayers:"fc3"
+  }
+
+layer{
+  name: "RBMVis"
+  type: kRBMVis
+  srclayers:"sigmoid3"
+  srclayers:"RBMHid"
+  rbmvis_conf{
+    num_output: 30
+  }
+  param{
+    name: "w4"
+    init{
+    type: kGaussian
+    mean: 0.0
+    std: 0.1
+    }
+  }
+  param{
+    name: "rb41"
+    init{
+    type: kConstant
+    value: 0.0
+    }
+  }
+}
+
+layer{
+  name: "RBMHid"
+  type: kRBMHid
+  srclayers:"RBMVis"
+  rbmhid_conf{
+    hid_dim: 30
+    gaussian: true
+  }
+  param{
+    name: "w4_1"
+    share_from: "w4"
+  }
+  param{
+    name: "rb42"
+    init{
+    type: kConstant
+    value: 0.0
+    }
+  }
+}
+}
+cluster {
+  nworker_groups: 1
+  nserver_groups: 1
+  nservers_per_group: 1
+  nworkers_per_group: 1
+  workspace: "examples/rbm/checkpoint/rbm3/"
+}

--- a/include/mshadow/tensor_random.h
+++ b/include/mshadow/tensor_random.h
@@ -68,20 +68,27 @@ namespace mshadow {
             gen_.seed(seed);
             #endif
         }
+        template<int dim>
+        inline void SampleBinary(Tensor<cpu, dim> &src) {
+          SampleBinary(src, src);
+        }
+
         /*!
          * \brief generate binary data according to a probability matrix
+         * \param src source
          * \param dst destination
          * \param a lower bound of uniform
          * \param b upper bound of uniform
          * \tparam dim dimension of tensor
          */
         template<int dim>
-        inline void SampleBinary( Tensor<cpu, dim> &dst) {
+        inline void SampleBinary(Tensor<cpu, dim> &dst, Tensor<cpu, dim> &src) {
             real_t a=0.0f;
             real_t b=1.0f;
-            Tensor<cpu, 2> mat = dst.FlatTo2D();
+            Tensor<cpu, 2> dmat = dst.FlatTo2D();
+            Tensor<cpu, 2> smat = src.FlatTo2D();
             std::uniform_real_distribution<real_t> distribution (a,b);
-            for ( index_t i = 0; i < mat.shape[1]; ++i ) {
+            for ( index_t i = 0; i < dmat.shape[1]; ++i ) {
                 #if MSHADOW_USE_MKL
                 #if MSHADOW_SINGLE_PRECISION
                 int status = vsRngUniform( 0, vStream_, mat.shape[0], mat[i].dptr, a, b );
@@ -96,8 +103,8 @@ namespace mshadow {
                     mat[i][j] = this->RandNext()*(b-a) + a;
                 }
                 */
-                for ( index_t j = 0; j < mat.shape[0]; ++j ) {
-                    mat[i][j] = distribution(gen_) > mat[i][j] ? 0.0f: 1.0f;
+                for ( index_t j = 0; j < dmat.shape[0]; ++j ) {
+                    dmat[i][j] = distribution(gen_) > smat[i][j] ? 0.0f: 1.0f;
                 }
                 #endif
             }

--- a/include/trainer/worker.h
+++ b/include/trainer/worker.h
@@ -192,15 +192,9 @@ class BPWorker: public Worker{
 
 class CDWorker: public Worker{
  public:
-  ~CDWorker() {}
-  void Init(int thread_id, int grp_id, int id) override;
   void TrainOneBatch(int step, Metric* perf) override;
   void TestOneBatch(int step, Phase phase, shared_ptr<NeuralNet> net,
       Metric* perf) override;
-  void PositivePhase(int step, shared_ptr<NeuralNet> net, Metric* perf);
-  void NegativePhase(int step, shared_ptr<NeuralNet> net, Metric* perf);
-  void GradientPhase(int step, shared_ptr<NeuralNet> net);
-  void LossPhase(int step, shared_ptr<NeuralNet> net, Metric* perf);
 };
 
 inline int BlobTrgt(int grp, int layer) {

--- a/include/trainer/worker.h
+++ b/include/trainer/worker.h
@@ -193,10 +193,10 @@ class BPWorker: public Worker{
 class CDWorker: public Worker{
  public:
   ~CDWorker() {}
-  void Init(int thread_id, int group_id, int worker_id) override;
+  void Init(int thread_id, int grp_id, int id) override;
   void TrainOneBatch(int step, Metric* perf) override;
-  void TestOneBatch(int step, Phase phase,
-       shared_ptr<NeuralNet> net, Metric* perf) override;
+  void TestOneBatch(int step, Phase phase, shared_ptr<NeuralNet> net,
+      Metric* perf) override;
   void PositivePhase(int step, shared_ptr<NeuralNet> net, Metric* perf);
   void NegativePhase(int step, shared_ptr<NeuralNet> net, Metric* perf);
   void GradientPhase(int step, shared_ptr<NeuralNet> net);

--- a/include/utils/param.h
+++ b/include/utils/param.h
@@ -74,13 +74,14 @@ class Param {
   static Param* Create(const ParamProto& proto);
   Param();
   virtual ~Param() {}
+  void Init(const ParamProto& proto) { proto_ = proto; }
   /**
    * Setup param object
    *
    * @param conf param configuration, include learning rate multiplier etc.
    * @param shape one value per dimension
    */
-  virtual void Setup(const ParamProto& conf, const std::vector<int>& shape);
+  virtual void Setup(const std::vector<int>& shape);
   /*
    * Fill the values according to init method, e.g., gaussian distribution.
    *

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -1,8 +1,11 @@
-#include "singa.h"
 
 #include <cblas.h>
 #include <glog/logging.h>
 #include <string>
+
+#include "singa.h"
+
+#include "utils/tinydir.h"
 
 namespace singa {
 
@@ -89,6 +92,9 @@ void Driver::Submit(bool resume, const JobProto& jobConf) {
   if (singa_conf_.has_log_dir())
     SetupLog(singa_conf_.log_dir(), std::to_string(job_id_)
              + "-" + jobConf.name());
+  tinydir_dir workspace;
+  if (tinydir_open(&workspace, jobConf.cluster().workspace().c_str()) == -1)
+    LOG(FATAL) << "workspace does not exist: " << jobConf.cluster().workspace();
   if (jobConf.num_openblas_threads() != 1)
     LOG(WARNING) << "openblas with "
       << jobConf.num_openblas_threads() << " threads";

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -31,21 +31,23 @@ void Driver::Init(int argc, char **argv) {
   RegisterLayer<ConvolutionLayer, int>(kConvolution);
   RegisterLayer<ConcateLayer, int>(kConcate);
   RegisterLayer<DropoutLayer, int>(kDropout);
+  RegisterLayer<EuclideanLossLayer, int>(kEuclideanLoss);
   RegisterLayer<InnerProductLayer, int>(kInnerProduct);
   RegisterLayer<LabelLayer, int>(kLabel);
   RegisterLayer<LRNLayer, int>(kLRN);
   RegisterLayer<MnistLayer, int>(kMnist);
   RegisterLayer<PrefetchLayer, int>(kPrefetch);
   RegisterLayer<PoolingLayer, int>(kPooling);
+  RegisterLayer<RBMHidLayer, int>(kRBMHid);
+  RegisterLayer<RBMVisLayer, int>(kRBMVis);
   RegisterLayer<RGBImageLayer, int>(kRGBImage);
   RegisterLayer<ReLULayer, int>(kReLU);
   RegisterLayer<ShardDataLayer, int>(kShardData);
+  RegisterLayer<SigmoidLayer, int>(kSigmoid);
   RegisterLayer<SliceLayer, int>(kSlice);
   RegisterLayer<SoftmaxLossLayer, int>(kSoftmaxLoss);
   RegisterLayer<SplitLayer, int>(kSplit);
   RegisterLayer<TanhLayer, int>(kTanh);
-  RegisterLayer<RBMVisLayer, int>(kRBMVis);
-  RegisterLayer<RBMHidLayer, int>(kRBMHid);
 #ifdef USE_LMDB
   RegisterLayer<LMDBDataLayer, int>(kLMDBData);
 #endif

--- a/src/proto/job.proto
+++ b/src/proto/job.proto
@@ -166,6 +166,8 @@ message LayerProto {
   optional ConcateProto concate_conf = 31;
   // configuration for dropout layer
   optional DropoutProto dropout_conf = 33;
+  // configuration for euclideanloss layer
+  optional EuclideanLossProto euclideanloss_conf = 50;
   // configuration for inner product layer
   optional InnerProductProto innerproduct_conf = 34;
   // configuration for local response normalization layer
@@ -178,6 +180,10 @@ message LayerProto {
   optional PoolingProto pooling_conf = 37;
   // configuration for prefetch layer
   optional PrefetchProto prefetch_conf = 44;
+  // configuration for rbmhid layer
+  optional RBMHidProto rbmhid_conf = 49;
+  // configuration for rbmvis layer
+  optional RBMVisProto rbmvis_conf = 48;
   // configuration for rectified linear unit layer
   optional ReLUProto relu_conf = 38;
   // configuration for rgb image parser layer
@@ -192,10 +198,7 @@ message LayerProto {
   optional SplitProto split_conf = 42;
   // configuration for tanh layer
   optional TanhProto tanh_conf = 43;
-  // configuration for rbmvis layer
-  optional RBMVisProto rbmvis_conf = 48;
-  // configuration for rbmhid layer
-  optional RBMHidProto rbmhid_conf = 49;
+
 
   // overrides the partition dimension for neural net
   optional int32 partition_dim = 60 [default = -1];
@@ -299,6 +302,9 @@ message TanhProto {
   optional float inner_scale = 2 [default = 1.0];
 }
 
+message EuclideanLossProto {
+}
+
 message SoftmaxLossProto {
   // computing accuracy against topk results
   optional int32 topk = 1 [default = 1];
@@ -367,6 +373,7 @@ message RBMVisProto {
 message RBMHidProto {
   optional int32 hid_dim = 1; // The number of outputs for the layer
   optional bool bias_term = 2 [default = true]; // whether to have bias terms
+  optional bool gaussian = 3 [default = false]; // use gaussian sampling or not
 }
 
 // Message that stores parameters used by InnerProductLayer
@@ -375,6 +382,8 @@ message InnerProductProto {
   required int32 num_output = 1;
   // use bias vector or not
   optional bool bias_term = 30 [default = true];
+  // transpose or not
+  optional bool transpose = 31 [default = false];
 }
 
 message LRNProto {
@@ -524,12 +533,14 @@ enum LayerType {
   kLRN = 6;
   kPooling = 8;
   kReLU = 9;
-  kRBMHid = 24;
   kRBMVis = 23;
+  kRBMHid = 24;
+  kSigmoid = 26;
   kTanh = 14;
   // Loss layers
   //  - Compute objective loss
   kSoftmaxLoss = 11;
+  kEuclideanLoss = 25;
   // Other layers
   //  - Connect layers when neural net is partitioned
   kBridgeDst = 16;

--- a/src/proto/job.proto
+++ b/src/proto/job.proto
@@ -21,18 +21,12 @@ message JobProto {
   required string name = 1;
   // neural net consits of a set of connected layers
   required NetProto neuralnet = 3;
-  // algorithms calculating gradients for one mini-batch/iteration
-  optional TrainOneBatchAlg alg = 5 [default = kUserAlg];
-  // user defined algorithm
-  optional string user_alg = 6;
+  // algorithm for computing gradients over one mini-batch
+  required AlgProto train_one_batch = 5;
   // configuration of SGD updater, including learning rate, etc.
   required UpdaterProto updater = 7;
   // cluster toplogy conf
   required ClusterProto cluster = 9;
-
-  // for setting CD fields
-  optional CDProto cd_conf = 12;
-
   // total num of steps for training
   required int32 train_steps = 16;
   // frequency of displaying training info
@@ -86,6 +80,16 @@ message JobProto {
 // Protos used by JobProto
 // -----------------------
 
+message AlgProto {
+  // algorithms calculating gradients for one mini-batch/iteration
+  optional AlgType alg = 1 [default = kUserAlg];
+  // user defined algorithm
+  optional string user_alg = 2;
+  // for setting CD fields
+  optional CDProto cd_conf = 10;
+
+  extensions 101 to 200;
+}
 message NetProto {
   repeated LayerProto layer = 1;
   // partitioning type for parallelism
@@ -140,7 +144,7 @@ message ClusterProto {
 
 message CDProto {
   //number of steps for gibbs sampling
-  optional int32 pcd_k = 1 [default = 1];
+  optional int32 cd_k = 1 [default = 1];
 }
 
 message LayerProto {
@@ -182,8 +186,6 @@ message LayerProto {
   optional PrefetchProto prefetch_conf = 44;
   // configuration for rbmhid layer
   optional RBMHidProto rbmhid_conf = 49;
-  // configuration for rbmvis layer
-  optional RBMVisProto rbmvis_conf = 48;
   // configuration for rectified linear unit layer
   optional ReLUProto relu_conf = 38;
   // configuration for rgb image parser layer
@@ -363,11 +365,6 @@ message MnistProto {
 message DropoutProto {
   // dropout ratio
   optional float dropout_ratio = 30 [default = 0.5];
-}
-
-message RBMVisProto {
-  optional int32 num_output = 1; // The number of outputs for the layer
-  optional bool bias_term = 2 [default = true]; // whether to have bias terms
 }
 
 message RBMHidProto {
@@ -559,16 +556,16 @@ enum PartitionType {
 }
 
 enum Phase {
-  kTrain = 0;
-  kValidation = 1;
-  kTest= 2;
+  kTrain = 1;
+  kValidation = 2;
+  kTest= 4;
   // postivie phase for contrastive divergence algorithm
-  kPositive = 3;
+  kPositive = 8;
   // negative phase for contrastive divergence algorithm
-  kNegative = 4;
-  kForward = 5;
-  kBackward = 6;
-  kLoss = 7;
+  kNegative = 16;
+  kForward = 32;
+  kBackward = 64;
+  kLoss = 128;
 }
 
 enum ParamType {
@@ -578,7 +575,7 @@ enum ParamType {
   kUser = 103;
 }
 
-enum TrainOneBatchAlg {
+enum AlgType {
   // Back-propagation algorithm for feed-forward models, e.g., CNN and RNN
   kBP = 1;
   // Contrastive Divergence algorithm for RBM, DBM, etc.

--- a/src/utils/common.cc
+++ b/src/utils/common.cc
@@ -40,7 +40,7 @@ string IntVecToString(const vector<int>& vec) {
  *  * Formatted string.
  *   */
 string VStringPrintf(string fmt, va_list l) {
-  char buffer[32768];
+  char buffer[4096];
   vsnprintf(buffer, sizeof(buffer), fmt.c_str(), l);
   return string(buffer);
 }


### PR DESCRIPTION
This is to implement RBM in SINGA.
To training RBM models, the Contrastive Divergence (CD) algorithm is implemented.
We have implemented a BPWorker to run the Back-Propagation algorithm. To implement the CD algorithm, we follow the same way
to create a CDWorker whose RunOneBatch function controls the logic of the CD algorithm, including positive phase,
negative phase and computing gradient phase. RBM's layers are different to the layers for feed-forward neural networks,
hence new layers for RBM models are added.