### PR TITLE
SINGA-109 Refine bridge layers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -47,6 +47,7 @@ SINGA_SRCS := src/driver.cc \
               src/neuralnet/loss_layer/softmax.cc \
               src/neuralnet/neuron_layer/argsort.cc \
               src/neuralnet/neuron_layer/convolution.cc \
+              src/neuralnet/neuron_layer/dummy.cc \
               src/neuralnet/neuron_layer/dropout.cc \
               src/neuralnet/neuron_layer/inner_product.cc \
               src/neuralnet/neuron_layer/lrn.cc \
@@ -119,6 +120,7 @@ TEST_SRCS := include/gtest/gtest_main.cc \
 						 src/test/test_paramslicer.cc \
 						 src/test/test_kvfile.cc \
 						 src/test/test_store.cc \
+						 src/test/test_connection_layers.cc \
 						 src/test/test_record_input_layer.cc \
 						 src/test/test_csv_input_layer.cc
 

--- a/include/singa/neuralnet/neuron_layer/dummy.h
+++ b/include/singa/neuralnet/neuron_layer/dummy.h
@@ -19,26 +19,33 @@
 *
 *************************************************************/
 
-#ifndef SINGA_NEURALNET_NEURON_LAYER_SIGMOID_H_
-#define SINGA_NEURALNET_NEURON_LAYER_SIGMOID_H_
+#ifndef SINGA_NEURALNET_NEURON_LAYER_DUMMY_H_
+#define SINGA_NEURALNET_NEURON_LAYER_DUMMY_H_
 
+#include <random>
 #include <vector>
 #include "singa/neuralnet/layer.h"
 #include "singa/proto/job.pb.h"
 
 namespace singa {
 /**
- * This layer apply Sigmoid function to neuron activations.
- * f(x)=1/(1+exp(-x))
- * f'(x)=f(x)*(1-f(x))
+ * This layer is dummy and do no real work.
+ * It is used for testing purpose only.
+ *
+ * Use it as input layer, it will generate random data;
+ * Use it as output layer, it will generate random grad;
+ * Use it as neuron layer, it will replicates data and grad.
  */
-class SigmoidLayer: public Layer {
+class DummyLayer: public Layer {
  public:
   void Setup(const LayerProto& proto, const vector<Layer*>& srclayers) override;
   void ComputeFeature(int flag, const vector<Layer*>& srclayers) override;
   void ComputeGradient(int flag, const vector<Layer*>& srclayers) override;
+ private:
+  bool input_ = false;  // use as input layer
+  bool output_ = false;  // use as output layer
 };
 
 }  // namespace singa
 
-#endif  // SINGA_NEURALNET_NEURON_LAYER_SIGMOID_H_
+#endif  // SINGA_NEURALNET_NEURON_LAYER_DUMMY_H_

--- a/include/singa/worker.h
+++ b/include/singa/worker.h
@@ -23,6 +23,7 @@
 #define SINGA_WORKER_H_
 
 #include <string>
+#include <unordered_map>
 #include <vector>
 #include "singa/comm/socket.h"
 #include "singa/neuralnet/neuralnet.h"
@@ -78,7 +79,6 @@ class Worker {
    */
   virtual void Setup(int grp_id, int id, const JobProto& conf,
       NeuralNet* train_net, NeuralNet* val_net, NeuralNet* test_net);
-
   /**
    * Main function of Worker.
    *
@@ -93,6 +93,17 @@ class Worker {
    * @param[in] net run test over the passed in neural net
    */
   void Test(int steps, Phase phase, NeuralNet* net);
+  /**
+   * Init sockets in a worker, including:
+   * 1. a global socket communicates with stub
+   * 2. a bridge socket dedicated for bridge layer communications
+   *
+   * the bridge socket will be binded to each bridge layer
+   *
+   * @param[in] net pointer to a neural net whose bridge layer will be binded
+   * with a socket.
+   */
+  void InitSockets(const NeuralNet* net);
   /**
    * Init values of Param instances assocaited with local layers (i.e., layers
    * dispatched to this worker).
@@ -118,7 +129,6 @@ class Worker {
    * initialized.
    */
   void InitNetParams(const JobProto& job_conf, NeuralNet* net);
-
   /**
    * Checkpoint all Param objects owned by the worker onto disk.
    * The serialization is done using BlobProtos which includes the name, version
@@ -130,7 +140,6 @@ class Worker {
    * @param net the training net whose Param objects will be dumped.
    */
   void Checkpoint(int step, const std::string& folder, NeuralNet* net);
-
   /**
     * Train one mini-batch.
     * Test/Validation is done before training.
@@ -139,7 +148,6 @@ class Worker {
     * @param[in] net neural net to be trained.
     */
   virtual void TrainOneBatch(int step, NeuralNet* net) = 0;
-
   /**
    * Test/validate one mini-batch data.
    *
@@ -148,7 +156,6 @@ class Worker {
    * @param[in] net neural net for test
    */
   virtual void TestOneBatch(int step, Phase phase, NeuralNet* net) = 0;
-
   /**
    * Display infomation from layers.
    *
@@ -159,7 +166,6 @@ class Worker {
    * @param net display layers from this neural net.
    */
   void Display(int flag, const std::string& prefix, NeuralNet* net);
-
   /**
    * Put Param values to server.
    *
@@ -167,7 +173,6 @@ class Worker {
    * @param step used as current param version for the put request
    */
   int Put(int step, Param* param);
-
   /**
    * Get Param with specific version from server
    * If the current version >= the requested version, then return.
@@ -176,7 +181,6 @@ class Worker {
    * @param step requested param version
    */
   int Get(int step, Param* param);
-
   /**
    * Update Param.
    *
@@ -184,7 +188,6 @@ class Worker {
    * @param step training step used for updating (e.g., deciding learning rate).
    */
   int Update(int step, Param* param);
-
   /**
    * Wait for the response of the update/get requests.
    *
@@ -192,23 +195,10 @@ class Worker {
    * @param step not used now.
    */
   int Collect(int step, Param* param);
-
   /**
    * Call Collect() for every param of net
    */
   int CollectAll(int step, NeuralNet* net);
-
-  /**
-   * Receive blobs from other workers due to model partitions.
-   */
-  void ReceiveBlobs(bool data, bool grad, BridgeLayer* layer, NeuralNet* net);
-
-  /**
-   * Send blobs to other workers due to model partitions.
-   */
-  void SendBlobs(bool data, bool grad, BridgeLayer* layer, NeuralNet* net);
-
-
   /**
    * @param[in] step
    * @return true if it is time to display training info, e.g., loss; otherwise
@@ -284,8 +274,10 @@ class Worker {
   NeuralNet* train_net_ = nullptr;
   NeuralNet* test_net_ = nullptr;
   NeuralNet* val_net_ = nullptr;
-  Dealer* layer_dealer_ = nullptr;
   Dealer* dealer_ = nullptr;
+  // bridge layer related
+  Dealer* bridge_dealer_ = nullptr;
+  std::unordered_map<std::string, Layer*> name2bridge_;
 };
 
 class BPWorker: public Worker {

--- a/src/neuralnet/connection_layer/bridge.cc
+++ b/src/neuralnet/connection_layer/bridge.cc
@@ -20,15 +20,89 @@
 *************************************************************/
 
 #include "singa/neuralnet/connection_layer/bridge.h"
+#include "singa/comm/msg.h"
 
 namespace singa {
 
 using std::vector;
-void BridgeDstLayer::Setup(const LayerProto& proto,
+
+void BridgeLayer::MakePaired(Layer* pair, int grp_id, Dealer* dealer,
+    std::unordered_map<std::string, Layer*>* name2bridge) {
+  pair_ = pair;
+  group_id_ = grp_id;
+  dealer_ = dealer;
+  name2bridge_ = name2bridge;
+}
+
+void BridgeLayer::SendBlobs(bool handle_data) {
+  CHECK(dealer_) << "NULL dealer for bridges in worker (" << group_id_
+                 << ", " << partition_id() << ")";
+  Msg *msg = new Msg();
+  msg->set_src(Addr(group_id_, partition_id(), kWorkerLayer));
+  msg->set_dst(Addr(group_id_, pair_->partition_id(), kWorkerLayer));
+  msg->AddFrame(pair_->name().c_str(), pair_->name().length());
+  auto const& blob = handle_data ? data(nullptr) : grad(nullptr);
+  msg->AddFrame(blob.cpu_data(), blob.count() * sizeof(float));
+  dealer_->Send(&msg);
+}
+
+void BridgeLayer::ReceiveBlobs(bool handle_data) {
+  CHECK(dealer_) << "NULL dealer for bridges in worker (" << group_id_
+                 << ", " << partition_id() << ")";
+  while (!ready()) {
+    auto msg = dealer_->Receive();
+    CHECK_EQ(AddrGrp(msg->src()), group_id_);
+    string name(static_cast<char*>(msg->FrameData()), msg->FrameSize());
+    auto receive_layer = name2bridge_->at(name);
+    auto blob = handle_data ? receive_layer->mutable_data(nullptr) :
+                receive_layer -> mutable_grad(nullptr);
+    msg->NextFrame();
+    memcpy(blob->mutable_cpu_data(), msg->FrameData(), msg->FrameSize());
+    dynamic_cast<BridgeLayer*>(receive_layer)->set_ready(true);
+    delete msg;
+  }
+}
+
+void BridgeSrcLayer::Setup(const LayerProto& conf,
     const vector<Layer*>& srclayers) {
-  Layer::Setup(proto, srclayers);
+  CHECK_GE(srclayers.size(), 1);
+  Layer::Setup(conf, srclayers);
+  data_.Reshape(srclayers[0]->data(this).shape());
+  grad_.ReshapeLike(data_);
+  data_.ShareData(srclayers[0]->data(this));
+  grad_.ShareData(srclayers[0]->grad(this));
+}
+
+void BridgeSrcLayer::ComputeFeature(int flag, const vector<Layer*>& srcs) {
+  // send data
+  SendBlobs(true);
+  // reset flag for receiving gradient in compute gradient phase
+  set_ready(false);
+}
+
+void BridgeSrcLayer::ComputeGradient(int flag, const vector<Layer*>& srcs) {
+  // receive gradient
+  ReceiveBlobs(false);
+}
+
+void BridgeDstLayer::Setup(const LayerProto& conf,
+    const vector<Layer*>& srclayers) {
   CHECK_EQ(srclayers.size(), 1);
+  Layer::Setup(conf, srclayers);
   data_.Reshape(srclayers[0]->data(this).shape());
   grad_.ReshapeLike(data_);
 }
+
+void BridgeDstLayer::ComputeFeature(int flag, const vector<Layer*>& srcs) {
+  // receive data
+  ReceiveBlobs(true);
+}
+
+void BridgeDstLayer::ComputeGradient(int flag, const vector<Layer*>& srcs) {
+  // send gradient
+  SendBlobs(false);
+  // reset flag for receiving data in compute feature phase
+  set_ready(false);
+}
+
 }  // namespace singa

--- a/src/neuralnet/neuron_layer/dummy.cc
+++ b/src/neuralnet/neuron_layer/dummy.cc
@@ -1,0 +1,72 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+
+#include "singa/neuralnet/neuron_layer/dummy.h"
+#include <glog/logging.h>
+
+namespace singa {
+
+void DummyLayer::Setup(const LayerProto& proto,
+                       const vector<Layer*>& srclayers) {
+  Layer::Setup(proto, srclayers);
+  if (proto.dummy_conf().input()) {  // use as input layer
+    CHECK_EQ(srclayers.size(), 0);
+    input_ = true;
+    vector<int> shape;
+    for (int s : proto.dummy_conf().shape()) shape.push_back(s);
+    data_.Reshape(shape);
+    grad_.ReshapeLike(data_);
+  } else {
+    CHECK_EQ(srclayers.size(), 1);
+    data_.ReshapeLike(srclayers[0]->data(this));
+    grad_.ReshapeLike(srclayers[0]->grad(this));
+  }
+  if (proto.dummy_conf().output()) {  // use as output layer
+    output_ = true;
+  }
+}
+
+std::random_device rd;
+std::mt19937 gen(rd());
+std::uniform_real_distribution<> dis(0, 1);
+
+void DummyLayer::ComputeFeature(int flag, const vector<Layer*>& srclayers) {
+  if (input_) {
+    // randomly init data with [0,1] values
+    for (int i = 0; i < data_.count(); ++i)
+      data_.mutable_cpu_data()[i] = dis(gen);
+  }
+  if (srclayers.size() > 0)
+    data_.CopyFrom(srclayers[0]->data(this));
+}
+
+void DummyLayer::ComputeGradient(int flag, const vector<Layer*>& srclayers) {
+  if (output_) {
+    // randomly init data with [0,1] values
+    for (int i = 0; i < data_.count(); ++i)
+      grad_.mutable_cpu_data()[i] = dis(gen);
+  }
+  if (srclayers.size() > 0) {
+    srclayers[0]->mutable_grad(this)->CopyFrom(grad_);
+  }
+}
+
+} // namespace singa

--- a/src/neuralnet/neuron_layer/dummy.cc
+++ b/src/neuralnet/neuron_layer/dummy.cc
@@ -69,4 +69,4 @@ void DummyLayer::ComputeGradient(int flag, const vector<Layer*>& srclayers) {
   }
 }
 
-} // namespace singa
+}  // namespace singa

--- a/src/proto/job.proto
+++ b/src/proto/job.proto
@@ -194,6 +194,8 @@ message LayerProto {
   optional ConvolutionProto convolution_conf = 30;
   // configuration for concatenation layer
   optional ConcateProto concate_conf = 31;
+  // configuration for dummy layer
+  optional DummyProto dummy_conf = 53;
   // configuration for dropout layer
   optional DropoutProto dropout_conf = 33;
   // configuration for inner product layer
@@ -392,6 +394,13 @@ message MnistProto {
   // scale to this size as input for deformation
   optional int32 resize = 35 [default = 0] ;
   optional int32 elastic_freq = 36 [default = 0];
+}
+
+message DummyProto {
+  // shape of data and grad blobs
+  optional bool input = 1 [default = false]; 
+  optional bool output = 2 [default = false]; 
+  repeated int32 shape = 3; 
 }
 
 // Message that stores parameters used by DropoutLayer

--- a/src/test/test_connection_layers.cc
+++ b/src/test/test_connection_layers.cc
@@ -1,0 +1,79 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+
+#include "gtest/gtest.h"
+#include "singa/neuralnet/connection_layer/bridge.h"
+#include "singa/neuralnet/neuron_layer/dummy.h"
+#include "singa/proto/job.pb.h"
+
+using namespace singa;
+
+TEST(ConnectionLayerTest, DummyTest) {
+  // use dummy as input layer
+  LayerProto proto_in;
+  vector<Layer*> src_in;
+  proto_in.set_name("dummy_input");
+  proto_in.mutable_dummy_conf()->set_input(true);
+  proto_in.mutable_dummy_conf()->add_shape(10);
+  proto_in.mutable_dummy_conf()->add_shape(20);
+  DummyLayer in;
+  in.Setup(proto_in, src_in);
+  ASSERT_EQ(in.data(nullptr).shape(0), 10);
+  ASSERT_EQ(in.data(nullptr).shape(1), 20);
+  in.ComputeFeature(0, src_in);
+ 
+  // use dummy as neuron layer
+  LayerProto proto_neu;
+  vector<Layer*> src_neu;
+  src_neu.push_back(static_cast<Layer*>(&in));
+  proto_neu.set_name("dummy_neuron");
+  proto_neu.mutable_dummy_conf();
+  DummyLayer neu;
+  neu.Setup(proto_neu, src_neu);
+  ASSERT_EQ(neu.data(nullptr).shape(0), 10);
+  ASSERT_EQ(neu.data(nullptr).shape(1), 20);
+  neu.ComputeFeature(0, src_neu);
+  ASSERT_EQ(in.data(nullptr).count(), neu.data(nullptr).count());
+  for (int i = 0; i < in.data(nullptr).count(); ++i)
+    ASSERT_EQ(in.data(nullptr).cpu_data()[i], neu.data(nullptr).cpu_data()[i]);
+
+  // use dummy as output layer
+  LayerProto proto_out;
+  vector<Layer*> src_out;
+  src_out.push_back(static_cast<Layer*>(&neu));
+  proto_out.set_name("dummy_output");
+  proto_out.mutable_dummy_conf()->set_output(true);
+  DummyLayer out;
+  out.Setup(proto_out, src_out);
+  ASSERT_EQ(out.data(nullptr).shape(0), 10);
+  ASSERT_EQ(out.data(nullptr).shape(1), 20);
+  out.ComputeFeature(0, src_out);
+  ASSERT_EQ(in.data(nullptr).count(), out.data(nullptr).count());
+  for (int i = 0; i < in.data(nullptr).count(); ++i)
+    ASSERT_EQ(in.data(nullptr).cpu_data()[i], out.data(nullptr).cpu_data()[i]);
+ 
+  // test for computing gradient
+  out.ComputeGradient(0, src_out);
+  neu.ComputeGradient(0, src_neu);
+  in.ComputeGradient(0, src_in);
+  for (int i = 0; i < in.grad(nullptr).count(); ++i)
+    ASSERT_EQ(in.grad(nullptr).cpu_data()[i], out.grad(nullptr).cpu_data()[i]);
+}

--- a/src/test/test_connection_layers.cc
+++ b/src/test/test_connection_layers.cc
@@ -19,7 +19,12 @@
 *
 *************************************************************/
 
+#include <string>
+#include <unordered_map>
+#include <vector>
 #include "gtest/gtest.h"
+#include "singa/comm/msg.h"
+#include "singa/comm/socket.h"
 #include "singa/neuralnet/connection_layer/bridge.h"
 #include "singa/neuralnet/neuron_layer/dummy.h"
 #include "singa/proto/job.pb.h"
@@ -28,8 +33,8 @@ using namespace singa;
 
 TEST(ConnectionLayerTest, DummyTest) {
   // use dummy as input layer
-  LayerProto proto_in;
   vector<Layer*> src_in;
+  LayerProto proto_in;
   proto_in.set_name("dummy_input");
   proto_in.mutable_dummy_conf()->set_input(true);
   proto_in.mutable_dummy_conf()->add_shape(10);
@@ -39,11 +44,11 @@ TEST(ConnectionLayerTest, DummyTest) {
   ASSERT_EQ(in.data(nullptr).shape(0), 10);
   ASSERT_EQ(in.data(nullptr).shape(1), 20);
   in.ComputeFeature(0, src_in);
- 
+
   // use dummy as neuron layer
-  LayerProto proto_neu;
   vector<Layer*> src_neu;
   src_neu.push_back(static_cast<Layer*>(&in));
+  LayerProto proto_neu;
   proto_neu.set_name("dummy_neuron");
   proto_neu.mutable_dummy_conf();
   DummyLayer neu;
@@ -56,9 +61,9 @@ TEST(ConnectionLayerTest, DummyTest) {
     ASSERT_EQ(in.data(nullptr).cpu_data()[i], neu.data(nullptr).cpu_data()[i]);
 
   // use dummy as output layer
-  LayerProto proto_out;
   vector<Layer*> src_out;
   src_out.push_back(static_cast<Layer*>(&neu));
+  LayerProto proto_out;
   proto_out.set_name("dummy_output");
   proto_out.mutable_dummy_conf()->set_output(true);
   DummyLayer out;
@@ -69,10 +74,83 @@ TEST(ConnectionLayerTest, DummyTest) {
   ASSERT_EQ(in.data(nullptr).count(), out.data(nullptr).count());
   for (int i = 0; i < in.data(nullptr).count(); ++i)
     ASSERT_EQ(in.data(nullptr).cpu_data()[i], out.data(nullptr).cpu_data()[i]);
- 
+
   // test for computing gradient
   out.ComputeGradient(0, src_out);
   neu.ComputeGradient(0, src_neu);
+  in.ComputeGradient(0, src_in);
+  for (int i = 0; i < in.grad(nullptr).count(); ++i)
+    ASSERT_EQ(in.grad(nullptr).cpu_data()[i], out.grad(nullptr).cpu_data()[i]);
+}
+
+
+TEST(ConnectionLayerTest, BridgeTest) {
+  // use dummy as input layer
+  vector<Layer*> src_in;
+  LayerProto proto_in;
+  proto_in.set_name("dummy_input");
+  proto_in.mutable_dummy_conf()->set_input(true);
+  proto_in.mutable_dummy_conf()->add_shape(10);
+  proto_in.mutable_dummy_conf()->add_shape(20);
+  DummyLayer in;
+  in.Setup(proto_in, src_in);
+
+  // add src bridge layer
+  vector<Layer*> src_src;
+  src_src.push_back(static_cast<Layer*>(&in));
+  LayerProto proto_src;
+  proto_in.set_name("bridge_src");
+  BridgeSrcLayer src;
+  src.Setup(proto_src, src_src);
+  ASSERT_EQ(src.data(nullptr).shape(0), 10);
+  ASSERT_EQ(src.data(nullptr).shape(1), 20);
+
+  // add dst bridge layer
+  vector<Layer*> src_dst;
+  src_dst.push_back(static_cast<Layer*>(&src));
+  LayerProto proto_dst;
+  proto_dst.set_name("bridge_dst");
+  BridgeDstLayer dst;
+  dst.Setup(proto_dst, src_dst);
+  ASSERT_EQ(dst.data(nullptr).shape(0), 10);
+  ASSERT_EQ(dst.data(nullptr).shape(1), 20);
+
+  // bind bridges to socket
+  Router router(10);
+  router.Bind("inproc://router");
+  Dealer dealer(0);
+  dealer.Connect("inproc://router");
+  std::unordered_map<std::string, Layer*> name2bridge;
+  name2bridge[src.name()] = &src;
+  name2bridge[dst.name()] = &dst;
+  src.MakePaired(static_cast<Layer*>(&dst), 0, &dealer, &name2bridge);
+  dst.MakePaired(static_cast<Layer*>(&src), 0, &dealer, &name2bridge);
+
+  // use dummy as output layer
+  LayerProto proto_out;
+  vector<Layer*> src_out;
+  src_out.push_back(static_cast<Layer*>(&dst));
+  proto_out.set_name("dummy_output");
+  proto_out.mutable_dummy_conf()->set_output(true);
+  DummyLayer out;
+  out.Setup(proto_out, src_out);
+
+  // test for computing feature
+  in.ComputeFeature(0, src_in);
+  src.ComputeFeature(0, src_src);
+  Msg* msg_data = router.Receive();
+  router.Send(&msg_data);
+  dst.ComputeFeature(0, src_dst);
+  out.ComputeFeature(0, src_out);
+  for (int i = 0; i < in.data(nullptr).count(); ++i)
+    ASSERT_EQ(in.data(nullptr).cpu_data()[i], out.data(nullptr).cpu_data()[i]);
+
+  // test for computing gradient
+  out.ComputeGradient(0, src_out);
+  dst.ComputeGradient(0, src_dst);
+  Msg* msg_grad = router.Receive();
+  router.Send(&msg_grad);
+  src.ComputeGradient(0, src_src);
   in.ComputeGradient(0, src_in);
   for (int i = 0; i < in.grad(nullptr).count(); ++i)
     ASSERT_EQ(in.grad(nullptr).cpu_data()[i], out.grad(nullptr).cpu_data()[i]);


### PR DESCRIPTION
re-implement bridge layers for model partition
 * move socket operations for sending/receiving blobs from worker into layers,
   so that it is transparent to users who will implment TrainOneBatch
 * when initialing worker, it will create a socket instance and pass it to all
   bridge layers using layer.MakePaired() function

SINGA-106 dummy layer also included
  dummy layer can be used as input, neuron, output layer to construct a simple
  neuralnet when only focusing on testing a specific layer

To test, just 'make test'
test_connection_layers.cc contains test for both bridge layer and dummy layer