### PR TITLE
SINGA-105 Update GUN make files for compiling cuda related code

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,8 @@ PROTO_PYS := tool/pb2/singa_pb2.py \
              tool/pb2/job_pb2.py \
              tool/pb2/common_pb2.py
 
+CUDA_SRCS := src/utils/math_kernel.cu
+
 SINGA_SRCS := src/driver.cc \
               src/server.cc \
               src/worker.cc \
@@ -132,18 +134,22 @@ bin_PROGRAMS = singa singatool $(PROGS)
 
 #lib_LTLIBRARIES = libsinga.la
 libsinga_la_SOURCES = $(PROTO_SRCS) $(SINGA_SRCS)
-libsinga_la_CXXFLAGS = $(DEFAULT_FLAGS) -msse3 -fpermissive
+libsinga_la_CXXFLAGS = $(DEFAULT_FLAGS) -msse3 -fpermissive -I$(top_srcdir)/include 
 if LMDB
 libsinga_la_CXXFLAGS += -DUSE_LMDB
 endif
-libsinga_la_LDFLAGS = -I./include
+#libsinga_la_LDFLAGS = -I$(top_srcdir)/include
+if DCUDA
+libsinga_la_SOURCES += $(CUDA_SRCS)
+libsinga_la_CXXFLAGS += $(CUDA_CFLAGS)
+libsinga_la_LDFLAGS = $(CUDA_LDFLAGS) $(CUDA_LIBS)
+endif
 
 
 #bin_PROGRAMS = singa
 singa_SOURCES = src/main.cc
-singa_CXXFLAGS = $(DEFAULT_FLAGS) -MMD
-singa_LDFLAGS = -I./include \
-                -lsinga \
+singa_CXXFLAGS = $(DEFAULT_FLAGS) -MMD -I$(top_srcdir)/include 
+singa_LDFLAGS = -lsinga \
                 -lglog  \
                 -lprotobuf \
                 -lrt \
@@ -155,31 +161,35 @@ if LMDB
 singa_LDFLAGS += -llmdb
 endif
 
+if DCUDA
+singa_SOURCES += $(CUDA_SRCS)
+singa_CXXFLAGS += $(CUDA_CFLAGS)
+singa_LDFLAGS += $(CUDA_LDFLAGS) $(CUDA_LIBS)
+endif
+
 #bin_PROGRAMS += singatool
 singatool_SOURCES = src/utils/tool.cc
 singatool_CXXFLAGS = -Wall -pthread -fPIC -std=c++11 -MMD -Wno-unknown-pragmas \
-                     -funroll-loops -DTHREADED
-singatool_LDFLAGS = -I./include \
-                    -lsinga \
+                     -funroll-loops -DTHREADED -I$(top_srcdir)/include 
+singatool_LDFLAGS = -lsinga \
                     -lglog  \
                     -lprotobuf \
                     -lzookeeper_mt
 
 #lib_LTLIBRARIES += libgtest.la
 libgtest_la_SOURCES = $(GTEST_HDRS) $(GTEST_SRCS)
-libgtest_la_CXXFLAGS = $(DEFAULT_FLAGS) -msse3 -fpermissive
+libgtest_la_CXXFLAGS = $(DEFAULT_FLAGS) -msse3 -fpermissive -I$(top_srcdir)/include
 if LMDB
 libgtest_la_CXXFLAGS += -DUSE_LMDB
 endif
-libgtest_la_LDFLAGS = -I./include
+#libgtest_la_LDFLAGS = -I$(top_srcdir)/include
 
 #bin_PROGRAMS += test
 
 singatest_SOURCES = $(GTEST_HDRS) $(TEST_SRCS)
-singatest_CXXFLAGS = $(DEFAULT_FLAGS)
+singatest_CXXFLAGS = $(DEFAULT_FLAGS) -I$(top_srcdir)/include 
 singatest_LDADD = ./libgtest.la
-singatest_LDFLAGS = -I./include \
-                -lsinga \
+singatest_LDFLAGS = -lsinga \
                 -lglog  \
                 -lprotobuf \
                 -lrt \
@@ -190,6 +200,11 @@ singatest_LDFLAGS = -I./include \
 			    -lgtest
 if LMDB
 singatest_LDFLAGS += -llmdb
+endif
+if DCUDA
+singatest_SOURCES += $(CUDA_SRCS)
+singatest_CXXFLAGS += $(CUDA_CFLAGS)
+singatest_LDFLAGS += $(CUDA_LDFLAGS) $(CUDA_LIBS)
 endif
 
 clean-local:
@@ -209,6 +224,9 @@ rat:
 	else \
 		echo "java is not found"; \
 	fi
+
+.cu.o: .cu
+	$(NVCC) $(MSHADOW_FLAGS) $(CUDA_CFLAGS) $(CUDA_LDFLAGS) $(CUDA_LIBS) -I$(top_srcdir)/include -std=c++11 -G -c -o $@ $<
 
 test: singatest
 	@./singatest

--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,61 @@ AC_PROG_CXX([g++])
 AC_PROG_CC
 AC_PROG_LIBTOOL
 
+# Setup custom CUDA paths
+AC_ARG_ENABLE(cuda,
+	[AS_HELP_STRING(--enable-cuda,enable CUDA support)],
+    cudaval="yes",
+    cudaval="no")
+AM_CONDITIONAL(DCUDA, [test "$cudaval" = "yes"])
+
+AC_ARG_WITH([cuda],
+   [AS_HELP_STRING(
+        [--with-cuda=PATH],
+        [prefix where CUDA is installed])],
+   [cuda_prefix=$withval],
+   [cuda_prefix="/usr/local/cuda"])
+if test "$cuda_prefix" == "yes"; then
+    if test "$withval" == "yes"; then
+        cuda_prefix="/usr/local/cuda"
+    fi
+fi
+
+AC_MSG_CHECKING([nvcc in $cuda_prefix/bin])
+if test -x "$cuda_prefix/bin/nvcc"; then
+    AC_MSG_RESULT([found])
+    AC_DEFINE_UNQUOTED([NVCC_PATH], ["$cuda_prefix/bin/nvcc"], [Path to nvcc binary])
+else
+    AC_MSG_RESULT([not found!])
+    AC_MSG_FAILURE([nvcc was not found in $cuda_prefix/bin])
+fi
+
+if test x"$cudaval" = x"yes"; then
+    CUDA_CFLAGS="-I$cuda_prefix/include"
+    CUDA_LDFLAGS="-L$cuda_prefix/lib64 -L$cuda_prefix/lib"
+    CUDA_LIBS="-lcuda -lcudart -lcurand"
+    NVCC="nvcc"
+	DEBUG="-DUSE_GPU "
+    AC_DEFINE(DCUDA,[1],[Defined if CUDA should be used])
+	AC_CHECK_LIB([cuda], [main], [], [
+ 		AC_MSG_ERROR([unable to find cuda library])
+ 	 ])
+	AC_CHECK_LIB([cudart], [main], [], [
+	  	AC_MSG_ERROR([unable to find cudart library])
+  	])
+	AC_CHECK_LIB([curand], [main], [], [
+ 	 	AC_MSG_ERROR([unable to find curand library])
+  	])
+else
+    CUDA_CFLAGS=""
+    CUDA_LDFLAGS=""
+    CUDA_LIBS=""
+    NVCC=""
+fi
+AC_SUBST(NVCC)
+AC_SUBST(CUDA_LDFLAGS)
+AC_SUBST(CUDA_LIBS)
+AC_SUBST(CUDA_CFLAGS)
+
 # Checks for libraries.
 AC_SEARCH_LIBS([cblas_sgemm], [openblas], [], [
   AC_MSG_ERROR([unable to find cblas_sgemm() function])
@@ -82,9 +137,9 @@ AC_ARG_ENABLE(debug,
 	[enable_debug=yes],[enable_debug=no])
 AM_CONDITIONAL(DEBUG, test "$enable_debug" = yes)
 if test x"$enable_debug" != x"no"; then
-	DEBUG='-g'
+	DEBUG+='-g'
 else
-	DEBUG='-O2'
+	DEBUG+='-O2'
 fi
 AC_SUBST([DEBUG])
 

--- a/configure.ac
+++ b/configure.ac
@@ -66,7 +66,7 @@ fi
 if test x"$cudaval" = x"yes"; then
     CUDA_CFLAGS="-I$cuda_prefix/include"
     CUDA_LDFLAGS="-L$cuda_prefix/lib64 -L$cuda_prefix/lib"
-    CUDA_LIBS="-lcuda -lcudart -lcurand"
+    CUDA_LIBS="-lcublas -lcudart -lcurand"
     NVCC="nvcc"
 	DEBUG="-DUSE_GPU "
     AC_DEFINE(DCUDA,[1],[Defined if CUDA should be used])


### PR DESCRIPTION
To compile with cuda library, try:
./configure --enable-cuda
It searches the system path for cuda header and libs. If cuda is installed in other places, then
./configure --enable-cuda --with-cuda="path to cuda folder"
Do not forget to add those paths to environment variables before run configure script.
If -eanble-cuda or -with-cuda is added, then -DUSE_GPU will be added to the compilation flags.