### PR TITLE
SINGA-60 Make learning rate and param init modular

### DIFF
--- a/examples/cifar10/job.conf
+++ b/examples/cifar10/job.conf
@@ -5,16 +5,18 @@ test_freq:300
 disp_freq:30
 alg: kBP
 updater{
-  weight_decay:0.004
-  lr_change: kFixedStep
   type: kSGD
-  fixedstep_conf:{
-    step:0
-    step:60000
-    step:65000
-    step_lr:0.001
-    step_lr:0.0001
-    step_lr:0.00001
+  weight_decay:0.004
+  learning_rate {
+    type: kFixedStep
+    fixedstep_conf:{
+      step:0
+      step:60000
+      step:65000
+      step_lr:0.001
+      step_lr:0.0001
+      step_lr:0.00001
+    }
   }
 }
 neuralnet {
@@ -63,15 +65,18 @@ neuralnet {
     }
     param {
       name: "w1"
-      init_method:kGaussian
-      std:0.0001
-      lr_scale:1.0
+      init {
+        type:kGaussian
+        std:0.0001
+      }
     }
     param {
       name: "b1"
-      init_method: kConstant
       lr_scale:2.0
-      value:0
+      init {
+        type: kConstant
+        value:0
+      }
     }
   }
 
@@ -112,15 +117,18 @@ neuralnet {
     }
     param {
       name: "w2"
-      init_method:kGaussian
-      std:0.01
-      lr_scale:1.0
+      init {
+        type:kGaussian
+        std:0.01
+      }
     }
     param {
       name: "b2"
-      init_method: kConstant
       lr_scale:2.0
-      value:0
+      init {
+        type: kConstant
+        value:0
+      }
     }
   }
   layer {
@@ -160,13 +168,17 @@ neuralnet {
     }
     param {
       name: "w3"
-      init_method:kGaussian
-      std:0.01
+      init {
+        type:kGaussian
+        std:0.01
+      }
     }
     param {
       name: "b3"
-      init_method: kConstant
-      value:0
+      init {
+        type: kConstant
+        value:0
+      }
     }
   }
   layer {
@@ -193,17 +205,20 @@ neuralnet {
     }
     param {
       name: "w4"
-      init_method:kGaussian
-      std:0.01
-      lr_scale:1.0
       wd_scale:250
+      init {
+        type:kGaussian
+        std:0.01
+      }
     }
     param {
       name: "b4"
-      init_method: kConstant
       lr_scale:2.0
       wd_scale:0
-      value:0
+      init {
+        type: kConstant
+        value:0
+      }
     }
   }
 

--- a/examples/mnist/conv.conf
+++ b/examples/mnist/conv.conf
@@ -4,15 +4,17 @@ test_steps:100
 test_freq:500
 disp_freq:50
 alg: kBP
-updater{
-  base_lr:0.01
+updater {
   momentum:0.9
   weight_decay:0.0005
-  lr_change: kInverse
   type: kSGD
-  inverse_conf {
-    gamma:0.0001
-    pow:0.75
+  learning_rate {
+    type : kInverse
+    base_lr:0.01
+    inverse_conf {
+      gamma:0.0001
+      pow:0.75
+    }
   }
 }
 neuralnet {
@@ -61,16 +63,19 @@ neuralnet {
       stride: 1
     }
     param{
-        name: "w1"
-        init_method:kUniformSqrtFanIn
-        lr_scale:1.0
+      name: "w1"
+      init {
+        type : kUniformSqrtFanIn
       }
+    }
     param{
-        name: "b1"
-        init_method: kConstant
-        lr_scale:2.0
+      name: "b1"
+      init {
+        type : kConstant
         value:0
       }
+      lr_scale:2.0
+    }
   }
   layer {
     name: "pool1"
@@ -92,16 +97,19 @@ neuralnet {
       stride: 1
     }
     param{
-        name: "w2"
-        init_method:kUniformSqrtFanIn
-        lr_scale:1.0
+      name: "w2"
+      init {
+        type :kUniformSqrtFanIn
       }
+    }
     param{
-        name: "b2"
-        init_method: kConstant
-        lr_scale:2.0
+      name: "b2"
+      init {
+        type : kConstant
         value:0
       }
+      lr_scale:2.0
+    }
   }
   layer {
     name: "pool2"
@@ -121,17 +129,19 @@ neuralnet {
       num_output: 500
     }
     param{
-        name: "w3"
-        init_method:kUniformSqrtFanIn
-        lr_scale:1.0
+      name: "w3"
+      init {
+        type :kUniformSqrtFanIn
       }
-    param{
-        name: "b3"
-        init_method: kConstant
-        lr_scale:2.0
-        value:0
     }
-
+    param{
+      name: "b3"
+      init {
+        type : kConstant
+        value:0
+      }
+      lr_scale:2.0
+    }
   }
 
   layer {
@@ -149,14 +159,17 @@ neuralnet {
     }
     param {
       name: "w4"
-      init_method:kUniformSqrtFanIn
-      lr_scale:1
+      init {
+        type :kUniformSqrtFanIn
+      }
     }
     param {
       name: "b4"
-      init_method: kConstant
+      init {
+        type : kConstant
+        value:0
+      }
       lr_scale:2
-      value:0
     }
   }
   layer{

--- a/examples/mnist/job.conf
+++ b/examples/mnist/job.conf
@@ -5,12 +5,14 @@ test_freq:60
 disp_freq:10
 alg: kBP
 updater{
-  base_lr: 0.001
-  lr_change: kStep
   type: kSGD
-  step_conf{
-    change_freq: 60
-    gamma: 0.997
+  learning_rate{
+    type : kStep
+    base_lr: 0.001
+    step_conf{
+      change_freq: 60
+      gamma: 0.997
+    }
   }
 }
 
@@ -61,15 +63,19 @@ neuralnet {
     }
     param{
       name: "w1"
-      init_method: kUniform
-      low:-0.05
-      high:0.05
+      init {
+        type: kUniform
+        low:-0.05
+        high:0.05
+      }
     }
     param{
       name: "b1"
-      init_method: kUniform
-      low: -0.05
-      high:0.05
+      init {
+        type : kUniform
+        low: -0.05
+        high:0.05
+      }
     }
   }
 
@@ -87,15 +93,19 @@ neuralnet {
     }
     param{
       name: "w2"
-      init_method: kUniform
-      low:-0.05
-      high:0.05
+      init {
+        type: kUniform
+        low:-0.05
+        high:0.05
+      }
     }
     param{
       name: "b2"
-      init_method: kUniform
-      low: -0.05
-      high:0.05
+      init {
+        type: kUniform
+        low: -0.05
+        high:0.05
+      }
     }
   }
 
@@ -113,15 +123,19 @@ neuralnet {
     }
     param{
       name: "w3"
-      init_method: kUniform
-      low:-0.05
-      high:0.05
+      init{
+        type: kUniform
+        low:-0.05
+        high:0.05
+      }
     }
     param{
       name: "b3"
-      init_method: kUniform
-      low: -0.05
-      high:0.05
+      init {
+        type : kUniform
+        low: -0.05
+        high:0.05
+      }
     }
 
   }
@@ -140,15 +154,19 @@ neuralnet {
     }
     param{
       name: "w4"
-      init_method: kUniform
-      low:-0.05
-      high:0.05
+      init {
+        type : kUniform
+        low:-0.05
+        high:0.05
+      }
     }
     param{
       name: "b4"
-      init_method: kUniform
-      low: -0.05
-      high:0.05
+      init {
+        type : kUniform
+        low: -0.05
+        high:0.05
+      }
     }
 
   }
@@ -167,15 +185,19 @@ neuralnet {
     }
     param{
       name: "w5"
-      init_method: kUniform
-      low:-0.05
-      high:0.05
+      init {
+        type : kUniform
+        low:-0.05
+        high:0.05
+      }
     }
     param{
       name: "b5"
-      init_method: kUniform
-      low: -0.05
-      high:0.05
+      init {
+        type : kUniform
+        low: -0.05
+        high:0.05
+      }
     }
 
   }
@@ -194,15 +216,19 @@ neuralnet {
     }
     param{
       name: "w6"
-      init_method: kUniform
-      low:-0.05
-      high:0.05
+      init {
+        type : kUniform
+        low:-0.05
+        high:0.05
+      }
     }
     param{
       name: "b6"
-      init_method: kUniform
-      low: -0.05
-      high:0.05
+      init {
+        type : kUniform
+        low: -0.05
+        high:0.05
+      }
     }
   }
   layer{

--- a/include/driver.h
+++ b/include/driver.h
@@ -34,6 +34,16 @@ class Driver {
   template<typename Subclass, typename Type>
   int RegisterUpdater(const Type& type);
   /**
+   * Register a learning rate generator subclasses.
+   *
+   * @param type ID of the subclass. If called to register built-in subclasses,
+   * it is from ChangeMethod; if called to register user-defined
+   * subclass, it is a string;
+   * @return 0 if success; otherwise -1.
+   */
+  template<typename Subclass, typename Type>
+  int RegisterLRGenerator(const Type& type);
+  /**
    * Register a Worker subclass.
    *
    * @param type ID of the subclass. If called to register built-in subclasses,
@@ -53,6 +63,17 @@ class Driver {
    */
   template<typename Subclass, typename Type>
   int RegisterParam(const Type& type);
+  /**
+   * Register ParamGenerator subclasses for initalizing Param objects.
+   *
+   * @param type ID of the subclass. If called to register built-in subclasses,
+   * it is from InitMethod; if called to register user-defined
+   * subclass, it is a string;
+   * @return 0 if success; otherwise -1.
+   */
+  template<typename Subclass, typename Type>
+  int RegisterParamGenerator(const Type& type);
+
   /**
    * Submit the job configuration for starting the job.
    * @param resume resume from last checkpoint if true.
@@ -90,9 +111,21 @@ int Driver::RegisterParam(const Type& type) {
   return 1;
 }
 template<typename Subclass, typename Type>
+int Driver::RegisterParamGenerator(const Type& type) {
+  auto factory = Singleton<Factory<singa::ParamGenerator>>::Instance();
+  factory->Register(type, CreateInstance(Subclass, ParamGenerator));
+  return 1;
+}
+template<typename Subclass, typename Type>
 int Driver::RegisterUpdater(const Type& type) {
   auto factory = Singleton<Factory<singa::Updater>>::Instance();
   factory->Register(type, CreateInstance(Subclass, Updater));
+  return 1;
+}
+template<typename Subclass, typename Type>
+int Driver::RegisterLRGenerator(const Type& type) {
+  auto factory = Singleton<Factory<singa::LRGenerator>>::Instance();
+  factory->Register(type, CreateInstance(Subclass, LRGenerator));
   return 1;
 }
 template<typename Subclass, typename Type>

--- a/include/trainer/worker.h
+++ b/include/trainer/worker.h
@@ -2,7 +2,6 @@
 #define SINGA_TRAINER_WORKER_H_
 #include "neuralnet/neuralnet.h"
 #include "proto/job.pb.h"
-#include "utils/updater.h"
 #include "communication/socket.h"
 
 namespace singa {
@@ -177,7 +176,6 @@ class Worker {
   JobProto job_conf_;
   shared_ptr<NeuralNet> train_net_, test_net_, validation_net_;
   Dealer* layer_dealer_, *dealer_;
-  Updater* updater_;
 };
 
 class BPWorker: public Worker{

--- a/include/utils/param.h
+++ b/include/utils/param.h
@@ -6,6 +6,51 @@
 #include "utils/blob.h"
 #include "communication/msg.h"
 
+namespace singa {
+
+/**
+ * Base parameter generator which intializes parameter values.
+ */
+
+class ParamGenerator {
+ public:
+  static ParamGenerator* Create(const ParamGenProto& proto);
+  virtual ~ParamGenerator() {}
+
+  virtual void Init(const ParamGenProto& proto) {
+    proto_ = proto;
+  }
+
+  virtual void Fill(Blob<float>* data);
+
+ protected:
+  ParamGenProto proto_;
+};
+
+class GaussianGen: public ParamGenerator {
+ public:
+  void  Fill(Blob<float>* data) override;
+};
+
+class UniformGen: public ParamGenerator {
+ public:
+  void  Fill(Blob<float>* data) override;
+};
+
+class GaussianSqrtFanInGen: public GaussianGen {
+ public:
+  void  Fill(Blob<float>* data) override;
+};
+
+class UniformSqrtFanInGen: public UniformGen {
+ public:
+  void Fill(Blob<float>* data) override;
+};
+
+class UniformSqrtFanInOutGen: public UniformGen {
+ public:
+  void Fill(Blob<float>* data) override;
+};
 /**
  * Base paramter class.
  *
@@ -24,7 +69,6 @@
  * load-balance among servers. Hence, we slice large Param objects into small
  * pieces. At the server side, one slice is a Param object.
  */
-namespace singa {
 class Param {
  public:
   static Param* Create(const ParamProto& proto);

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -50,18 +50,35 @@ void Driver::Init(int argc, char **argv) {
   RegisterLayer<LMDBDataLayer, int>(kLMDBData);
 #endif
 
-  // register updater
+  // register updaters
   RegisterUpdater<AdaGradUpdater>(kAdaGrad);
   RegisterUpdater<NesterovUpdater>(kNesterov);
   // TODO(wangwei) RegisterUpdater<kRMSPropUpdater>(kRMSProp);
   RegisterUpdater<SGDUpdater>(kSGD);
 
-  // register worker
+  // register learning rate change methods
+  RegisterLRGenerator<LRGenerator>(kFixed);
+  RegisterLRGenerator<FixedStepLRGen>(kFixedStep);
+  RegisterLRGenerator<StepLRGen>(kStep);
+  RegisterLRGenerator<LinearLRGen>(kLinear);
+  RegisterLRGenerator<ExpLRGen>(kExponential);
+  RegisterLRGenerator<InvLRGen>(kInverse);
+  RegisterLRGenerator<InvTLRGen>(kInverseT);
+
+  // register workers
   RegisterWorker<BPWorker>(kBP);
   RegisterWorker<CDWorker>(kCD);
 
-  // register param
+  // register params
   RegisterParam<Param>(0);
+
+  // register param init methods
+  RegisterParamGenerator<ParamGenerator>(kConstant);
+  RegisterParamGenerator<GaussianGen>(kGaussian);
+  RegisterParamGenerator<UniformGen>(kUniform);
+  RegisterParamGenerator<GaussianSqrtFanInGen>(kGaussianSqrtFanIn);
+  RegisterParamGenerator<UniformSqrtFanInGen>(kUniformSqrtFanIn);
+  RegisterParamGenerator<UniformSqrtFanInOutGen>(kUniformSqrtFanInOut);
 }
 
 

--- a/src/proto/job.proto
+++ b/src/proto/job.proto
@@ -101,21 +101,11 @@ message UpdaterProto {
   // configuration for RMSProp algorithm
   optional RMSPropProto rmsprop_conf = 3;
 
-  // built-in change method for learning rate
-  optional ChangeMethod lr_change = 10 [default = kUserChange];
-  // user-defined change method
-  optional string user_lr_change = 11;
-
-  optional FixedStepProto fixedstep_conf = 40;
-  optional StepProto step_conf = 41;
-  optional LinearProto linear_conf = 42;
-  optional ExponentialProto exponential_conf = 43;
-  optional InverseProto inverse_conf = 44;
-  optional InverseTProto inverset_conf = 45;
+  // learning rate generator
+  optional LRGenProto learning_rate = 11;
   optional float momentum = 31 [default = 0];
   optional float weight_decay = 32 [default = 0];
-  // base learning rate
-  optional float base_lr = 34 [default = 0];
+
   // used to avoid divide by 0, i.e. x/(y+delta)
   optional float delta = 35 [default = 0.00000001];
 
@@ -220,24 +210,13 @@ message LayerProto {
 message ParamProto {
   // used for identifying the same params from diff models and display deug info
   optional string name =  1 [default = ""];
-  optional InitMethod init_method = 2 [default = kGaussian];
   // for built-in Param
   optional ParamType type = 3 [default = kParam];
   // for user-defined Param
   optional string user_type = 4;
-  // constant init
-  optional float value = 5 [default = 1];
-  // for uniform sampling
-  optional UniformProto uniform_conf = 6;
-  optional float low = 7 [default = -1];
-  optional float high = 8 [default = 1];
 
-  // for gaussian sampling
-  optional GaussianProto gaussian_conf = 9;
-  optional float mean = 10 [default = 0];
-  optional float std = 11 [default = 1];
-
-  // multiplied on the global learning rate.
+  optional ParamGenProto init =5;
+    // multiplied on the global learning rate.
   optional float lr_scale = 15 [default = 1];
   // multiplied on the global weight decay.
   optional float wd_scale = 16 [default = 1];
@@ -260,6 +239,38 @@ message ParamProto {
 // ---------------------------
 // protos for different layers
 // ---------------------------
+// learning rate generator proto
+message LRGenProto {
+  // user-defined change method
+  optional ChangeMethod type = 1 [default = kUserChange];
+  optional string user_type = 2;
+
+  optional float base_lr = 3 [default = 0.01];
+
+  optional FixedStepProto fixedstep_conf = 40;
+  optional StepProto step_conf = 41;
+  optional LinearProto linear_conf = 42;
+  optional ExponentialProto exponential_conf = 43;
+  optional InverseProto inverse_conf = 44;
+  optional InverseTProto inverset_conf = 45;
+
+  extensions 101 to 200;
+}
+
+message ParamGenProto {
+  optional InitMethod type = 1 [default = kUserInit];
+  optional string user_type =2;
+  // constant init
+  optional float value = 3 [default = 1];
+  // for gaussian sampling
+  optional float mean = 4 [default = 0];
+  optional float std = 5 [default = 1];
+  // for uniform sampling
+  optional float low = 8 [default = -1];
+  optional float high = 9 [default = 1];
+
+  extensions 101 to 200;
+}
 
 message RGBImageProto {
   // scale factor for each pixel
@@ -476,11 +487,9 @@ enum InitMethod {
   kGaussian = 1;
   // uniform sampling between low and high
   kUniform = 2;
-  // copy the content and history which are from previous training
-  kPretrained = 3;
   // from Toronto Convnet, let a=1/sqrt(fan_in), w*=a after generating from
   // Gaussian distribution
-  kGaussainSqrtFanIn = 4;
+  kGaussianSqrtFanIn = 4;
   // from Toronto Convnet, rectified linear activation, let
   // a=sqrt(3)/sqrt(fan_in), range is [-a, +a]; no need to set value=sqrt(3),
   // the program will multiply it.

--- a/src/trainer/server.cc
+++ b/src/trainer/server.cc
@@ -21,7 +21,6 @@ void Server::Setup(const UpdaterProto& proto,
     std::unordered_map<int, ParamEntry*>* shard,
     const vector<int>& slice2group) {
   updater_ = Updater::Create(proto);
-  updater_->Init(proto);
   shard_ = shard;
   slice2group_ = slice2group;
 }


### PR DESCRIPTION
The learning rate of SGD typically changes through time.
There are many different ways to change the learning rate of SGD. SINGA has implemented a couple of changing methods. But users may want to implement their own changing method. To make this part modular, this ticket is going to create a base learning rate generator, e.g. called LRGenerator, which is declared like,


    class LRGenerator {
      public:
        virtual float Get (int step) = 0;
      protected:
       LRProto proto_;
    };


Users can then inherit LRGenerator to implement the their own changing algorithm in the `Get(int step)`. Users can also add configurations for their generator by extending the base LRGenProto.

Similarly, we make the parameter initialization modular by creating a base class ParamGenerator which has a function tot initialize parameter values:

    Fill(Blob<float>* data)

Users can implement their parameter initializing methods by extending ParamGenerator.