### PR TITLE
 SINGA-82 Refactor input layers using data store abstraction

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,11 @@ SINGA_SRCS := src/driver.cc \
               src/neuralnet/output_layer.cc \
               src/neuralnet/neuralnet.cc \
               src/comm/socket.cc \
-              src/comm/msg.cc
+              src/comm/msg.cc \
+							src/io/kvfile.cc \
+							src/io/kvfile_store.cc \
+							src/io/textfile_store.cc \
+							src/io/store.cc
 
 SINGA_HDRS := include/singa.h \
               include/utils/cluster.h \
@@ -80,6 +84,10 @@ SINGA_HDRS := include/singa.h \
               include/mshadow/tensor_random.h \
               include/comm/msg.h \
               include/comm/socket.h
+							src/io/store.h \
+							src/io/kvfile.h \
+							src/io/kvfile_store.h \
+							src/io/textfile_store.h
 
 GTEST_SRCS := include/gtest/gtest-all.cc
 GTEST_HRDS := include/gtest/gtest.h
@@ -89,7 +97,8 @@ TEST_SRCS := include/gtest/gtest_main.cc \
 			 src/test/test_msg.cc \
 			 src/test/test_neuralnet.cc \
 			 src/test/test_paramslicer.cc \
-			 src/test/test_shard.cc
+			 src/test/test_shard.cc \
+			 src/test/test_store.cc
 
 #EXTRA_PROGRAMS = $(PROGS)
 EXTRA_PROGRAMS = singatest

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,7 @@ SINGA_SRCS := src/driver.cc \
               src/utils/updater.cc \
               src/utils/data_shard.cc \
               src/utils/blob.cc \
+              src/utils/image_transform.cc \
               src/server.cc \
               src/worker.cc \
               src/stub.cc \
@@ -64,6 +65,8 @@ SINGA_HDRS := include/singa.h \
               include/utils/blob.h \
               include/utils/updater.h \
               include/utils/tinydir.h \
+              include/utils/tokenizer.h \
+              include/utils/image_transform.h \
               include/server.h \
               include/worker.h \
               include/stub.h \
@@ -84,10 +87,10 @@ SINGA_HDRS := include/singa.h \
               include/mshadow/tensor_random.h \
               include/comm/msg.h \
               include/comm/socket.h
-							src/io/store.h \
-							src/io/kvfile.h \
-							src/io/kvfile_store.h \
-							src/io/textfile_store.h
+							include/io/store.h \
+							include/io/kvfile.h \
+							include/io/kvfile_store.h \
+							include/io/textfile_store.h
 
 GTEST_SRCS := include/gtest/gtest-all.cc
 GTEST_HRDS := include/gtest/gtest.h
@@ -98,7 +101,9 @@ TEST_SRCS := include/gtest/gtest_main.cc \
 			 src/test/test_neuralnet.cc \
 			 src/test/test_paramslicer.cc \
 			 src/test/test_shard.cc \
-			 src/test/test_store.cc
+			 src/test/test_store.cc \
+			 src/test/test_proto_record_layer.cc \
+			 src/test/test_csv_record_layer.cc
 
 #EXTRA_PROGRAMS = $(PROGS)
 EXTRA_PROGRAMS = singatest

--- a/examples/cifar10/Makefile.example
+++ b/examples/cifar10/Makefile.example
@@ -29,12 +29,7 @@ cifar-10-binary-bin:
 	tar xf cifar-10-binary.tar.gz
 
 create:
-	$(CXX) create_shard.cc -std=c++11 -lsinga -lprotobuf -lglog \
+	$(CXX) create_data.cc -std=c++11 -lsinga -lprotobuf -lglog \
 		-I../../include -L../../.libs/ -Wl,-unresolved-symbols=ignore-in-shared-libs \
-		-Wl,-rpath=../../.libs/  -o create_shard.bin
-	mkdir cifar10_train_shard
-	mkdir cifar10_test_shard
-	./create_shard.bin cifar-10-batches-bin .
-
-
-
+		-Wl,-rpath=../../.libs/  -o create_data.bin
+	./create_data.bin cifar-10-batches-bin .

--- a/examples/cifar10/job.conf
+++ b/examples/cifar10/job.conf
@@ -1,7 +1,7 @@
 name: "cifar10-convnet"
 train_steps: 1000
 test_steps: 100
-test_freq:300
+test_freq: 300
 disp_freq: 30
 train_one_batch {
   alg: kBP
@@ -24,41 +24,38 @@ updater{
 neuralnet {
   layer{
     name: "data"
-    type: kShardData
-    sharddata_conf {
-      path: "examples/cifar10/cifar10_train_shard"
+    type: kProtoRecord
+    store_conf {
+      backend: "kvfile"
+      path: "examples/cifar10/train_data.bin"
+      mean_file: "examples/cifar10/image_mean.bin"
       batchsize: 64
       random_skip: 5000
+      shape: 3
+      shape: 32
+      shape: 32
     }
     exclude: kTest
   }
   layer{
     name: "data"
-    type: kShardData
-    sharddata_conf {
-      path: "examples/cifar10/cifar10_test_shard"
+    type: kProtoRecord
+    store_conf {
+      backend: "kvfile"
+      path: "examples/cifar10/test_data.bin"
+      mean_file: "examples/cifar10/image_mean.bin"
       batchsize: 100
+      shape: 3
+      shape: 32
+      shape: 32
     }
     exclude: kTrain
-  }
-  layer{
-    name:"rgb"
-    type: kRGBImage
-    srclayers: "data"
-    rgbimage_conf {
-      meanfile: "examples/cifar10/image_mean.bin"
-    }
-  }
-  layer{
-    name: "label"
-    type: kLabel
-    srclayers: "data"
   }
 
   layer {
     name: "conv1"
     type: kCConvolution
-    srclayers: "rgb"
+    srclayers: "data"
     convolution_conf {
       num_filters: 32
       kernel: 5
@@ -223,7 +220,6 @@ neuralnet {
       }
     }
   }
-
   layer{
     name: "loss"
     type: kSoftmaxLoss
@@ -231,7 +227,7 @@ neuralnet {
       topk:1
     }
     srclayers:"ip1"
-    srclayers: "label"
+    srclayers: "data"
   }
 }
 cluster {

--- a/examples/mnist/Makefile.example
+++ b/examples/mnist/Makefile.example
@@ -34,10 +34,8 @@ mnist:
 	gunzip t10k-images-idx3-ubyte.gz && gunzip t10k-labels-idx1-ubyte.gz
 
 create:
-	$(CXX) create_shard.cc -std=c++11 -lsinga -lprotobuf -lglog -I../../include \
+	$(CXX) create_data.cc -std=c++11 -lsinga -lprotobuf -lglog -I../../include \
 		-L../../.libs/ -Wl,-unresolved-symbols=ignore-in-shared-libs -Wl,-rpath=../../.libs/ \
-		-o create_shard.bin
-	mkdir mnist_train_shard
-	mkdir mnist_test_shard
-	./create_shard.bin train-images-idx3-ubyte train-labels-idx1-ubyte mnist_train_shard
-	./create_shard.bin t10k-images-idx3-ubyte t10k-labels-idx1-ubyte mnist_test_shard
+		-o create_data.bin
+	./create_data.bin train-images-idx3-ubyte train-labels-idx1-ubyte train_data.bin
+	./create_data.bin t10k-images-idx3-ubyte t10k-labels-idx1-ubyte test_data.bin

--- a/examples/mnist/conv.conf
+++ b/examples/mnist/conv.conf
@@ -22,43 +22,39 @@ updater {
 neuralnet {
   layer {
     name: "data"
-    type:  kShardData
-    sharddata_conf {
-      path: "examples/mnist/mnist_train_shard"
+    type: kProtoRecord
+    store_conf {
+      backend: "kvfile"
+      path: "examples/mnist/train_data.bin"
       batchsize: 64
+      std_value: 255
+      random_skip: 5000
+      shape: 1
+      shape: 28
+      shape: 28
     }
     exclude: kTest
   }
 
   layer {
     name: "data"
-    type: kShardData
-    sharddata_conf {
-      path: "examples/mnist/mnist_test_shard"
+    type: kProtoRecord
+    store_conf {
+      backend: "kvfile"
+      path: "examples/mnist/test_data.bin"
+      std_value: 255
       batchsize: 100
+      shape: 1
+      shape: 28
+      shape: 28
     }
     exclude: kTrain
   }
 
-  layer{
-    name:"mnist"
-    type: kMnist
-    srclayers: "data"
-    mnist_conf {
-      norm_a:255
-      norm_b:0
-    }
-  }
-
-  layer{
-    name: "label"
-    type: kLabel
-    srclayers: "data"
-  }
   layer {
     name: "conv1"
     type: kCConvolution
-    srclayers: "mnist"
+    srclayers: "data"
     convolution_conf {
       num_filters: 20
       kernel: 5
@@ -181,7 +177,7 @@ neuralnet {
       topk:1
     }
     srclayers:"ip2"
-    srclayers:"label"
+    srclayers:"data"
   }
 }
 cluster {

--- a/examples/mnist/create_data.cc
+++ b/examples/mnist/create_data.cc
@@ -105,9 +105,10 @@ void create_data(const char* image_filename, const char* label_filename,
 
 int main(int argc, char** argv) {
   if (argc != 4) {
-    std::cout<<"This program create a DataShard for a MNIST dataset\n"
+    std::cout << "This program create a DataShard for a MNIST dataset\n"
         "Usage:\n"
-        "    create_shard.bin  input_image_file input_label_file output_db_file\n"
+        "    create_shard.bin  input_image_file input_label_file"
+        " output_db_file\n"
         "The MNIST dataset could be downloaded at\n"
         "    http://yann.lecun.com/exdb/mnist/\n"
         "You should gunzip them after downloading.";

--- a/examples/mnist/job.conf
+++ b/examples/mnist/job.conf
@@ -21,45 +21,37 @@ updater{
 neuralnet {
   layer {
     name: "data"
-    type: kShardData
-    sharddata_conf {
-      path: "examples/mnist/mnist_train_shard"
-      batchsize: 1000
+    type: kProtoRecord
+    store_conf {
+      backend: "kvfile"
+      path: "examples/mnist/train_data.bin"
+      random_skip: 5000
+      batchsize: 64
+      shape: 784
+      std_value: 127.5
+      mean_value: 127.5
     }
     exclude: kTest
   }
 
   layer {
     name: "data"
-    type: kShardData
-    sharddata_conf {
-      path: "examples/mnist/mnist_test_shard"
-      batchsize: 1000
+    type: kProtoRecord
+    store_conf {
+      backend: "kvfile"
+      path: "examples/mnist/test_data.bin"
+      batchsize: 100
+      shape: 784
+      std_value: 127.5
+      mean_value: 127.5
     }
     exclude: kTrain
   }
 
   layer{
-    name:"mnist"
-    type: kMnist
-    srclayers: "data"
-    mnist_conf {
-      norm_a: 127.5
-      norm_b: 1
-    }
-  }
-
-
-  layer{
-    name: "label"
-    type: kLabel
-    srclayers: "data"
-  }
-
-  layer{
     name: "fc1"
     type: kInnerProduct
-    srclayers:"mnist"
+    srclayers:"data"
     innerproduct_conf{
       num_output: 2500
     }
@@ -239,7 +231,7 @@ neuralnet {
       topk:1
     }
     srclayers:"fc6"
-    srclayers:"label"
+    srclayers:"data"
   }
 }
 cluster {

--- a/examples/rbm/autoencoder.conf
+++ b/examples/rbm/autoencoder.conf
@@ -21,44 +21,35 @@ updater{
 neuralnet {
   layer {
     name: "data"
-    type: kShardData
-    sharddata_conf {
-      path: "examples/mnist/mnist_train_shard"
-      batchsize: 1000
+    type: kProtoRecord
+    store_conf {
+      backend: "kvfile"
+      path: "examples/mnist/train_data.bin"
+      batchsize: 100
+      std_value: 255
+      shape: 784
     }
     exclude: kTest
   }
 
   layer {
     name: "data"
-    type: kShardData
-    sharddata_conf {
-      path: "examples/mnist/mnist_test_shard"
-      batchsize: 1000
+    type: kProtoRecord
+    store_conf {
+      backend: "kvfile"
+      path: "examples/mnist/test_data.bin"
+      std_value: 255
+      batchsize: 100
+      shape: 784
     }
     exclude: kTrain
   }
 
-  layer{
-    name:"mnist"
-    type: kMnist
-    srclayers: "data"
-    mnist_conf {
-      norm_a: 255
-      norm_b: 0
-    }
-  }
-
-  layer{
-    name: "label"
-    type: kLabel
-    srclayers: "data"
-  }
 
   layer{
     name: "Inner1"
     type: kInnerProduct
-    srclayers:"mnist"
+    srclayers:"data"
     innerproduct_conf{
       num_output: 1000
     }
@@ -228,7 +219,7 @@ neuralnet {
     name: "loss"
     type:kEuclideanLoss
     srclayers:"Sigmoid8"
-    srclayers:"mnist"
+    srclayers:"data"
   }
 }
 cluster {

--- a/examples/rbm/rbm1.conf
+++ b/examples/rbm/rbm1.conf
@@ -17,42 +17,36 @@ updater{
 }
 
 neuralnet {
-layer {
-  name: "data"
-  type: kShardData
-  sharddata_conf {
-    path: "examples/mnist/mnist_train_shard"
-    batchsize: 100
+  layer {
+    name: "data"
+    type: kProtoRecord
+    store_conf {
+      backend: "kvfile"
+      path: "examples/mnist/train_data.bin"
+      batchsize: 100
+      std_value: 255
+      shape: 784
+    }
+    exclude: kTest
   }
-  exclude: kTest
-}
 
-
-layer {
-  name: "data"
-  type: kShardData
-  sharddata_conf {
-    path: "examples/mnist/mnist_test_shard"
-    batchsize: 100
+  layer {
+    name: "data"
+    type: kProtoRecord
+    store_conf {
+      backend: "kvfile"
+      path: "examples/mnist/test_data.bin"
+      std_value: 255
+      batchsize: 100
+      shape: 784
+    }
+    exclude: kTrain
   }
-  exclude: kTrain
-}
-
-
-layer{
-  name:"mnist"
-  type: kMnist
-  srclayers: "data"
-  mnist_conf {
-    norm_a: 255
-    norm_b: 0
-  }
-}
 
 layer{
   name: "RBMVis"
   type: kRBMVis
-  srclayers:"mnist"
+  srclayers:"data"
   srclayers:"RBMHid"
   rbm_conf{
     hdim: 1000

--- a/examples/rbm/rbm2.conf
+++ b/examples/rbm/rbm2.conf
@@ -18,42 +18,36 @@ updater{
 }
 
 neuralnet {
-layer {
-  name: "data"
-  type: kShardData
-  sharddata_conf {
-    path: "examples/mnist/mnist_train_shard"
-    batchsize: 100
+  layer {
+    name: "data"
+    type: kProtoRecord
+    store_conf {
+      backend: "kvfile"
+      path: "examples/mnist/train_data.bin"
+      batchsize: 100
+      std_value: 255
+      shape: 784
+    }
+    exclude: kTest
   }
-  exclude: kTest
-}
 
-
-layer {
-  name: "data"
-  type: kShardData
-  sharddata_conf {
-    path: "examples/mnist/mnist_test_shard"
-    batchsize: 100
+  layer {
+    name: "data"
+    type: kProtoRecord
+    store_conf {
+      backend: "kvfile"
+      path: "examples/mnist/test_data.bin"
+      std_value: 255
+      batchsize: 100
+      shape: 784
+    }
+    exclude: kTrain
   }
-  exclude: kTrain
-}
-
-
-layer{
-  name:"mnist"
-  type: kMnist
-  srclayers: "data"
-  mnist_conf {
-    norm_a: 255
-    norm_b: 0
-  }
-}
 
 layer{
   name: "Inner1"
   type: kInnerProduct
-  srclayers:"mnist"
+  srclayers:"data"
   innerproduct_conf{
     num_output: 1000
   }

--- a/examples/rbm/rbm3.conf
+++ b/examples/rbm/rbm3.conf
@@ -20,42 +20,37 @@ updater{
 
 
 neuralnet {
-layer {
-  name: "data"
-  type: kShardData
-  sharddata_conf {
-    path: "examples/mnist/mnist_train_shard"
-    batchsize: 100
+  layer {
+    name: "data"
+    type: kProtoRecord
+    store_conf {
+      backend: "kvfile"
+      path: "examples/mnist/train_data.bin"
+      batchsize: 100
+      std_value: 255
+      shape: 784
+    }
+    exclude: kTest
   }
-  exclude: kTest
-}
 
-
-layer {
-  name: "data"
-  type: kShardData
-  sharddata_conf {
-    path: "examples/mnist/mnist_test_shard"
-    batchsize: 100
+  layer {
+    name: "data"
+    type: kProtoRecord
+    store_conf {
+      backend: "kvfile"
+      path: "examples/mnist/test_data.bin"
+      std_value: 255
+      batchsize: 100
+      shape: 784
+    }
+    exclude: kTrain
   }
-  exclude: kTrain
-}
 
-
-layer{
-  name:"mnist"
-  type: kMnist
-  srclayers: "data"
-  mnist_conf {
-    norm_a: 255
-    norm_b: 0
-  }
-}
 
 layer{
     name: "Inner1"
     type: kInnerProduct
-    srclayers:"mnist"
+    srclayers:"data"
     innerproduct_conf{
       num_output: 1000
     }

--- a/examples/rbm/rbm4.conf
+++ b/examples/rbm/rbm4.conf
@@ -18,42 +18,37 @@ updater{
 }
 
 neuralnet {
-layer {
-  name: "data"
-  type: kShardData
-  sharddata_conf {
-    path: "examples/mnist/mnist_train_shard"
-    batchsize: 100
+  layer {
+    name: "data"
+    type: kProtoRecord
+    store_conf {
+      backend: "kvfile"
+      path: "examples/mnist/train_data.bin"
+      batchsize: 100
+      std_value: 255
+      shape: 784
+    }
+    exclude: kTest
   }
-  exclude: kTest
-}
 
-
-layer {
-  name: "data"
-  type: kShardData
-  sharddata_conf {
-    path: "examples/mnist/mnist_test_shard"
-    batchsize: 100
+  layer {
+    name: "data"
+    type: kProtoRecord
+    store_conf {
+      backend: "kvfile"
+      path: "examples/mnist/test_data.bin"
+      std_value: 255
+      batchsize: 100
+      shape: 784
+    }
+    exclude: kTrain
   }
-  exclude: kTrain
-}
 
 
-layer{
-  name:"mnist"
-  type: kMnist
-  srclayers: "data"
-  mnist_conf {
-    norm_a: 255
-    norm_b: 0
-  }
-}
-
-layer{
+  layer{
     name: "Inner1"
     type: kInnerProduct
-    srclayers:"mnist"
+    srclayers:"data"
     innerproduct_conf{
       num_output: 1000
     }

--- a/examples/rnnlm/Makefile.example
+++ b/examples/rnnlm/Makefile.example
@@ -38,11 +38,11 @@ download:
 
 create:
 	protoc --proto_path=../../src/proto --proto_path=. --cpp_out=. rnnlm.proto
-	$(CXX) create_shard.cc rnnlm.pb.cc -std=c++11 -lsinga -lprotobuf -lzookeeper_mt -lglog -I../../include -I../../include/proto \
+	$(CXX) create_data.cc rnnlm.pb.cc -std=c++11 -lsinga -lprotobuf -lzookeeper_mt -lglog -I../../include -I../../include/proto \
 		-L../../.libs/ -L/usr/local/lib -Wl,-unresolved-symbols=ignore-in-shared-libs -Wl,-rpath=../../.libs/ \
-		-o create_shard.bin
+		-o create_data.bin
 	for d in $(dirshards); do mkdir -p $${d}; done
-	./create_shard.bin -train $(dirname)/train -test $(dirname)/test -valid $(dirname)/valid -class_size $(numclass)
+	./create_data.bin -train $(dirname)/train -test $(dirname)/test -valid $(dirname)/valid -class_size $(numclass)
 
 
 rnnlm:

--- a/examples/rnnlm/job.conf
+++ b/examples/rnnlm/job.conf
@@ -33,7 +33,8 @@ layer {
   name: "data"
   user_type: "kData"
   [data_conf] {
-    path: "examples/rnnlm/train_shard"
+    backend: "kvfile"
+    path: "examples/rnnlm/train_data.bin"
     max_window: 10
   }
   exclude: kVal
@@ -43,16 +44,10 @@ layer {
   name: "data"
   user_type: "kData"
   [data_conf] {
-    path: "examples/rnnlm/valid_shard"
+    path: "examples/rnnlm/valid_data.bin"
     max_window: 10
   }
   exclude: kTrain
-}
-
-layer{
-  name:"label"
-  user_type: "kLabel"
-  srclayers: "data"
 }
 
 layer{
@@ -90,7 +85,7 @@ layer{
   name: "loss"
   user_type: "kLoss"
   srclayers:"hidden"
-  srclayers:"label"
+  srclayers:"data"
   [loss_conf] {
     nclass:100
     vocab_size: 3720

--- a/examples/rnnlm/main.cc
+++ b/examples/rnnlm/main.cc
@@ -36,7 +36,6 @@ int main(int argc, char **argv) {
   driver.RegisterLayer<rnnlm::HiddenLayer, std::string>("kHidden");
   driver.RegisterLayer<rnnlm::LossLayer, std::string>("kLoss");
   driver.RegisterLayer<rnnlm::DataLayer, std::string>("kData");
-  driver.RegisterLayer<rnnlm::LabelLayer, std::string>("kLabel");
 
   singa::JobProto jobConf = driver.job_conf();
 

--- a/examples/rnnlm/rnnlm.cc
+++ b/examples/rnnlm/rnnlm.cc
@@ -18,12 +18,13 @@
 * under the License.
 *
 *************************************************************/
+#include "./rnnlm.h"
+
 #include <string>
 #include <algorithm>
 #include "mshadow/tensor.h"
 #include "mshadow/tensor_expr.h"
 #include "mshadow/cxxnet_op.h"
-#include "./rnnlm.h"
 #include "./rnnlm.pb.h"
 
 namespace rnnlm {
@@ -64,7 +65,7 @@ void DataLayer::Setup(const LayerProto& conf, const vector<Layer*>& srclayers) {
   window_ = 0;
 }
 
-void SetInst(int k, WordRecord& word, Blob<float>* to) {
+void SetInst(int k, const WordRecord& word, Blob<float>* to) {
   float* dptr = to->mutable_cpu_data() + k * 4;
   dptr[0] = static_cast<float>(word.word_index());
   dptr[1] = static_cast<float>(word.class_index());

--- a/examples/rnnlm/rnnlm.h
+++ b/examples/rnnlm/rnnlm.h
@@ -69,20 +69,20 @@ class DataLayer : public RNNLayer, public singa::DataLayer {
 
  private:
   int max_window_;
-  singa::DataShard* shard_;
+  singa::io::Store* store_ = nullptr;
 };
 
 
 /**
  * LabelLayer that read records_[1] to records_[window_] from DataLayer to
  * offer label information
- */
 class LabelLayer : public RNNLayer {
  public:
   void Setup(const LayerProto& conf, const vector<Layer*>& srclayers) override;
   void ComputeFeature(int flag, const vector<Layer*>& srclayers) override;
   void ComputeGradient(int flag, const vector<Layer*>& srclayers) override {}
 };
+ */
 
 
 /**

--- a/examples/rnnlm/rnnlm.proto
+++ b/examples/rnnlm/rnnlm.proto
@@ -35,6 +35,7 @@ message LossProto {
 message DataProto {
   required string path = 1;
   optional int32 max_window = 2;
+  optional string backend = 3 [default = "kvfile"];
 }
 
 extend singa.LayerProto {
@@ -49,8 +50,4 @@ message WordRecord {
   optional int32 class_index = 3;
   optional int32 class_start = 4;
   optional int32 class_end = 5;
-}
-
-extend singa.Record {
-  optional WordRecord word = 101;
 }

--- a/include/io/hdfs_store.h
+++ b/include/io/hdfs_store.h
@@ -1,0 +1,22 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+
+// TODO(wangwei) use hdfs as data storage

--- a/include/io/imagefolder_store.h
+++ b/include/io/imagefolder_store.h
@@ -1,0 +1,21 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+// TODO(wangwei) store images in a disk folder

--- a/include/io/kvfile.h
+++ b/include/io/kvfile.h
@@ -32,8 +32,8 @@
 #include <google/protobuf/message.h>
 #endif
 
-namespace singa { namespace io {
-
+namespace singa {
+namespace io {
 
 /**
  * KVFile stores training/validation/test tuples.
@@ -171,7 +171,7 @@ class KVFile {
   //!< bytes in buf_, used in reading
   int bufsize_ = 0;
 };
-} /* io */
+}  // namespace io
 
 /**
  * @deprecated {ShardData is deprecated! Use KVFile}.

--- a/include/io/kvfile.h
+++ b/include/io/kvfile.h
@@ -1,0 +1,182 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+
+#ifndef SINGA_IO_KVFILE_H_
+#define SINGA_IO_KVFILE_H_
+
+#include <fstream>
+#include <string>
+#include <unordered_set>
+
+#define USE_PROTOBUF 1
+
+#ifdef USE_PROTOBUF
+#include <google/protobuf/message.h>
+#endif
+
+namespace singa { namespace io {
+
+
+/**
+ * KVFile stores training/validation/test tuples.
+ * Every worker node should have a KVFile for training data (validation/test
+ * KVFile is optional).
+ * KVFile consists of a set of unordered tuples. Each tuple is
+ * encoded as [key_len key val_len val] (key_len and val_len are of type
+ * uint32, which indicate the bytes of key and value respectively.
+ *
+ * When KVFile is created, it will remove the last tuple if the value size
+ * and key size do not match because the last write crashed.
+ *
+ * TODO(wangwei) split one KVFile into multiple KVFile s.
+ *
+ */
+class KVFile {
+ public:
+  enum Mode {
+    // read only mode used in training
+    kRead = 0,
+    // write mode used in creating KVFile (will overwrite previous one)
+    kCreate = 1,
+    // append mode, e.g. used when previous creating crashes
+    kAppend = 2
+  };
+
+  /**
+   * KVFile constructor.
+   *
+   * @param path path to the disk KVFile, it can be
+   *  - a path to local disk file.
+   *  - a path to local directory. This is to be compatible with the older
+   *    version (DataShard). The KVFile is shard.dat under that directory
+   *  - a hdfs file starting with "hdfs://"
+   * @param mode KVFile open mode, KVFile::kRead, KVFile::kWrite or
+   * KVFile::kAppend
+   * @param bufsize Cache bufsize bytes data for every disk op (read or write),
+   * default is 10MB.
+   */
+  KVFile(const std::string& path, Mode mode, int bufsize = 10485760);
+  ~KVFile();
+
+#ifdef USE_PROTOBUF
+  /**
+   * read next tuple from the KVFile.
+   *
+   * @param key Tuple key
+   * @param val Record of type Message
+   * @return false if read unsuccess, e.g., the tuple was not inserted
+   *         completely.
+   */
+  bool Next(std::string* key, google::protobuf::Message* val);
+  /**
+   * Append one tuple to the KVFile.
+   *
+   * @param key e.g., image path
+   * @param val
+   * @return false if unsucess, e.g., inserted before
+   */
+  bool Insert(const std::string& key, const google::protobuf::Message& tuple);
+#endif
+  /**
+   * read next tuple from the KVFile.
+   *
+   * @param key Tuple key
+   * @param val Record of type string
+   * @return false if unsuccess, e.g. the tuple was not inserted completely.
+   */
+  bool Next(std::string* key, std::string* val);
+  /**
+   * Append one tuple to the KVFile.
+   *
+   * @param key e.g., image path
+   * @param val
+   * @return false if unsucess, e.g., inserted before
+   */
+  bool Insert(const std::string& key, const std::string& tuple);
+  /**
+   * Move the read pointer to the head of the KVFile file.
+   * Used for repeated reading.
+   */
+  void SeekToFirst();
+  /**
+   * Flush buffered data to disk.
+   * Used only for kCreate or kAppend.
+   */
+  void Flush();
+  /**
+   * Iterate through all tuples to get the num of all tuples.
+   *
+   * @return num of tuples
+   */
+  int Count();
+  /**
+   * @return path to KVFile file
+   */
+  inline std::string path() { return path_; }
+
+ protected:
+  /**
+   * Read the next key and prepare buffer for reading value.
+   *
+   * @param key
+   * @return length (i.e., bytes) of value field.
+   */
+  int Next(std::string* key);
+  /**
+   * Setup the disk pointer to the right position for append in case that
+   * the pervious write crashes.
+   *
+   * @param path KVFile path.
+   * @return offset (end pos) of the last success written record.
+   */
+  int PrepareForAppend(const std::string& path);
+  /**
+   * Read data from disk if the current data in the buffer is not a full field.
+   *
+   * @param size size of the next field.
+   */
+  bool PrepareNextField(int size);
+
+ private:
+  std::string path_ = "";
+  Mode mode_;
+  //!< either ifstream or ofstream
+  std::fstream fdat_;
+  //!< to avoid replicated record
+  std::unordered_set<std::string> keys_;
+  //!< internal buffer
+  char* buf_ = nullptr;
+  //!< offset inside the buf_
+  int offset_ = 0;
+  //!< allocated bytes for the buf_
+  int capacity_ = 0;
+  //!< bytes in buf_, used in reading
+  int bufsize_ = 0;
+};
+} /* io */
+
+/**
+ * @deprecated {ShardData is deprecated! Use KVFile}.
+using ShardData = KVFile;
+*/
+}  // namespace singa
+
+#endif  // SINGA_IO_KVFILE_H_

--- a/include/io/kvfile_store.h
+++ b/include/io/kvfile_store.h
@@ -1,0 +1,53 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+
+
+#ifndef SINGA_IO_KVFILE_STORE_H_
+#define SINGA_IO_KVFILE_STORE_H_
+
+#include <string>
+#include "io/store.h"
+#include "io/kvfile.h"
+
+namespace singa { namespace io {
+
+/**
+ * Use the KVFile as the data storage.
+ *
+ * KVFile is a binary file. Each tuple is stored as byte string.
+ */
+class KVFileStore : public Store {
+ public:
+  bool Open(const std::string& source, Mode mode) override;
+  void Close() override;
+  bool Read(std::string* key, std::string* value) override;
+  void SeekToFirst() override;
+  bool Write(const std::string& key, const std::string& value) override;
+  void Flush() override;
+
+ private:
+  KVFile* file_ = nullptr;
+  Mode mode_;
+};
+
+} /* io */
+} /* singa */
+#endif  // SINGA_IO_KVFILE_STORE_H_

--- a/include/io/kvfile_store.h
+++ b/include/io/kvfile_store.h
@@ -36,6 +36,7 @@ namespace singa { namespace io {
  */
 class KVFileStore : public Store {
  public:
+  ~KVFileStore() { Close();}
   bool Open(const std::string& source, Mode mode) override;
   void Close() override;
   bool Read(std::string* key, std::string* value) override;

--- a/include/io/kvfile_store.h
+++ b/include/io/kvfile_store.h
@@ -19,7 +19,6 @@
 *
 *************************************************************/
 
-
 #ifndef SINGA_IO_KVFILE_STORE_H_
 #define SINGA_IO_KVFILE_STORE_H_
 
@@ -27,7 +26,8 @@
 #include "io/store.h"
 #include "io/kvfile.h"
 
-namespace singa { namespace io {
+namespace singa {
+namespace io {
 
 /**
  * Use the KVFile as the data storage.
@@ -49,6 +49,7 @@ class KVFileStore : public Store {
   Mode mode_;
 };
 
-} /* io */
-} /* singa */
+}  // namespace io
+}  // namespace singa
+
 #endif  // SINGA_IO_KVFILE_STORE_H_

--- a/include/io/store.h
+++ b/include/io/store.h
@@ -1,0 +1,79 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+
+#ifndef SINGA_IO_STORE_H_
+#define SINGA_IO_STORE_H_
+
+#include <string>
+
+namespace singa { namespace io {
+using std::string;
+enum Mode { kCreate, kRead, kAppend };
+
+/**
+ * General key-value store that provides functions for reading and writing
+ * tuples.
+ *
+ * Subclasses implement the functions for a specific data storage, e.g., CSV
+ * file, HDFS, image folder, singa::io::SFile, leveldb, lmdb, etc.
+ */
+class Store {
+ public:
+  Store() { }
+  virtual ~Store() { }
+  /**
+   * @param[in] source path to the storage, could be a file path, folder path
+   * or hdfs path, or even a http url.
+   * @param[in] mode
+   * @return true if open successfully, otherwise false.
+   */
+  virtual bool Open(const std::string& source, Mode mode) = 0;
+  virtual void Close() = 0;
+  /**
+   * Read a tuple.
+   *
+   * @param[out] key
+   * @param[out] value
+   * @return true if read successfully, otherwise false.
+   */
+  virtual bool Read(std::string* key, std::string* value) = 0;
+  /**
+   * Seek the read header to the first tuple.
+   */
+  virtual void SeekToFirst() = 0;
+  /**
+   * Write a tuple.
+   *
+   * @param[in] key
+   * @param[in] value
+   * @return true if success, otherwise false.
+   */
+  virtual bool Write(const std::string& key, const std::string& value) = 0;
+  /**
+   * Flush writing buffer if it has.
+   */
+  virtual void Flush() {}
+};
+
+Store* CreateStore(const std::string& store);
+} // namespace io
+} /* singa */
+#endif  // SINGA_IO_STORE_H_

--- a/include/io/store.h
+++ b/include/io/store.h
@@ -38,6 +38,10 @@ enum Mode { kCreate, kRead, kAppend };
 class Store {
  public:
   Store() { }
+  /**
+   * In case that users forget to call Close() to release resources, e.g.,
+   * memory, you can release them here.
+   */
   virtual ~Store() { }
   /**
    * @param[in] source path to the storage, could be a file path, folder path
@@ -46,6 +50,9 @@ class Store {
    * @return true if open successfully, otherwise false.
    */
   virtual bool Open(const std::string& source, Mode mode) = 0;
+  /**
+   * Release resources.
+   */
   virtual void Close() = 0;
   /**
    * Read a tuple.
@@ -73,7 +80,22 @@ class Store {
   virtual void Flush() {}
 };
 
-Store* CreateStore(const std::string& store);
+/**
+ * Create a Store object.
+ *
+ * @param[in] backend identifier for a specific backend. Two backends are
+ * inluced currently, i.e., "kvfile", "textfile"
+ * @return a pointer to the newly created Store.
+ */
+Store* CreateStore(const string& backend);
+/**
+ * Create and open a Store object.
+ *
+ * @param[in] backend, @see CreateStore().
+ * @param[in] path
+ * @param[in] mode kRead or kCreate or kAppend
+ */
+Store* OpenStore(const string& backend, const string& path, Mode mode);
 } // namespace io
 } /* singa */
 #endif  // SINGA_IO_STORE_H_

--- a/include/io/store.h
+++ b/include/io/store.h
@@ -24,7 +24,9 @@
 
 #include <string>
 
-namespace singa { namespace io {
+namespace singa {
+namespace io {
+
 using std::string;
 enum Mode { kCreate, kRead, kAppend };
 
@@ -96,6 +98,8 @@ Store* CreateStore(const string& backend);
  * @param[in] mode kRead or kCreate or kAppend
  */
 Store* OpenStore(const string& backend, const string& path, Mode mode);
-} // namespace io
-} /* singa */
+
+}  // namespace io
+}  // namespace singa
+
 #endif  // SINGA_IO_STORE_H_

--- a/include/io/textfile_store.h
+++ b/include/io/textfile_store.h
@@ -1,0 +1,49 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+
+
+#include <fstream>
+#include "io/store.h"
+
+namespace singa { namespace io {
+/**
+ * Use text file as the data storage, one line per tuple.
+ *
+ * It is used for storeing CSV format data where the key is the line No. and
+ * the value is the line.
+ */
+class TextFileStore : public Store {
+ public:
+  bool Open(const std::string& source, Mode mode) override;
+  void Close() override;
+  bool Read(std::string* key, std::string* value) override;
+  void SeekToFirst() override;
+  bool Write(const std::string& key, const std::string& value) override;
+  void Flush() override;
+
+ private:
+  int lineNo_ = 0;
+  std::fstream* fs_ = nullptr;
+  Mode mode_;
+};
+} /* io */
+
+} /* singa */

--- a/include/io/textfile_store.h
+++ b/include/io/textfile_store.h
@@ -19,11 +19,15 @@
 *
 *************************************************************/
 
+#ifndef SINGA_IO_TEXTFILE_STORE_H_
+#define SINGA_IO_TEXTFILE_STORE_H_
 
 #include <fstream>
+#include <string>
 #include "io/store.h"
 
-namespace singa { namespace io {
+namespace singa {
+namespace io {
 /**
  * Use text file as the data storage, one line per tuple.
  *
@@ -45,6 +49,8 @@ class TextFileStore : public Store {
   std::fstream* fs_ = nullptr;
   Mode mode_;
 };
-} /* io */
 
-} /* singa */
+}  // namespace io
+}  // namespace singa
+
+#endif  // SINGA_IO_TEXTFILE_STORE_H_

--- a/include/neuralnet/input_layer.h
+++ b/include/neuralnet/input_layer.h
@@ -69,7 +69,8 @@ class StoreInputLayer : virtual public InputLayer {
   virtual bool Parse(int k, int flag, const string& key, const string& val) = 0;
 
  protected:
-  int batchsize_;
+  int batchsize_ = 1;
+  int random_skip_ = 0;
   io::Store* store_ = nullptr;
 };
 

--- a/include/neuralnet/input_layer.h
+++ b/include/neuralnet/input_layer.h
@@ -24,9 +24,9 @@
 
 #include <string>
 #include <vector>
+#include "io/store.h"
 #include "neuralnet/layer.h"
 #include "utils/data_shard.h"
-#include "io/store.h"
 /**
  * \file this file includes the declarations of input layers that inherit the
  * base InputLayer to load input features.

--- a/include/neuralnet/layer.h
+++ b/include/neuralnet/layer.h
@@ -34,6 +34,8 @@
 
 namespace singa {
 using std::vector;
+// TODO(wangwei) make AuxType a template argument for Layer.
+using AuxType = int;
 /**
  * Base layer class.
  *
@@ -186,6 +188,12 @@ class Layer {
     return &data_;
   }
   /**
+   * @return auxiliary data, e.g., image label.
+   */
+  virtual const vector<AuxType>& aux_data(const Layer* from = nullptr) const {
+    return aux_data_;
+  }
+  /**
    * @see data().
    * @return the const ref of the Blob for the gradient of this layer, mainly
    * used in BP algorithm.
@@ -205,6 +213,7 @@ class Layer {
  protected:
   LayerProto layer_conf_;
   Blob<float> data_, grad_;
+  vector<AuxType> aux_data_;
 };
 
 /**

--- a/include/singa.h
+++ b/include/singa.h
@@ -23,6 +23,7 @@
 #define SINGA_SINGA_H_
 
 #include "comm/socket.h"
+#include "io/store.h"
 #include "neuralnet/neuralnet.h"
 #include "neuralnet/layer.h"
 #include "proto/job.pb.h"
@@ -31,7 +32,6 @@
 #include "utils/param.h"
 #include "utils/singleton.h"
 #include "utils/factory.h"
-#include "io/store.h"
 #include "./driver.h"
 
 #endif  // SINGA_SINGA_H_

--- a/include/singa.h
+++ b/include/singa.h
@@ -31,6 +31,7 @@
 #include "utils/param.h"
 #include "utils/singleton.h"
 #include "utils/factory.h"
+#include "io/store.h"
 #include "./driver.h"
 
 #endif  // SINGA_SINGA_H_

--- a/include/utils/image_transform.h
+++ b/include/utils/image_transform.h
@@ -1,0 +1,29 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+#include <glog/logging.h>
+// TODO(wangwei) provide image transformation API, the implementation can be
+// done by opencv, manual transform, or mshadow.
+namespace singa {
+
+void ImageTransform(const float* in, const float* mean, bool mirror, int h_crop,
+    int w_crop, int h_offset, int w_offset, int channel, int height, int width,
+    float scale, float* out);
+} /* singa */

--- a/include/utils/image_transform.h
+++ b/include/utils/image_transform.h
@@ -18,6 +18,10 @@
 * under the License.
 *
 *************************************************************/
+
+#ifndef SINGA_UTILS_IMAGE_TRANSFORM_H_
+#define SINGA_UTILS_IMAGE_TRANSFORM_H_
+
 #include <glog/logging.h>
 // TODO(wangwei) provide image transformation API, the implementation can be
 // done by opencv, manual transform, or mshadow.
@@ -26,4 +30,6 @@ namespace singa {
 void ImageTransform(const float* in, const float* mean, bool mirror, int h_crop,
     int w_crop, int h_offset, int w_offset, int channel, int height, int width,
     float scale, float* out);
-} /* singa */
+}  // namespace singa
+
+#endif  // SINGA_UTILS_IMAGE_TRANSFORM_H_

--- a/include/utils/tokenizer.h
+++ b/include/utils/tokenizer.h
@@ -18,10 +18,13 @@
 * under the License.
 *
 *************************************************************/
-#ifndef SINGA_UTILS_TOKENIER_H_
-#define SINGA_UTILS_TOKENIER_H_
-#include <string>
+
+#ifndef SINGA_UTILS_TOKENIZER_H_
+#define SINGA_UTILS_TOKENIZER_H_
+
 #include <glog/logging.h>
+#include <string>
+
 namespace singa {
 /**
  * Tokenize a string.
@@ -48,12 +51,14 @@ class Tokenizer {
     out = buf_.substr(start, pos);
     return *this;
   }
-
   bool Valid() { return start_ < buf_.length(); }
-  private:
-   unsigned start_;
-   std::string sep_;
-   const std::string& buf_;
+
+ private:
+  unsigned start_;
+  std::string sep_;
+  const std::string& buf_;
 };
-} /* singa */
-#endif // SINGA_UTILS_TOKENIER_H_
+
+}  // namespace singa
+
+#endif  // SINGA_UTILS_TOKENIZER_H_

--- a/include/utils/tokenizer.h
+++ b/include/utils/tokenizer.h
@@ -18,33 +18,42 @@
 * under the License.
 *
 *************************************************************/
-
-
-#include <fstream>
-#include "io/store.h"
-
-namespace singa { namespace io {
+#ifndef SINGA_UTILS_TOKENIER_H_
+#define SINGA_UTILS_TOKENIER_H_
+#include <string>
+#include <glog/logging.h>
+namespace singa {
 /**
- * Use text file as the data storage, one line per tuple.
+ * Tokenize a string.
  *
- * It is used for storeing CSV format data where the key is the line No. and
- * the value is the line.
+ * example:
+ * Tokenizer t("assa,asf;wes", ",;");
+ * string x;
+ * t >> x; // x is assa
+ * t >> x; // x is asf
+ * t >> x; // x is wes
+ * cout << (t >> x); // print 0.
  */
-class TextFileStore : public Store {
+class Tokenizer {
  public:
-  ~TextFileStore() { Close(); }
-  bool Open(const std::string& source, Mode mode) override;
-  void Close() override;
-  bool Read(std::string* key, std::string* value) override;
-  void SeekToFirst() override;
-  bool Write(const std::string& key, const std::string& value) override;
-  void Flush() override;
+  Tokenizer(const std::string& str, const std::string& sep): start_(0),
+  sep_(sep), buf_(str) {}
+  Tokenizer & operator>>(std::string& out) {
+    CHECK_LT(start_, buf_.length());
+    int start = start_;
+    auto pos = buf_.find_first_of(sep_, start);
+    if (pos == std::string::npos)
+      pos = buf_.length();
+    start_ = pos + 1;
+    out = buf_.substr(start, pos);
+    return *this;
+  }
 
- private:
-  int lineNo_ = 0;
-  std::fstream* fs_ = nullptr;
-  Mode mode_;
+  bool Valid() { return start_ < buf_.length(); }
+  private:
+   unsigned start_;
+   std::string sep_;
+   const std::string& buf_;
 };
-} /* io */
-
 } /* singa */
+#endif // SINGA_UTILS_TOKENIER_H_

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -54,6 +54,11 @@ void Driver::Init(int argc, char **argv) {
   ReadProtoFromTextFile(argv[arg_pos+1], &job_conf_);
 
   // register layers
+
+  RegisterLayer<ProtoRecordLayer, int>(kProtoRecord);
+  RegisterLayer<CSVRecordLayer, int>(kCSVRecord);
+  RegisterLayer<ImagePreprocessLayer, int>(kImagePreprocess);
+
   RegisterLayer<BridgeDstLayer, int>(kBridgeDst);
   RegisterLayer<BridgeSrcLayer, int>(kBridgeSrc);
   RegisterLayer<ConvolutionLayer, int>(kConvolution);

--- a/src/io/kvfile.cc
+++ b/src/io/kvfile.cc
@@ -22,9 +22,10 @@
 #include "io/kvfile.h"
 
 #include <glog/logging.h>
-#include <string>
 
-namespace singa { namespace io {
+namespace singa {
+namespace io {
+
 KVFile::KVFile(const std::string& path, Mode mode, int capacity) :
 path_(path), mode_(mode), capacity_(capacity) {
   buf_ = new char[capacity];
@@ -213,5 +214,5 @@ bool KVFile::PrepareNextField(int size) {
   return true;
 }
 
-} /* io */
+}  // namespace io
 }  // namespace singa

--- a/src/io/kvfile.cc
+++ b/src/io/kvfile.cc
@@ -1,0 +1,217 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+
+#include "io/kvfile.h"
+
+#include <glog/logging.h>
+#include <string>
+
+namespace singa { namespace io {
+KVFile::KVFile(const std::string& path, Mode mode, int capacity) :
+path_(path), mode_(mode), capacity_(capacity) {
+  buf_ = new char[capacity];
+  switch (mode) {
+    case KVFile::kRead:
+      fdat_.open(path_, std::ios::in | std::ios::binary);
+      if (!fdat_.is_open()) {
+        // path may be a directory
+        path_ = path + "/shard.dat";
+        fdat_.open(path_, std::ios::in | std::ios::binary);
+      }
+      CHECK(fdat_.is_open()) << "Cannot create file " << path_;
+      break;
+    case KVFile::kCreate:
+      fdat_.open(path_, std::ios::binary | std::ios::out | std::ios::trunc);
+      CHECK(fdat_.is_open()) << "Cannot create file " << path_;
+      break;
+    case KVFile::kAppend:
+      fdat_.open(path_, std::ios::in | std::ios::binary);
+      if (!fdat_.is_open()) {
+        // path may be a directory
+        path_ = path + "/shard.dat";
+        fdat_.open(path_, std::ios::in | std::ios::binary);
+      }
+      CHECK(fdat_.is_open()) << "Cannot open file " << path_;
+      {
+        int last_tuple = PrepareForAppend(path_);
+        fdat_.open(path_, std::ios::binary | std::ios::out
+            | std::ios::in | std::ios::ate);
+        fdat_.seekp(last_tuple);
+      }
+      break;
+    default:
+      LOG(FATAL) << "unknown model to open KVFile " << mode;
+      break;
+  }
+}
+
+KVFile::~KVFile() {
+  if (mode_ != kRead)
+    Flush();
+  delete buf_;
+  fdat_.close();
+}
+#ifdef USE_PROTOBUF
+bool KVFile::Next(std::string* key, google::protobuf::Message* val) {
+  int vallen = Next(key);
+  if (vallen == 0) return false;
+  val->ParseFromArray(buf_ + offset_, vallen);
+  offset_ += vallen;
+  return true;
+}
+
+bool KVFile::Insert(const std::string& key,
+    const google::protobuf::Message& val) {
+  std::string str;
+  val.SerializeToString(&str);
+  return Insert(key, str);
+}
+#endif
+
+bool KVFile::Next(std::string *key, std::string* val) {
+  int vallen = Next(key);
+  if (vallen == 0) return false;
+  val->clear();
+  for (int i = 0; i < vallen; ++i)
+    val->push_back(buf_[offset_ + i]);
+  offset_ += vallen;
+  return true;
+}
+
+// insert one complete tuple
+bool KVFile::Insert(const std::string& key, const std::string& val) {
+  if (keys_.find(key) != keys_.end() || val.size() == 0)
+    return false;
+  int size = key.size() + val.size() + 2*sizeof(size_t);
+  if (bufsize_ + size > capacity_) {
+    fdat_.write(buf_, bufsize_);
+    bufsize_ = 0;
+    CHECK_LE(size, capacity_) << "Tuple size is larger than capacity "
+      << "Try a larger capacity size";
+  }
+  *reinterpret_cast<size_t*>(buf_ + bufsize_) = key.size();
+  bufsize_ += sizeof(size_t);
+  memcpy(buf_ + bufsize_, key.data(), key.size());
+  bufsize_ += key.size();
+  *reinterpret_cast<size_t*>(buf_ + bufsize_) = val.size();
+  bufsize_ += sizeof(size_t);
+  memcpy(buf_ + bufsize_, val.data(), val.size());
+  bufsize_ += val.size();
+  return true;
+}
+
+void KVFile::SeekToFirst() {
+  CHECK_EQ(mode_, kRead);
+  bufsize_ = 0;
+  offset_ = 0;
+  fdat_.clear();
+  fdat_.seekg(0);
+  CHECK(fdat_.is_open()) << "Cannot create file " << path_;
+}
+
+void KVFile::Flush() {
+  fdat_.write(buf_, bufsize_);
+  fdat_.flush();
+  bufsize_ = 0;
+}
+
+int KVFile::Count() {
+  std::ifstream fin(path_, std::ios::in | std::ios::binary);
+  CHECK(fdat_.is_open()) << "Cannot create file " << path_;
+  int count = 0;
+  while (true) {
+    size_t len;
+    fin.read(reinterpret_cast<char*>(&len), sizeof(len));
+    if (!fin.good()) break;
+    fin.seekg(len, std::ios_base::cur);
+    if (!fin.good()) break;
+    fin.read(reinterpret_cast<char*>(&len), sizeof(len));
+    if (!fin.good()) break;
+    fin.seekg(len, std::ios_base::cur);
+    if (!fin.good()) break;
+    count++;
+  }
+  fin.close();
+  return count;
+}
+
+int KVFile::Next(std::string *key) {
+  key->clear();
+  int ssize = sizeof(size_t);
+  if (!PrepareNextField(ssize)) return 0;
+  int keylen = *reinterpret_cast<size_t*>(buf_ + offset_);
+  offset_ += ssize;
+  if (!PrepareNextField(keylen)) return 0;
+  for (int i = 0; i < keylen; ++i)
+    key->push_back(buf_[offset_ + i]);
+  offset_ += keylen;
+  if (!PrepareNextField(ssize)) return 0;
+  int vallen = *reinterpret_cast<size_t*>(buf_ + offset_);
+  offset_ += ssize;
+  if (!PrepareNextField(vallen)) return 0;
+  return vallen;
+}
+
+int KVFile::PrepareForAppend(const std::string& path) {
+  std::ifstream fin(path, std::ios::in | std::ios::binary);
+  if (!fin.is_open()) return 0;
+  int last_tuple_offset = 0;
+  char buf[256];
+  size_t len;
+  while (true) {
+    fin.read(reinterpret_cast<char*>(&len), sizeof(len));
+    if (!fin.good()) break;
+    fin.read(buf, len);
+    buf[len] = '\0';
+    if (!fin.good()) break;
+    fin.read(reinterpret_cast<char*>(&len), sizeof(len));
+    if (!fin.good()) break;
+    fin.seekg(len, std::ios_base::cur);
+    if (!fin.good()) break;
+    keys_.insert(std::string(buf));
+    last_tuple_offset = fin.tellg();
+  }
+  fin.close();
+  return last_tuple_offset;
+}
+
+// if the buf does not have the next complete field, read data from disk
+bool KVFile::PrepareNextField(int size) {
+  if (offset_ + size > bufsize_) {
+    bufsize_ -= offset_;
+    // wangsh: commented, not sure what this check does
+    // CHECK_LE(bufsize_, offset_);
+    for (int i = 0; i < bufsize_; ++i)
+      buf_[i] = buf_[i + offset_];
+    offset_ = 0;
+    if (fdat_.eof()) {
+      return false;
+    } else {
+      fdat_.read(buf_ + bufsize_, capacity_ - bufsize_);
+      bufsize_ += fdat_.gcount();
+      if (size > bufsize_) return false;
+    }
+  }
+  return true;
+}
+
+} /* io */
+}  // namespace singa

--- a/src/io/kvfile_store.cc
+++ b/src/io/kvfile_store.cc
@@ -19,11 +19,12 @@
 *
 *************************************************************/
 
-
 #include "io/kvfile_store.h"
+
 #include <glog/logging.h>
 
-namespace singa { namespace io {
+namespace singa {
+namespace io {
 
 bool KVFileStore::Open(const std::string& source, Mode mode) {
   CHECK(file_ == nullptr);
@@ -66,6 +67,5 @@ void KVFileStore::Flush() {
   file_->Flush();
 }
 
-} /* io */
-
-} /* singa */
+}  // namespace io
+}  // namespace singa

--- a/src/io/kvfile_store.cc
+++ b/src/io/kvfile_store.cc
@@ -1,0 +1,71 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+
+
+#include "io/kvfile_store.h"
+#include <glog/logging.h>
+
+namespace singa { namespace io {
+
+bool KVFileStore::Open(const std::string& source, Mode mode) {
+  CHECK(file_ == nullptr);
+  if (mode == kRead)
+    file_ = new KVFile(source, KVFile::kRead);
+  else if (mode == kCreate)
+    file_ = new KVFile(source, KVFile::kCreate);
+  else if (mode == kAppend)
+    file_ = new KVFile(source, KVFile::kAppend);
+  mode_ = mode;
+  return file_ != nullptr;
+}
+
+void KVFileStore::Close() {
+  if (file_ != nullptr)
+    delete file_;
+  file_ = nullptr;
+}
+
+bool KVFileStore::Read(std::string* key, std::string* value) {
+  CHECK_EQ(mode_, kRead);
+  CHECK(file_ != nullptr);
+  return file_->Next(key, value);
+}
+
+void KVFileStore::SeekToFirst() {
+  CHECK_EQ(mode_, kRead);
+  CHECK(file_ != nullptr);
+  file_->SeekToFirst();
+}
+bool KVFileStore::Write(const std::string& key, const std::string& value) {
+  CHECK_NE(mode_, kRead);
+  CHECK(file_ != nullptr);
+  return file_->Insert(key, value);
+}
+
+void KVFileStore::Flush() {
+  CHECK_NE(mode_, kRead);
+  CHECK(file_!= nullptr);
+  file_->Flush();
+}
+
+} /* io */
+
+} /* singa */

--- a/src/io/store.cc
+++ b/src/io/store.cc
@@ -1,0 +1,57 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+
+
+#include "io/store.h"
+#include "io/kvfile_store.h"
+#include "io/textfile_store.h"
+
+namespace singa { namespace io {
+Store* CreateStore(const std::string& backend) {
+  Store *store = nullptr;
+  if (backend.compare("textfile") == 0) {
+    store = new TextFileStore();
+  } else if (backend.compare("kvfile") == 0) {
+    store = new KVFileStore();
+  }
+
+#ifdef USE_LMDB
+  if (backend == "lmdb") {
+    return new LMDBStore();
+  }
+#endif
+
+#ifdef USE_OPENCV
+  if (backend == "imagefolder") {
+    return new ImageFolderStore();
+  }
+#endif
+
+#ifdef USE_HDFS
+  if (backend == "hdfs") {
+    return new HDFSStore();
+  }
+#endif
+  return store;
+}
+} /* io */
+
+} /* singa */

--- a/src/io/textfile_store.cc
+++ b/src/io/textfile_store.cc
@@ -40,6 +40,7 @@ void TextFileStore::Close() {
       fs_->close();
     }
     delete fs_;
+    fs_ = nullptr;
   }
 }
 

--- a/src/io/textfile_store.cc
+++ b/src/io/textfile_store.cc
@@ -23,13 +23,14 @@
 #include "io/textfile_store.h"
 #include <glog/logging.h>
 
-namespace singa { namespace io {
+namespace singa {
+namespace io {
+
 bool TextFileStore::Open(const std::string& source, Mode mode) {
   if (mode == kRead)
     fs_ = new std::fstream(source, std::fstream::in);
-  else if (mode == kCreate) {
+  else if (mode == kCreate)
     fs_ = new std::fstream(source, std::fstream::out);
-  }
   mode_ = mode;
   return fs_->is_open();
 }
@@ -79,6 +80,5 @@ void TextFileStore::Flush() {
   fs_->flush();
 }
 
-} /* io */
-
-} /* singa */
+}  // namespace io
+}  // namespace singa

--- a/src/io/textfile_store.cc
+++ b/src/io/textfile_store.cc
@@ -1,0 +1,83 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+
+
+#include "io/textfile_store.h"
+#include <glog/logging.h>
+
+namespace singa { namespace io {
+bool TextFileStore::Open(const std::string& source, Mode mode) {
+  if (mode == kRead)
+    fs_ = new std::fstream(source, std::fstream::in);
+  else if (mode == kCreate) {
+    fs_ = new std::fstream(source, std::fstream::out);
+  }
+  mode_ = mode;
+  return fs_->is_open();
+}
+
+void TextFileStore::Close() {
+  if (fs_ != nullptr) {
+    if (fs_->is_open()) {
+      fs_->close();
+    }
+    delete fs_;
+  }
+}
+
+bool TextFileStore::Read(std::string* key, std::string* value) {
+  CHECK_EQ(mode_, kRead);
+  CHECK(fs_ != nullptr);
+  CHECK(value != nullptr);
+  CHECK(key != nullptr);
+  if (!std::getline(*fs_, *value)) {
+    if (fs_->eof())
+      return false;
+    else
+      LOG(FATAL) << "error in reading csv file";
+  }
+  *key = std::to_string(lineNo_++);
+  return true;
+}
+
+void TextFileStore::SeekToFirst() {
+  CHECK_EQ(mode_, kRead);
+  CHECK(fs_ != nullptr);
+  lineNo_ = 0;
+  fs_->clear();
+  fs_->seekg(0);
+}
+
+bool TextFileStore::Write(const std::string& key, const std::string& value) {
+  CHECK_NE(mode_, kRead);
+  CHECK(fs_ != nullptr);
+  // csv store does not write key
+  *fs_ << value << '\n';
+  return true;
+}
+
+void TextFileStore::Flush() {
+  fs_->flush();
+}
+
+} /* io */
+
+} /* singa */

--- a/src/neuralnet/input_layer.cc
+++ b/src/neuralnet/input_layer.cc
@@ -104,10 +104,10 @@ void StoreInputLayer::ComputeFeature(int flag,
         store_->SeekToFirst();
         CHECK(store_->Read(&key, &val));
       }
-      random_skip_ --;
+      random_skip_--;
     }
   }
-  for (int k = 0; k < batchsize_; k++){
+  for (int k = 0; k < batchsize_; k++) {
     if (!store_->Read(&key, &val)) {
       store_->SeekToFirst();
       CHECK(store_->Read(&key, &val));
@@ -153,7 +153,7 @@ void SingleLabelRecordLayer::ComputeFeature(int flag,
 
   if (mean_.count()) {
     const float* mean = mean_.cpu_data();
-    for (int k = 0; k < batchsize_; k++){
+    for (int k = 0; k < batchsize_; k++) {
       float* dptr = data_.mutable_cpu_data() + k * mean_.count();
       for (int i = 0; i < mean_.count(); i++) {
         dptr[i] -= mean[i];
@@ -162,7 +162,7 @@ void SingleLabelRecordLayer::ComputeFeature(int flag,
   }
   if (std_.count()) {
     const float* std = std_.cpu_data();
-    for (int k = 0; k < batchsize_; k++){
+    for (int k = 0; k < batchsize_; k++) {
       float* dptr = data_.mutable_cpu_data() + k * std_.count();
       for (int i = 0; i < std_.count(); i++) {
         dptr[i] /= std[i];

--- a/src/neuralnet/loss_layer.cc
+++ b/src/neuralnet/loss_layer.cc
@@ -92,7 +92,7 @@ void SoftmaxLossLayer::ComputeFeature(int flag,
   Tensor<cpu, 2> prob(data_.mutable_cpu_data(), s);
   Tensor<cpu, 2> src(srclayers[0]->mutable_data(this)->mutable_cpu_data(), s);
   Softmax(prob, src);
-  const float* label = srclayers[1]->data(this).cpu_data();
+  const auto& label = srclayers[1]->aux_data(this);
   const float* probptr = prob.dptr;
   float loss = 0, precision = 0;
   for (int n = 0; n < batchsize_; n++) {
@@ -123,7 +123,7 @@ void SoftmaxLossLayer::ComputeFeature(int flag,
 
 void SoftmaxLossLayer::ComputeGradient(int flag,
     const vector<Layer*>& srclayers) {
-  const float* label = srclayers[1]->data(this).cpu_data();
+  const auto& label = srclayers[1]->aux_data();
   Blob<float>* gsrcblob = srclayers[0]->mutable_grad(this);
   gsrcblob->CopyFrom(data_);
   float* gsrcptr = gsrcblob->mutable_cpu_data();

--- a/src/proto/job.proto
+++ b/src/proto/job.proto
@@ -190,8 +190,6 @@ message LayerProto {
   optional ConcateProto concate_conf = 31;
   // configuration for dropout layer
   optional DropoutProto dropout_conf = 33;
-  // configuration for euclideanloss layer
-  optional EuclideanLossProto euclideanloss_conf = 50;
   // configuration for inner product layer
   optional InnerProductProto innerproduct_conf = 34;
   // configuration for local response normalization layer
@@ -218,6 +216,9 @@ message LayerProto {
   optional SoftmaxLossProto softmaxloss_conf = 40;
   // configuration for split layer
   optional SplitProto split_conf = 42;
+  // configuration for store input layers
+  optional StoreProto store_conf = 51;
+
 
 
   // overrides the partition dimension for neural net
@@ -316,9 +317,20 @@ message SplitProto {
   optional int32 num_splits = 1 [default = 1];
 }
 
-message EuclideanLossProto {
+message StoreProto {
+  required string backend = 1;
+  optional string path = 2;
+  optional string separator = 3 [default = ","];
+  optional string mean_file = 4;
+  optional string std_file = 5;
+  optional float mean_value = 6;
+  optional float std_value = 7;
+  optional int32 batchsize = 8 [default = 1];
+  repeated int32 shape = 9;
+  optional bool encoded = 10 [default = false];
+  optional int32 random_skip = 11 [default = 0];
+  optional bool has_label = 12 [default = true];
 }
-
 message SoftmaxLossProto {
   // computing accuracy against topk results
   optional int32 topk = 1 [default = 1];
@@ -525,11 +537,12 @@ enum InitMethod {
 enum LayerType {
   // Data layers
   //  - Load records from file, database
+  kProtoRecord = 29;
+  kCSVRecord = 30;
+  kImagePreprocess = 31;
   kLMDBData = 17;
   kPrefetch = 19;
   kShardData = 3;
-  // Parser layers
-  //  - Parse features from records, e.g., pixels
   kLabel = 18;
   kMnist = 7;
   kRGBImage = 10;
@@ -582,6 +595,7 @@ enum Phase {
   kForward = 32;
   kBackward = 64;
   kLoss = 128;
+  kDeploy = 256;
 }
 
 enum ParamType {

--- a/src/test/test_csv_record_layer.cc
+++ b/src/test/test_csv_record_layer.cc
@@ -48,7 +48,7 @@ class CSVRecordLayerTest : public ::testing::Test {
 TEST_F(CSVRecordLayerTest, Setup) {
   singa::CSVRecordLayer layer;
   layer.Setup(csv_conf, std::vector<singa::Layer*>{});
-  EXPECT_EQ(2, layer.aux_data().size());
+  EXPECT_EQ(2, static_cast<int>(layer.aux_data().size()));
   EXPECT_EQ(6, layer.data(nullptr).count());
 }
 

--- a/src/test/test_csv_record_layer.cc
+++ b/src/test/test_csv_record_layer.cc
@@ -1,0 +1,92 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+#include <string>
+#include <vector>
+#include <fstream>
+
+#include "gtest/gtest.h"
+#include "neuralnet/input_layer.h"
+#include "proto/job.pb.h"
+
+class CSVRecordLayerTest : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    std::string path ="src/test/test.csv";
+    std::ofstream ofs(path, std::ofstream::out);
+    ASSERT_TRUE(ofs.is_open());
+    ofs << "12,3.2,1,14.1\n";
+    ofs << "2,0.2,0,1.1\n";
+    ofs << "1,2.2,1,4.1\n";
+    ofs.close();
+    auto conf = csv_conf.mutable_store_conf();
+    conf->set_path(path);
+    conf->set_batchsize(2);
+    conf->add_shape(3);
+    conf->set_backend("textfile");
+  }
+  singa::LayerProto csv_conf;
+};
+
+TEST_F(CSVRecordLayerTest, Setup) {
+  singa::CSVRecordLayer layer;
+  layer.Setup(csv_conf, std::vector<singa::Layer*>{});
+  EXPECT_EQ(2, layer.aux_data().size());
+  EXPECT_EQ(6, layer.data(nullptr).count());
+}
+
+TEST_F(CSVRecordLayerTest, ComputeFeature) {
+  singa::CSVRecordLayer csv;
+  csv.Setup(csv_conf, std::vector<singa::Layer*>{});
+  csv.ComputeFeature(singa::kTrain, std::vector<singa::Layer*>{});
+
+  EXPECT_EQ(12, csv.aux_data()[0]);
+  EXPECT_EQ(2, csv.aux_data()[1]);
+  auto data = csv.data(nullptr);
+  EXPECT_EQ(3.2f, data.cpu_data()[0]);
+  EXPECT_EQ(14.1f, data.cpu_data()[2]);
+  EXPECT_EQ(0.2f, data.cpu_data()[3]);
+  EXPECT_EQ(1.1f, data.cpu_data()[5]);
+}
+TEST_F(CSVRecordLayerTest, ComputeFeatureDeploy) {
+  singa::CSVRecordLayer csv;
+  csv_conf.mutable_store_conf()->set_shape(0, 4);
+  csv.Setup(csv_conf, std::vector<singa::Layer*>{});
+  csv.ComputeFeature(singa::kDeploy, std::vector<singa::Layer*>{});
+
+  auto data = csv.data(nullptr);
+  EXPECT_EQ(12.f, data.cpu_data()[0]);
+  EXPECT_EQ(1.f, data.cpu_data()[2]);
+  EXPECT_EQ(14.1f, data.cpu_data()[3]);
+  EXPECT_EQ(0.2f, data.cpu_data()[5]);
+}
+
+TEST_F(CSVRecordLayerTest, SeekToFirst) {
+  singa::CSVRecordLayer csv;
+  csv.Setup(csv_conf, std::vector<singa::Layer*>{});
+  csv.ComputeFeature(singa::kTrain, std::vector<singa::Layer*>{});
+  csv.ComputeFeature(singa::kTrain, std::vector<singa::Layer*>{});
+
+  auto data = csv.data(nullptr);
+  EXPECT_EQ(2.2f, data.cpu_data()[0]);
+  EXPECT_EQ(4.1f, data.cpu_data()[2]);
+  EXPECT_EQ(3.2f, data.cpu_data()[3]);
+  EXPECT_EQ(14.1f, data.cpu_data()[5]);
+}

--- a/src/test/test_proto_record_layer.cc
+++ b/src/test/test_proto_record_layer.cc
@@ -1,0 +1,122 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "neuralnet/input_layer.h"
+#include "proto/job.pb.h"
+#include "proto/common.pb.h"
+
+class ProtoRecordLayerTest : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    std::string path ="src/test/test.bin";
+    auto* store = singa::io::CreateStore("kvfile");
+    store->Open(path, singa::io::kCreate);
+    {
+    singa::SingleLabelImageRecord image;
+    image.add_data(3.2);
+    image.add_data(1);
+    image.add_data(14.1);
+    image.set_label(12);
+    std::string val;
+    image.SerializeToString(&val);
+    store->Write("0", val);
+    }
+
+    {
+    singa::SingleLabelImageRecord image;
+    image.add_data(0.2);
+    image.add_data(0);
+    image.add_data(1.1);
+    image.set_label(2);
+    std::string val;
+    image.SerializeToString(&val);
+    store->Write("1", val);
+    }
+
+    {
+    singa::SingleLabelImageRecord image;
+    image.add_data(2.2);
+    image.add_data(1);
+    image.add_data(4.1);
+    image.set_label(1);
+    std::string val;
+    image.SerializeToString(&val);
+    store->Write("2", val);
+    }
+    store->Flush();
+    store->Close();
+
+    auto conf = image_conf.mutable_store_conf();
+    conf->set_path(path);
+    conf->set_batchsize(2);
+    conf->add_shape(3);
+    conf->set_backend("kvfile");
+  }
+  singa::LayerProto image_conf;
+};
+
+TEST_F(ProtoRecordLayerTest, Setup) {
+  singa::ProtoRecordLayer layer;
+  layer.Setup(image_conf, std::vector<singa::Layer*>{});
+  EXPECT_EQ(2, layer.aux_data().size());
+  EXPECT_EQ(6, layer.data(nullptr).count());
+}
+
+TEST_F(ProtoRecordLayerTest, ComputeFeature) {
+  singa::ProtoRecordLayer image;
+  image.Setup(image_conf, std::vector<singa::Layer*>{});
+  image.ComputeFeature(singa::kTrain, std::vector<singa::Layer*>{});
+
+  EXPECT_EQ(12, image.aux_data()[0]);
+  EXPECT_EQ(2, image.aux_data()[1]);
+  auto data = image.data(nullptr);
+  EXPECT_EQ(3.2f, data.cpu_data()[0]);
+  EXPECT_EQ(14.1f, data.cpu_data()[2]);
+  EXPECT_EQ(0.2f, data.cpu_data()[3]);
+  EXPECT_EQ(1.1f, data.cpu_data()[5]);
+}
+TEST_F(ProtoRecordLayerTest, ComputeFeatureDeploy) {
+  singa::ProtoRecordLayer image;
+  image.Setup(image_conf, std::vector<singa::Layer*>{});
+  image.ComputeFeature(singa::kDeploy, std::vector<singa::Layer*>{});
+
+  auto data = image.data(nullptr);
+  EXPECT_EQ(3.2f, data.cpu_data()[0]);
+  EXPECT_EQ(14.1f, data.cpu_data()[2]);
+  EXPECT_EQ(0.2f, data.cpu_data()[3]);
+  EXPECT_EQ(1.1f, data.cpu_data()[5]);
+}
+
+TEST_F(ProtoRecordLayerTest, SeekToFirst) {
+  singa::ProtoRecordLayer image;
+  image.Setup(image_conf, std::vector<singa::Layer*>{});
+  image.ComputeFeature(singa::kTrain, std::vector<singa::Layer*>{});
+  image.ComputeFeature(singa::kTrain, std::vector<singa::Layer*>{});
+
+  auto data = image.data(nullptr);
+  EXPECT_EQ(2.2f, data.cpu_data()[0]);
+  EXPECT_EQ(4.1f, data.cpu_data()[2]);
+  EXPECT_EQ(3.2f, data.cpu_data()[3]);
+  EXPECT_EQ(14.1f, data.cpu_data()[5]);
+}

--- a/src/test/test_proto_record_layer.cc
+++ b/src/test/test_proto_record_layer.cc
@@ -79,7 +79,7 @@ class ProtoRecordLayerTest : public ::testing::Test {
 TEST_F(ProtoRecordLayerTest, Setup) {
   singa::ProtoRecordLayer layer;
   layer.Setup(image_conf, std::vector<singa::Layer*>{});
-  EXPECT_EQ(2, layer.aux_data().size());
+  EXPECT_EQ(2, static_cast<int>(layer.aux_data().size()));
   EXPECT_EQ(6, layer.data(nullptr).count());
 }
 

--- a/src/test/test_store.cc
+++ b/src/test/test_store.cc
@@ -1,0 +1,92 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+#include <string>
+#include "gtest/gtest.h"
+#include "io/store.h"
+
+TEST(TextFileStore, Open) {
+  auto store = singa::io::CreateStore("textfile");
+  EXPECT_EQ(store->Open("src/test/store.txt", singa::io::kCreate), true);
+  store->Close();
+  EXPECT_EQ(store->Open("src/test/store.txt", singa::io::kRead), true);
+  store->Close();
+}
+
+TEST(TextFileStore, Write) {
+  auto store = singa::io::CreateStore("textfile");
+  store->Open("src/test/store.txt", singa::io::kCreate);
+  store->Write("001", "first tuple");
+  store->Write("002", "second tuple");
+  store->Flush();
+  store->Write("003", "third tuple");
+  store->Close();
+}
+
+TEST(TextFileStore, Read) {
+  auto store = singa::io::CreateStore("textfile");
+  EXPECT_EQ(store->Open("src/test/store.txt", singa::io::kRead), true);
+  std::string key, value;
+  EXPECT_EQ(store->Read(&key, &value), true);
+  EXPECT_EQ(key, "0");
+  EXPECT_EQ(value, "first tuple");
+
+  EXPECT_EQ(store->Read(&key, &value), true);
+  EXPECT_EQ(store->Read(&key, &value), true);
+  EXPECT_EQ(store->Read(&key, &value), false);
+  store->SeekToFirst();
+
+  EXPECT_EQ(store->Read(&key, &value), true);
+  EXPECT_EQ(key, "0");
+  EXPECT_EQ(value, "first tuple");
+}
+TEST(KVFileStore, Open) {
+  auto store = singa::io::CreateStore("kvfile");
+  EXPECT_EQ(store->Open("src/test/store.bin", singa::io::kCreate), true);
+  store->Close();
+  EXPECT_EQ(store->Open("src/test/store.bin", singa::io::kRead), true);
+  store->Close();
+}
+TEST(KVFileStore, Write) {
+  auto store = singa::io::CreateStore("kvfile");
+  store->Open("src/test/store.bin", singa::io::kCreate);
+  store->Write("001", "first tuple");
+  store->Write("002", "second tuple");
+  store->Flush();
+  store->Write("003", "third tuple");
+  store->Close();
+}
+TEST(KVFileStore, Read) {
+  auto store = singa::io::CreateStore("kvfile");
+  store->Open("src/test/store.bin", singa::io::kRead);
+  std::string key, value;
+  EXPECT_EQ(store->Read(&key, &value), true);
+  EXPECT_EQ(key, "001");
+  EXPECT_EQ(value, "first tuple");
+
+  EXPECT_EQ(store->Read(&key, &value), true);
+  EXPECT_EQ(store->Read(&key, &value), true);
+  EXPECT_EQ(store->Read(&key, &value), false);
+  store->SeekToFirst();
+
+  EXPECT_EQ(store->Read(&key, &value), true);
+  EXPECT_EQ(key, "001");
+  EXPECT_EQ(value, "first tuple");
+}

--- a/src/utils/image_transform.cc
+++ b/src/utils/image_transform.cc
@@ -53,4 +53,5 @@ void ImageTransform(const float* in, const float* mean, bool mirror, int h_crop,
     }
   }
 }
-} /* singa */
+
+}  // namespace singa


### PR DESCRIPTION
This ticket is to refine the data input layers, including loading and parsing layers.

* Add Store abstraction for reading and writing data. Two backends are supported now,
      1. KVFile, which was named DataShard. It is a binary file, each tuple has a unique key.
      2. TextFile, which is a plain text file with each line be the value field of a tuple (the key is the line No.).    
TODO, implment HDFS and image folder as the backend.

* Add StoreLayer to read data from Store, e.g., KVFile, TextFile (will add support for HDFS later).
* Implemente subclasses of StoreLayer to parse different format tuples, e.g., SingleLabelImageRecord or CSV line.
* Update examples to use the new input layers.
* Add unit tests.
* Add a function for Layer class, which returns a vector<AuxType> for auxiliary data (e.g., label).

TODO
    1. make AuxType a template argument of Layer class, and extend data() to return a vector of Blob for multiple dense features.
    2. separate layer classeses into different files to make the structure of the source folder clear.
