### PR TITLE
SINGA-71 Fix a buf from repeated averaging gradients from workers

### DIFF
--- a/src/trainer/trainer.cc
+++ b/src/trainer/trainer.cc
@@ -481,7 +481,6 @@ const vector<Msg*> Trainer::HandleUpdate(ParamEntry *entry, Msg** msg) {
         mshadow::Tensor<mshadow::cpu,1> grad((*it)->mutable_cpu_grad(), shape);
         sum += grad;
       }
-      sum /= entry->num_total;
     }
     int step = (*msg)->trgt_version();
     GenMsgs(kUpdate, step, entry, *msg, &ret);


### PR DESCRIPTION
The Trainer::HandleUpdate() averaged the gradients from local workers
from the same group. But the average is also conducted in the
Updater::Update() function. In other words, the gradients were averaged
twice which made them smaller than normal values, and the learning
slower.

The bug is fixed by removing the averaging operation in
Trainer::HandleUpdate()