### PR TITLE
SINGA-95 Add make test after building

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -122,7 +122,7 @@ TEST_SRCS := include/gtest/gtest_main.cc \
 						 src/test/test_csv_input_layer.cc
 
 #EXTRA_PROGRAMS = $(PROGS)
-EXTRA_PROGRAMS = singatest
+EXTRA_PROGRAMS = singatest test
 #EXTRA_LTLIBRARIES = $(LTLIBS)
 EXTRA_LTLIBRARIES = libgtest.la
 
@@ -172,7 +172,7 @@ libgtest_la_CXXFLAGS += -DUSE_LMDB
 endif
 libgtest_la_LDFLAGS = -I./include
 
-#bin_PROGRAMS += singatest
+#bin_PROGRAMS += test
 
 singatest_SOURCES = $(GTEST_HDRS) $(TEST_SRCS)
 singatest_CXXFLAGS = $(DEFAULT_FLAGS)
@@ -185,7 +185,7 @@ singatest_LDFLAGS = -I./include \
                 -lzmq \
                 -lczmq \
                 -lzookeeper_mt \
-								-lgtest
+			    -lgtest
 if LMDB
 singatest_LDFLAGS += -llmdb
 endif
@@ -207,6 +207,9 @@ rat:
 	else \
 		echo "java is not found"; \
 	fi
+
+test: singatest
+	@./singatest
 
 $(PROTO_HDRS) $(PROTO_SRCS): $(PROTOS)
 	protoc --proto_path=$(top_srcdir)/src/proto --cpp_out=$(top_srcdir)/src/proto $(PROTOS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -176,6 +176,7 @@ libgtest_la_LDFLAGS = -I./include
 
 singatest_SOURCES = $(GTEST_HDRS) $(TEST_SRCS)
 singatest_CXXFLAGS = $(DEFAULT_FLAGS)
+singatest_LDADD = ./libgtest.la
 singatest_LDFLAGS = -I./include \
                 -lsinga \
                 -lglog  \

--- a/configure.ac
+++ b/configure.ac
@@ -68,7 +68,7 @@ AC_ARG_ENABLE(test,
 	[enable_test=yes],[enable_test=no])
 AM_CONDITIONAL(SINGATEST, test "$enable_test" = yes)
 if test x"$enable_test" != x"no"; then
-	PROGS='singatest'
+	PROGS='singatest test'
 	LTLIBS='libgtest.la'
 else
 	PROGS=''


### PR DESCRIPTION
Add a new target named "test". Users just run "make test" and the system will finish the compilation and execution of the test.