### PR TITLE
[SINGA-93] Remove the asterisk in the log tcp://169.254.12.152:*:49152

### DIFF
--- a/src/comm/socket.cc
+++ b/src/comm/socket.cc
@@ -120,7 +120,7 @@ int Router::Bind(const std::string& endpoint) {
     port = zsock_bind(router_, "%s", endpoint.c_str());
   }
   CHECK_NE(port, -1) << endpoint;
-  LOG(INFO) << "bind successfully to " << endpoint + ":" + std::to_string(port);
+  LOG(INFO) << "bind successfully to " << zsock_endpoint(router_);
   return port;
 }
 


### PR DESCRIPTION
I think the asterisk is unnecessary in the log as follows:
I1016 11:45:58.958664 3862 socket.cc:123] bind successfully to tcp://169.254.12.152:*:49152.
It's better to remove it.