### PR TITLE
SINGA-94 Move call to google::InitGoogleLogging() from Driver::Init() to main().

### DIFF
--- a/src/driver.cc
+++ b/src/driver.cc
@@ -64,17 +64,16 @@ extern "C" void openblas_set_num_threads(int num);
 namespace singa {
 
 void Driver::Init(int argc, char **argv) {
-  google::InitGoogleLogging(argv[0]);
-  //  unique job ID generated from singa-run.sh, passed in as "-singa_job <id>"
+  // unique job ID generated from singa-run.sh, passed in as "-singa_job <id>"
   int arg_pos = ArgPos(argc, argv, "-singa_job");
   job_id_ = (arg_pos != -1) ? atoi(argv[arg_pos+1]) : -1;
-  //  global signa conf passed by singa-run.sh as "-singa_conf <path>"
+  // global signa conf passed by singa-run.sh as "-singa_conf <path>"
   arg_pos = ArgPos(argc, argv, "-singa_conf");
   if (arg_pos != -1)
     ReadProtoFromTextFile(argv[arg_pos+1], &singa_conf_);
   else
     ReadProtoFromTextFile("conf/singa.conf", &singa_conf_);
-  //  job conf passed by users as "-conf <path>"
+  // job conf passed by users as "-conf <path>"
   arg_pos = ArgPos(argc, argv, "-conf");
   CHECK_NE(arg_pos, -1);
   ReadProtoFromTextFile(argv[arg_pos+1], &job_conf_);

--- a/src/main.cc
+++ b/src/main.cc
@@ -20,7 +20,9 @@
 *************************************************************/
 
 #include <iostream>
+#include <glog/logging.h>
 #include "singa/singa.h"
+
 /**
  * \file main.cc provides an example main function.
  *
@@ -51,6 +53,10 @@ int main(int argc, char **argv) {
               << "-test\t test performance or extract features\n";
     return 0;
   }
+
+  // initialize glog before creating the driver
+  google::InitGoogleLogging(argv[0]);
+
   // must create driver at the beginning and call its Init method.
   singa::Driver driver;
   driver.Init(argc, argv);


### PR DESCRIPTION
It appears that google::InitGoogleLogging() was never intended to be called inside a library.
The reason is because calling google::InitGoogleLogging() twice results in program termination with the error log "You called InitGoogleLogging() twice!".
Calling google::InitGoogleLogging() inside Driver::Init() prevents users of the Singa library from making this call in their own main() function, as recommended by glog documentation.