### PR TITLE
SINGA-77 Integrate with Apache RAT

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -163,7 +163,20 @@ endif
 clean-local:
 	rm -rf $(PROTO_SRCS) $(PROTO_HDRS)
 	rm -rf $(PROTO_PYS)
+	rm -rf rat_check
+	rm -rf tool/pb2
 
+rat:
+	@if test ! -z '$(shell command -v java 2>/dev/null)'; then \
+		if test ! -z '$(shell echo $$RAT_PATH)'; then \
+			make clean;\
+			java -jar $(RAT_PATH) -E rat-excludes -d . > rat_check; \
+		else \
+			echo "RAT_PATH is not set to correct jar file"; \
+		fi \
+	else \
+		echo "java is not found"; \
+	fi
 
 $(PROTO_HDRS) $(PROTO_SRCS): $(PROTOS)
 	protoc --proto_path=$(top_srcdir)/src/proto --cpp_out=$(top_srcdir)/src/proto $(PROTOS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -169,10 +169,10 @@ clean-local:
 rat:
 	@if test ! -z '$(shell command -v java 2>/dev/null)'; then \
 		if test ! -z '$(shell echo $$RAT_PATH)'; then \
-			make clean;\
+			make distclean;\
 			java -jar $(RAT_PATH) -E rat-excludes -d . > rat_check; \
 		else \
-			echo "RAT_PATH is not set to correct jar file"; \
+			echo "RAT_PATH is not set to correct jar file. Apache RAT can be downloaded at http://creadur.apache.org/rat/download_rat.cgi"; \
 		fi \
 	else \
 		echo "java is not found"; \

--- a/rat-excludes
+++ b/rat-excludes
@@ -1,0 +1,13 @@
+rat-excludes
+Makefile.*
+configure
+.gitignore
+conf/*
+config/*
+\.dirstamp
+autom4te.cache/*
+config.*
+libtool
+stamp-h1
+.*\.conf
+.*\.md


### PR DESCRIPTION
(Thanks Zhongle for the help with the Makefile.am)

Apache RAT enables automatic checking of license headers in source files. SINGA supports RAT by adding
a target into the Makefile, and providing a `rat-excludes` file at the top-level directory.
Specifically, the `make rat` target does the following:
+ Check for java and Apache RAT .jar file in the $RAT_PATH variable.
+ Invoke `make clean`
+ Invoke RAT and write the output to `rat_check` file.

Notice the side-effect of `make rat` that removes all built files. Thus, it is recommended to use before
building the source.