### PR TITLE
SINGA-67 Add singatest into build targets

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,9 +4,12 @@ AUTOMAKE_OPTIONS = foreign subdir-objects
 AM_CPPFLAGS = -I$(top_srcdir)/src
 
 MSHADOW_FLAGS = -DMSHADOW_USE_CUDA=0 -DMSHADOW_USE_CBLAS=1 -DMSHADOW_USE_MKL=0
+DEFAULT_FLAGS = -Wall -pthread -fPIC -std=c++11 -Wno-unknown-pragmas \
+              $(MSHADOW_FLAGS) -DCPU_ONLY=1 -funroll-loops -DTHREADED
 
-AC_CXXFLAGS = -O3 -Wall -pthread -fPIC -std=c++11 -Wno-unknown-pragmas \
-              $(MSHADOW_FLAGS) -DCPU_ONLY=1 -funroll-loops
+CFLAGS = -O2 $(DEBUG)
+CXXFLAGS = -O2 $(DEBUG) 
+AC_CXXFLAGS = -O2 $(DEBUG)
 
 INCLUDES = -I$(top_srcdir)/include
 
@@ -87,31 +90,28 @@ TEST_SRCS := include/gtest/gtest_main.cc \
 			 src/test/test_paramslicer.cc \
 			 src/test/test_shard.cc
 
-lib_LTLIBRARIES = libsinga.la
+#EXTRA_PROGRAMS = $(PROGS)
+EXTRA_PROGRAMS = singatest
+#EXTRA_LTLIBRARIES = $(LTLIBS)
+EXTRA_LTLIBRARIES = libgtest.la
+
+lib_LTLIBRARIES = libsinga.la $(LTLIBS)
+bin_PROGRAMS = singa singatool $(PROGS)
+
+#lib_LTLIBRARIES = libsinga.la
 libsinga_la_SOURCES = $(PROTO_HDRS) $(PROTO_SRCS) $(SINGA_HDRS) $(SINGA_SRCS)
-libsinga_la_CXXFLAGS = -O3 -Wall -pthread -fPIC -std=c++11 -Wno-unknown-pragmas \
-                       $(MSHADOW_FLAGS) -DCPU_ONLY=1 -funroll-loops -gdwarf-2 -msse3 \
-                       -gstrict-dwarf -Woverloaded-virtual -DTHREADED -fpermissive
+libsinga_la_CXXFLAGS = $(DEFAULT_FLAGS) -gdwarf-2 -msse3 \
+                       -gstrict-dwarf -Woverloaded-virtual -fpermissive
 if LMDB
 libsinga_la_CXXFLAGS += -DUSE_LMDB
 endif
 libsinga_la_LDFLAGS = -I./include
 
-lib_LTLIBRARIES += libgtest.la
-libgtest_la_SOURCES = $(GTEST_HDRS) $(GTEST_SRCS)
-libgtest_la_CXXFLAGS = -O3 -Wall -pthread -fPIC -std=c++11 -Wno-unknown-pragmas \
-                       $(MSHADOW_FLAGS) -DCPU_ONLY=1 -funroll-loops -gdwarf-2 -msse3 \
-                       -gstrict-dwarf -Woverloaded-virtual -DTHREADED -fpermissive
-if LMDB
-libgtest_la_CXXFLAGS += -DUSE_LMDB
-endif
-libgtest_la_LDFLAGS = -I./include
 
 
-bin_PROGRAMS = singa
+#bin_PROGRAMS = singa
 singa_SOURCES = src/main.cc
-singa_CXXFLAGS = -O3 -Wall -pthread -fPIC -std=c++11 -MMD -Wno-unknown-pragmas \
-                 $(MSHADOW_FLAGS) -DCPU_ONLY=1 -funroll-loops -DTHREADED
+singa_CXXFLAGS = $(DEFAULT_FLAGS) -MMD 
 singa_LDFLAGS = -I./include \
                 -lsinga \
                 -lglog  \
@@ -125,9 +125,9 @@ if LMDB
 singa_LDFLAGS += -llmdb
 endif
 
-bin_PROGRAMS += singatool
+#bin_PROGRAMS += singatool
 singatool_SOURCES = src/utils/tool.cc
-singatool_CXXFLAGS = -O3 -Wall -pthread -fPIC -std=c++11 -MMD -Wno-unknown-pragmas \
+singatool_CXXFLAGS = -Wall -pthread -fPIC -std=c++11 -MMD -Wno-unknown-pragmas \
                      -funroll-loops -DTHREADED
 singatool_LDFLAGS = -I./include \
                     -lsinga \
@@ -135,10 +135,19 @@ singatool_LDFLAGS = -I./include \
                     -lprotobuf \
                     -lzookeeper_mt
 
-bin_PROGRAMS += singatest
+#lib_LTLIBRARIES += libgtest.la
+libgtest_la_SOURCES = $(GTEST_HDRS) $(GTEST_SRCS)
+libgtest_la_CXXFLAGS = $(DEFAULT_FLAGS) -gdwarf-2 -msse3 \
+					-gstrict-dwarf -Woverloaded-virtual -fpermissive
+if LMDB
+libgtest_la_CXXFLAGS += -DUSE_LMDB
+endif
+libgtest_la_LDFLAGS = -I./include
+
+#bin_PROGRAMS += singatest
+
 singatest_SOURCES = $(GTEST_HDRS) $(TEST_SRCS)
-singatest_CXXFLAGS = -O3 -Wall -pthread -fPIC -std=c++11 -MMD -Wno-unknown-pragmas \
-                 $(MSHADOW_FLAGS) -DCPU_ONLY=1 -funroll-loops -DTHREADED
+singatest_CXXFLAGS = $(DEFAULT_FLAGS) 
 singatest_LDFLAGS = -I./include \
                 -lsinga \
                 -lglog  \

--- a/Makefile.am
+++ b/Makefile.am
@@ -78,6 +78,14 @@ SINGA_HDRS := include/singa.h \
               include/communication/msg.h \
               include/communication/socket.h
 
+GTEST_SRCS := include/gtest/gtest-all.cc
+GTEST_HRDS := include/gtest/gtest.h
+TEST_SRCS := include/gtest/gtest_main.cc \
+			 src/test/test_cluster.cc \
+			 src/test/test_msg.cc \
+			 src/test/test_neuralnet.cc \
+			 src/test/test_paramslicer.cc \
+			 src/test/test_shard.cc
 
 lib_LTLIBRARIES = libsinga.la
 libsinga_la_SOURCES = $(PROTO_HDRS) $(PROTO_SRCS) $(SINGA_HDRS) $(SINGA_SRCS)
@@ -88,6 +96,17 @@ if LMDB
 libsinga_la_CXXFLAGS += -DUSE_LMDB
 endif
 libsinga_la_LDFLAGS = -I./include
+
+lib_LTLIBRARIES += libgtest.la
+libgtest_la_SOURCES = $(GTEST_HDRS) $(GTEST_SRCS)
+libgtest_la_CXXFLAGS = -O3 -Wall -pthread -fPIC -std=c++11 -Wno-unknown-pragmas \
+                       $(MSHADOW_FLAGS) -DCPU_ONLY=1 -funroll-loops -gdwarf-2 -msse3 \
+                       -gstrict-dwarf -Woverloaded-virtual -DTHREADED -fpermissive
+if LMDB
+libgtest_la_CXXFLAGS += -DUSE_LMDB
+endif
+libgtest_la_LDFLAGS = -I./include
+
 
 bin_PROGRAMS = singa
 singa_SOURCES = src/main.cc
@@ -115,6 +134,24 @@ singatool_LDFLAGS = -I./include \
                     -lglog  \
                     -lprotobuf \
                     -lzookeeper_mt
+
+bin_PROGRAMS += singatest
+singatest_SOURCES = $(GTEST_HDRS) $(TEST_SRCS)
+singatest_CXXFLAGS = -O3 -Wall -pthread -fPIC -std=c++11 -MMD -Wno-unknown-pragmas \
+                 $(MSHADOW_FLAGS) -DCPU_ONLY=1 -funroll-loops -DTHREADED
+singatest_LDFLAGS = -I./include \
+                -lsinga \
+                -lglog  \
+                -lprotobuf \
+                -lrt \
+                -lopenblas \
+                -lzmq \
+                -lczmq \
+                -lzookeeper_mt \
+				-lgtest
+if LMDB
+singatest_LDFLAGS += -llmdb
+endif
 
 clean-local:
 	rm -rf $(PROTO_SRCS) $(PROTO_HDRS)

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_CONFIG_MACRO_DIR(config)
 AC_CONFIG_SRCDIR([src/utils/common.cc])
 AC_CONFIG_HEADER([config.h])
 AM_INIT_AUTOMAKE([subdir-objects foreign])
-#m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 ACLOCAL_AMFLAGS = -I m4 --install
 
 # Checks for programs.
@@ -44,11 +44,11 @@ if test x"$enable_lmdb" = x"yes"; then
 	AC_DEFINE(LMDB, 1, [Enable Option layer])
 fi
 
-AC_ARG_ENABLE(singatest,
-	AS_HELP_STRING([--enable-singatest],[enable singa test]),
-	[enable_singatest=yes],[enable_singatest=no])
-AM_CONDITIONAL(SINGATEST, test "$enable_singatest" = yes)
-if test x"$enable_singatest" != x"no"; then
+AC_ARG_ENABLE(test,
+	AS_HELP_STRING([--enable-test],[enable singa test]),
+	[enable_test=yes],[enable_test=no])
+AM_CONDITIONAL(SINGATEST, test "$enable_test" = yes)
+if test x"$enable_test" != x"no"; then
 	PROGS='singatest'
 	LTLIBS='libgtest.la'
 else

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_CONFIG_MACRO_DIR(config)
 AC_CONFIG_SRCDIR([src/utils/common.cc])
 AC_CONFIG_HEADER([config.h])
 AM_INIT_AUTOMAKE([subdir-objects foreign])
-m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+#m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 ACLOCAL_AMFLAGS = -I m4 --install
 
 # Checks for programs.
@@ -43,6 +43,31 @@ if test x"$enable_lmdb" = x"yes"; then
 	  ])
 	AC_DEFINE(LMDB, 1, [Enable Option layer])
 fi
+
+AC_ARG_ENABLE(singatest,
+	AS_HELP_STRING([--enable-singatest],[enable singa test]),
+	[enable_singatest=yes],[enable_singatest=no])
+AM_CONDITIONAL(SINGATEST, test "$enable_singatest" = yes)
+if test x"$enable_singatest" != x"no"; then
+	PROGS='singatest'
+	LTLIBS='libgtest.la'
+else
+	PROGS=''
+	LTLIBS=''
+fi
+AC_SUBST([PROGS])
+AC_SUBST([LTLIBS])
+
+AC_ARG_ENABLE(debug,
+	AS_HELP_STRING([--enable-debug],[enable debug mode]),
+	[enable_debug=yes],[enable_debug=no])
+AM_CONDITIONAL(DEBUG, test "$enable_debug" = yes)
+if test x"$enable_debug" != x"no"; then
+	DEBUG='-g'
+else
+	DEBUG=''
+fi
+AC_SUBST([DEBUG])
 
 #AC_CHECK_LIB([opencv_imgproc], [main], [], [
 #  AC_MSG_ERROR([unable to find opencv_imgproc lib])


### PR DESCRIPTION
Modified Makefile.am to add a target named "singatest".
Now "make" will generate 5 files/libs: libsinga.la libgtest.la singa singatool singatest.
User can also specify the target he wants to generate, for example, "make singa".