### PR TITLE
[SINGA-101] Add ll (ls -l) command in .bashrc file when using docker

### DIFF
--- a/tool/docker/mesos/.bashrc
+++ b/tool/docker/mesos/.bashrc
@@ -6,5 +6,9 @@ export HADOOP_HOME=/opt/hadoop-2.6.0
 export PATH=$PATH:$HADOOP_HOME/bin:$HADOOP_HOME/sbin
 export JAVA_HOME=/opt/jdk1.8.0_60
 alias ls="ls --color=always"
+# some more ls aliases
+alias ll="ls -alF"
+alias la="ls -A"
+alias l="ls -CF"
 export SINGA_HOME=/root/incubator-singa
 export PATH=$PATH:$SINGA_HOME/bin

--- a/tool/docker/singa/.bashrc
+++ b/tool/docker/singa/.bashrc
@@ -6,3 +6,7 @@ export JAVA_HOME=/opt/jdk1.8.0_60
 export SINGA_HOME=/root/incubator-singa
 export PATH=$PATH:$SINGA_HOME/bin
 alias ls="ls --color=always"
+# some more ls aliases
+alias ll="ls -alF"
+alias la="ls -A"
+alias l="ls -CF"


### PR DESCRIPTION
Root loads docker containers while the command ll (ls -l) cannot be found. However ll is handier than ls -l.
#91 