### PR TITLE
SINGA-66 Fix bugs in Worker::RunOneBatch function and ClusterProto

### DIFF
--- a/src/proto/job.proto
+++ b/src/proto/job.proto
@@ -117,8 +117,8 @@ message UpdaterProto {
 }
 
 message ClusterProto {
-  optional int32 nworker_groups = 1;
-  optional int32 nserver_groups = 2;
+  optional int32 nworker_groups = 1 [default = 1];
+  optional int32 nserver_groups = 2 [default = 1];
   optional int32 nworkers_per_group = 3 [default = 1];
   optional int32 nservers_per_group = 4 [default = 1];
   optional int32 nworkers_per_procs = 5 [default = 1];

--- a/src/trainer/worker.cc
+++ b/src/trainer/worker.cc
@@ -162,12 +162,12 @@ void Worker::Run() {
   InitLocalParams();
   Metric perf;
   while (!StopNow(step_)) {
-    if (ValidateNow(step_)) {
+    if (ValidateNow(step_) && validation_net_ != nullptr) {
       //LOG(ERROR)<<"Validation at step "<<step;
       CollectAll(validation_net_, step_);
       Test(job_conf_.valid_steps(), kValidation, validation_net_);
     }
-    if (TestNow(step_)) {
+    if (TestNow(step_) && test_net_ != nullptr) {
       //LOG(ERROR)<<"Test at step "<<step;
       CollectAll(test_net_, step_);
       Test(job_conf_.test_steps(), kTest, test_net_);


### PR DESCRIPTION
Add checks for test_net_ and validation_net_ (!=nullptr) before conduct
testing and validation.

Set default values (1) to nworker_groups and nserver_groups.