### PR TITLE
SINGA-99 Add Support for Batch Normalization

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -55,6 +55,7 @@ SINGA_SRCS := src/driver.cc \
               src/neuralnet/neuron_layer/relu.cc \
               src/neuralnet/neuron_layer/sigmoid.cc \
               src/neuralnet/neuron_layer/stanh.cc \
+              src/neuralnet/neuron_layer/batch_norm.cc \
               src/neuralnet/neuron_layer/softmax.cc \
               src/neuralnet/neuralnet.cc \
               src/comm/socket.cc \

--- a/include/singa/neuralnet/input_layer/store.h
+++ b/include/singa/neuralnet/input_layer/store.h
@@ -24,6 +24,9 @@
 
 #include <string>
 #include <vector>
+#include <algorithm>
+#include <ctime>
+#include <cstdlib>
 #include "singa/io/store.h"
 #include "singa/neuralnet/layer.h"
 
@@ -55,6 +58,14 @@ class StoreInputLayer : virtual public InputLayer {
   int batchsize_ = 1;
   int random_skip_ = 0;
   io::Store* store_ = nullptr;
+  bool enable_shuffle_ = false;
+  bool buffer_shaped_ = false;
+  int shuffle_number_ = 0;
+  int buffer_pointer_ = 0;
+  int datasize_ = 0;
+  Blob<float> shuffle_buffer_;
+  vector<int> shuffle_index_;
+  vector<AuxType> aux_shuffle_buffer_;
 };
 
 /**

--- a/include/singa/utils/singa_op.h
+++ b/include/singa/utils/singa_op.h
@@ -197,12 +197,12 @@ struct Sqrt {
 
 /*********************************************************************/
 /**
- * c = pow(a, b), i.e., c = a^b
+ * c = pow(b, a), i.e., c = b^a
  */
 template<typename Dtype>
 struct Pow {
   inline static void Map(const Dtype & a, const Dtype &b, Dtype * c) {
-    *c = pow(a, b);
+    *c = pow(b, a);
   }
 #ifdef USE_GPU
   inline static void CudaMap(const Dtype * a,

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -56,6 +56,7 @@
 #include "singa/neuralnet/neuron_layer/sigmoid.h"
 #include "singa/neuralnet/neuron_layer/stanh.h"
 #include "singa/neuralnet/neuron_layer/softmax.h"
+#include "singa/neuralnet/neuron_layer/batch_norm.h"
 #include "singa/neuralnet/output_layer/record.h"
 #include "singa/neuralnet/output_layer/csv.h"
 
@@ -114,6 +115,7 @@ void Driver::Init(int argc, char **argv) {
   RegisterLayer<SplitLayer, int>(kSplit);
   RegisterLayer<STanhLayer, int>(kSTanh);
   RegisterLayer<SoftmaxLayer, int>(kSoftmax);
+  RegisterLayer<BatchNormLayer, int>(kBatchNorm);
 
 #ifdef USE_LMDB
   RegisterLayer<LMDBDataLayer, int>(kLMDBData);

--- a/src/neuralnet/input_layer/store.cc
+++ b/src/neuralnet/input_layer/store.cc
@@ -62,7 +62,7 @@ void StoreInputLayer::ComputeFeature(int flag,
       random_skip_--;
     }
   }
-  if ((flag & kTrain) == kTrain) {
+  if ((flag & kTrain) == kTrain && enable_shuffle_) {
     if (!buffer_shaped_) {
       datasize_ = data_.count() / batchsize_;
       vector<int> shape {batchsize_*shuffle_number_, datasize_};

--- a/src/neuralnet/input_layer/store.cc
+++ b/src/neuralnet/input_layer/store.cc
@@ -32,6 +32,14 @@ void StoreInputLayer::Setup(const LayerProto& conf,
     const vector<Layer*>& srclayers) {
   InputLayer::Setup(conf, srclayers);
   batchsize_ = conf.store_conf().batchsize();
+  bool enable_shuffle_ = conf.store_conf().enable_shuffle();
+  if (enable_shuffle_) {
+    shuffle_number_ = conf.store_conf().shuffle_number();
+    buffer_pointer_ = shuffle_number_*batchsize_;
+    buffer_shaped_ = false;
+    for (int i = 0; i < buffer_pointer_; ++i)
+      shuffle_index_.push_back(i);
+  }
   if (conf.partition_dim() == 0) {
     batchsize_ /= conf.num_partitions();
   }
@@ -54,20 +62,56 @@ void StoreInputLayer::ComputeFeature(int flag,
       random_skip_--;
     }
   }
-  for (int k = 0; k < batchsize_; k++) {
-    if (!store_->Read(&key, &val)) {
-      store_->SeekToFirst();
-      CHECK(store_->Read(&key, &val));
+  if ((flag & kTrain) == kTrain) {
+    if (!buffer_shaped_) {
+      datasize_ = data_.count() / batchsize_;
+      vector<int> shape {batchsize_*shuffle_number_, datasize_};
+      shuffle_buffer_.Reshape(shape);
+      aux_shuffle_buffer_.resize(batchsize_*shuffle_number_);
+      std::srand(unsigned(std::time(0)));
+      buffer_shaped_ = true;
     }
-    // TODO(wangwei) random skip and shuffle among this mini-batch
-    Parse(k, flag, key, val);
+    if (buffer_pointer_ == shuffle_number_*batchsize_) {
+      for (int i = 0; i < shuffle_number_; i++) {
+        for (int k = 0; k < batchsize_; k++) {
+          if (!store_->Read(&key, &val)) {
+            store_->SeekToFirst();
+            CHECK(store_->Read(&key, &val));
+          }
+          Parse(k, flag, key, val);
+        }
+        std::copy(data_.mutable_cpu_data(),
+            data_.mutable_cpu_data()+batchsize_*datasize_,
+            shuffle_buffer_.mutable_cpu_data() + i * batchsize_*datasize_);
+        std::copy(aux_data_.begin(), aux_data_.end(),
+            aux_shuffle_buffer_.begin() + i * batchsize_);
+      }
+      std::random_shuffle(shuffle_index_.begin(), shuffle_index_.end());
+      buffer_pointer_ = 0;
+    }
+    for (int k = 0; k < batchsize_; ++k) {
+      std::copy(shuffle_buffer_.mutable_cpu_data()
+          +shuffle_index_[buffer_pointer_]*datasize_,
+          shuffle_buffer_.mutable_cpu_data()
+          +shuffle_index_[buffer_pointer_]*datasize_+datasize_,
+          data_.mutable_cpu_data()+k*datasize_);
+      aux_data_[k] = aux_shuffle_buffer_[shuffle_index_[buffer_pointer_]];
+      buffer_pointer_++;
+    }
+  } else {
+    for (int k = 0; k < batchsize_; k++) {
+      if (!store_->Read(&key, &val)) {
+        store_->SeekToFirst();
+        CHECK(store_->Read(&key, &val));
+      }
+      Parse(k, flag, key, val);
+    }
   }
 }
 
 void SingleLabelRecordLayer::Setup(const LayerProto& conf,
     const vector<Layer*>& srclayers) {
   StoreInputLayer::Setup(conf, srclayers);
-
   vector<int> shape {batchsize_};
   for (int s : conf.store_conf().shape())
     shape.push_back(s);

--- a/src/neuralnet/neuron_layer/batch_norm.cc
+++ b/src/neuralnet/neuron_layer/batch_norm.cc
@@ -1,0 +1,127 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+
+#include "singa/neuralnet/neuron_layer/batch_norm.h"
+
+#include <glog/logging.h>
+#include <cmath>
+#include "singa/utils/singleton.h"
+#include "singa/utils/math_blob.h"
+
+namespace singa {
+    
+using std::vector;
+
+void BatchNormLayer::Setup(const LayerProto& conf,
+    const vector<Layer *>& srclayers) {
+  Layer::Setup(conf, srclayers);
+
+  auto src = srclayers[0]->data(this);
+  batchsize_ = src.shape()[0];
+  dim_ = src.count()/src.shape()[0];
+  data_.ReshapeLike(srclayers[0]->data(this));
+  grad_.ReshapeLike(srclayers[0]->grad(this));
+  var_.Reshape(vector<int> {dim_});
+  mean_.ReshapeLike(var_);
+  tmpx_.ReshapeLike(data_);
+  tmptx_.ReshapeLike(data_);
+  tmp_.ReshapeLike(var_);
+  xnorm_.ReshapeLike(data_);
+  gvar_.ReshapeLike(var_);
+  gmean_.ReshapeLike(var_);
+  gxnorm_.ReshapeLike(xnorm_);
+  gamma_ = Param::Create(conf.param(0));
+  beta_ = Param::Create(conf.param(1));
+  gamma_->Setup(vector<int>{dim_});
+  beta_->Setup(vector<int>{dim_});
+}
+
+void BatchNormLayer::ComputeFeature(int flag, 
+    const vector<Layer*>& srclayers) {
+  const Blob<float>& src_ = srclayers[0]->data(this);
+  //compute mean
+  MVSumRow<float>(cpu, 1.0/batchsize_, .0, src_, &mean_);
+  //compute var
+  Copy<float>(cpu, src_, &xnorm_);
+  MVAddRow<float>(cpu, -1.0, 1.0, mean_, &xnorm_);
+  Map<op::Square<float>, float>(cpu, xnorm_, &tmpx_);
+  MVSumRow<float>(cpu, 1.0/batchsize_, .0, tmpx_, &var_);
+  //compute xnorm 
+  tmp_.SetValue(1e-5);
+  AXPY<float>(cpu, 1.0, var_, &tmp_);
+  Map<op::Sqrt<float>, float>(cpu, tmp_, &tmp_);
+  RepmatRow<float>(cpu, tmp_, &tmpx_);
+  Div<float>(cpu, xnorm_, tmpx_, &xnorm_);
+  //compute data
+  RepmatRow<float>(cpu, gamma_->data(), &tmpx_);
+  Mult<float>(cpu, xnorm_, tmpx_, &data_);
+  MVAddRow<float>(cpu, 1.0, 1.0, beta_->data(), &data_);
+}
+
+void BatchNormLayer::ComputeGradient(int flag,
+    const vector<Layer*>& srclayers) {
+  const Blob<float>& src_ = srclayers[0]->data(this);
+  
+  //compute gxnorm
+  RepmatRow<float>(cpu, gamma_->data(), &tmpx_);
+  Mult<float>(cpu, grad_, tmpx_, &gxnorm_);
+  //compute gvar
+  Copy<float>(cpu, src_, &tmptx_);
+  MVAddRow<float>(cpu, -1.0, 1.0, mean_, &tmptx_);
+  Mult<float>(cpu, gxnorm_, tmptx_, &tmpx_);
+  tmp_.SetValue(1e-5);
+  AXPY<float>(cpu, 1.0, var_, &tmp_);
+  Map<op::Pow<float>, float>(cpu, -1.5, tmp_, &tmp_);
+  Map<op::Mult<float>, float>(cpu, -0.5, tmp_, &tmp_);
+  RepmatRow<float>(cpu, tmp_, &tmptx_);
+  Mult<float>(cpu, tmpx_, tmptx_, &tmpx_);
+  MVSumRow<float>(cpu, 1.0, .0, tmpx_, &gvar_);
+  //compute gmean
+  tmp_.SetValue(1e-5);
+  AXPY<float>(cpu, 1.0, var_, &tmp_);
+  Map<op::Pow<float>, float>(cpu, -0.5, tmp_, &tmp_);
+  Map<op::Mult<float>, float>(cpu, -1.0, tmp_, &tmp_);
+  RepmatRow<float>(cpu, tmp_, &tmpx_);
+  Mult<float>(cpu, tmpx_, gxnorm_, &tmpx_);
+  MVSumRow<float>(cpu, 1.0, .0, tmpx_, &gmean_);
+  //compute gsrc
+  if (srclayers[0]->mutable_grad(this) != nullptr) {
+    auto gsrc_ = srclayers[0]->mutable_grad(this);
+    tmp_.SetValue(1e-5);
+    AXPY<float>(cpu, 1.0, var_, &tmp_);
+    Map<op::Pow<float>, float>(cpu, -0.5, tmp_, &tmp_);
+    RepmatRow<float>(cpu, tmp_, &tmpx_);
+    Mult<float>(cpu, tmpx_, gxnorm_, gsrc_);
+    Copy<float>(cpu, src_, &tmptx_);
+    MVAddRow<float>(cpu, -1.0, 1.0, mean_, &tmptx_);
+    RepmatRow<float>(cpu, gvar_, &tmpx_);
+    Mult<float>(cpu, tmpx_, tmptx_, &tmpx_);
+    AXPY<float>(cpu, 2.0/batchsize_, tmpx_, gsrc_);
+    RepmatRow<float>(cpu, gmean_, &tmpx_);
+    AXPY<float>(cpu, 1.0/batchsize_, tmpx_, gsrc_);
+  }
+  //compute ggamma
+  Mult<float>(cpu, grad_, xnorm_, &tmpx_);
+  MVSumRow<float>(cpu, 1.0, .0, tmpx_, gamma_->mutable_grad());
+  //compute gbeta
+  MVSumRow<float>(cpu, 1.0, .0, grad_, beta_->mutable_grad());
+}
+}  //  namespace singa

--- a/src/neuralnet/neuron_layer/dropout.cc
+++ b/src/neuralnet/neuron_layer/dropout.cc
@@ -31,7 +31,7 @@ void DropoutLayer::Setup(const LayerProto& conf,
     const vector<Layer*>& srclayers) {
   Layer::Setup(conf, srclayers);
   data_.ReshapeLike(srclayers[0]->data(this));
-  grad_.ReshapeLike(*srclayers[0]->mutable_grad(this));
+  grad_.ReshapeLike(data_);
   mask_.Reshape(srclayers[0]->data(this).shape());
   pdrop_ = conf.dropout_conf().dropout_ratio();
 }

--- a/src/proto/job.proto
+++ b/src/proto/job.proto
@@ -198,7 +198,7 @@ message LayerProto {
   optional DropoutProto dropout_conf = 33;
   // configuration for inner product layer
   optional InnerProductProto innerproduct_conf = 34;
-  // configuration for local response normalization layer
+  // configuration for LMDB data layer
   optional DataProto lmdbdata_conf = 35;
   // configuration for local response normalization layer
   optional LRNProto lrn_conf = 45;
@@ -334,6 +334,10 @@ message StoreProto {
   optional bool encoded = 10 [default = false];
   optional int32 random_skip = 11 [default = 0];
   optional bool has_label = 12 [default = true];
+  optional bool enable_shuffle = 13 [default = false];
+  // if enable shuffle among mini-batch then
+  //   the shuffle buffer size = shuffle_number*batchsize
+  optional int32 shuffle_number = 14 [default = 50];
 }
 message SoftmaxLossProto {
   // computing accuracy against topk results
@@ -575,6 +579,7 @@ enum LayerType {
   kSigmoid = 26;
   kSTanh = 14;
   kSoftmax = 34;
+  kBatchNorm = 36;
   // Loss layers
   //  - Compute objective loss
   kSoftmaxLoss = 11;


### PR DESCRIPTION
Add an implementation of batch normalization layer as a neuron layer.
  -New neuron layer: batch_norm.cc
Batch normalization layer has no hyperparameter, it has two parameters to train.

Add support within-shard shuffle among min-batchs in the store.cc
 -Changed file: store.cc, job.proto
Add two optional setting into the configuration of RecordInput layer.
Set enable_shuffle=true to enable data shuffle.
Option shuffle_number corresponds to the total number of mini-batchs among which the data will shuffle.