### PR TITLE
SINGA-115 - Print layer debug information in the neural net graph file

### DIFF
--- a/include/singa/neuralnet/connection_layer.h
+++ b/include/singa/neuralnet/connection_layer.h
@@ -97,6 +97,7 @@ class SliceLayer : public ConnectionLayer {
   void Setup(const LayerProto& proto, const vector<Layer*>& srclayers) override;
   void ComputeFeature(int flag, const vector<Layer*>& srclayers) override;
   void ComputeGradient(int flag, const vector<Layer*>& srclayers) override;
+  const std::string ToString(bool debug, int flag) override;
   const Blob<float>& data(const Layer* from) const override;
   const Blob<float>& grad(const Layer* from) const override;
   Blob<float>* mutable_data(const Layer* from) override;
@@ -116,6 +117,7 @@ class SplitLayer : public ConnectionLayer {
   void Setup(const LayerProto& proto, const vector<Layer*>& srclayers) override;
   void ComputeFeature(int flag, const vector<Layer*>& srclayers) override;
   void ComputeGradient(int flag, const vector<Layer*>& srclayers) override;
+  const std::string ToString(bool debug, int flag) override;
   const Blob<float>& grad(const Layer* from) const override;
   Blob<float>* mutable_grad(const Layer* from) override;
 };

--- a/include/singa/neuralnet/neuralnet.h
+++ b/include/singa/neuralnet/neuralnet.h
@@ -110,6 +110,12 @@ class NeuralNet {
   }
   inline Param* paramid2param(int id) const { return paramid2param_.at(id); }
 
+  /**
+   * Conver the neural net into graph representation.
+   * Each layer is converted into a node.
+   * @param include_shape if true label the node with shape info
+   */
+  const Graph ToGraph(bool include_shape) const;
  protected:
   /**
    * Create a neural net graph, one node for each layer.

--- a/include/singa/utils/common.h
+++ b/include/singa/utils/common.h
@@ -7,9 +7,9 @@
 * to you under the Apache License, Version 2.0 (the
 * "License"); you may not use this file except in compliance
 * with the License.  You may obtain a copy of the License at
-* 
+*
 *   http://www.apache.org/licenses/LICENSE-2.0
-* 
+*
 * Unless required by applicable law or agreed to in writing,
 * software distributed under the License is distributed on an
 * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -32,6 +32,8 @@
 
 namespace singa {
 
+using std::vector;
+using std::string;
 std::string IntVecToString(const std::vector<int>& vec);
 std::string VStringPrintf(std::string fmt, va_list l);
 std::string StringPrintf(std::string fmt, ...);
@@ -149,7 +151,10 @@ void WriteProtoToTextFile(const Message& proto, const char* filename);
 void ReadProtoFromBinaryFile(const char* filename, Message* proto);
 void WriteProtoToBinaryFile(const Message& proto, const char* filename);
 
-
+/**
+ * Write a string (e.g., graph reprensetation of a net) into a text file.
+ */
+void WriteStringToTextFile(const string& filename, const string& context);
 }  // namespace singa
 
 #endif  // SINGA_UTILS_COMMON_H_

--- a/include/singa/utils/graph.h
+++ b/include/singa/utils/graph.h
@@ -7,9 +7,9 @@
 * to you under the Apache License, Version 2.0 (the
 * "License"); you may not use this file except in compliance
 * with the License.  You may obtain a copy of the License at
-* 
+*
 *   http://www.apache.org/licenses/LICENSE-2.0
-* 
+*
 * Unless required by applicable law or agreed to in writing,
 * software distributed under the License is distributed on an
 * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -26,19 +26,36 @@
 #include <string>
 #include <map>
 #include <vector>
-
 namespace singa {
+using std::string;
+using std::map;
 
+/**
+ * Node class representing a layer in a neural net.
+ *
+ * TODO remove layer dependent fields, like origin, and partition_id, to make
+ * it an independent and simple class.
+ */
 class Node {
  public:
   /**
    * Node constructor.
    *
-   * @param name name of the corresponding layer
+   * @param name identifier of the node, e.g, layer name.
    */
-  explicit Node(std::string name);
+  explicit Node(string name);
   /**
-   * Node constructor.
+   * Construct a node with specified attributes.
+   * @param name node identifier
+   * @param attrs node attributes for printing, including "shape", "color", etc.
+   * Depending on the visulization engine, if using graphviz, then the attribute
+   * list is http://www.graphviz.org/content/attrs.
+   */
+  Node(string name, const std::map<string, string>& attrs);
+  /**
+   * @deprecated {to make the Graph class an independent class.}
+   *
+   * Node constructor used for model partitioning.
    *
    * This node is a partition of some node.
    * @param name node name
@@ -46,22 +63,26 @@ class Node {
    * @param id partition id of this node
    * @param proto conf of the corresponding layer
    */
-  Node(const std::string& name, const std::string& origin, int id, void* proto);
+  Node(const string& name, const std::string& origin, int id, void* proto);
   ~Node() {}  // the proto field is deleted outside by other functions
-  void AddDstNode(Node* dstnode);
-  void AddSrcNode(Node* srcnode);
+
+
+  void AddDstNode(Node* dst);
+  void AddSrcNode(Node* src);
   void RemoveDstNode(Node* dst);
   void RemoveSrcNode(Node* src);
 
-  std::string name = "";
+  string name = "";
   //! name of the origin node/layer from which is node is derived
-  std::string origin = "";
+  string origin = "";
   //! partition id
   int partition_id = 0;
   //! proto of the corresponding layer
   void* proto = nullptr;
   std::vector<Node*> srcnodes;
   std::vector<Node*> dstnodes;
+  //!< node attribute including shape, color, etc.
+  std::map<string, string> attrs;
 };
 
 /**
@@ -73,6 +94,7 @@ class Graph {
  public:
   Graph() {}
   ~Graph();
+  const Graph Reverse() const;
   /**
    * @return all nodes of the graph
    */
@@ -83,34 +105,84 @@ class Graph {
    * @param name node name
    * @return return the node of given name
    */
-  inline Node* node(const std::string& name) const {
+  inline Node* node(const string& name) const {
     return name2node_.at(name);
   }
+  /**
+   * Add an exiting node into this graph.
+   */
   void AddNode(Node* node);
-  Node* AddNode(const std::string& name);
+  /**
+   * Creat an node with the given name and add it into the graph.
+   * @return the newly created node.
+   */
+  Node* AddNode(const string& name);
+  /**
+   * Create an node with the given name and attributes.
+   */
+  Node* AddNode(const string& name, const std::map<string, string>& attrs);
+  /**
+   * Add an edge connecting the two given nodes.
+   */
   void AddEdge(Node* srcnode, Node* dstnode);
-  void AddEdge(const std::string& src, const std::string& dst);
+  /**
+   * Add an edge connecting the two nodes with the given name.
+   */
+  void AddEdge(const string& src, const std::string& dst);
+  /**
+   * Add an edge connecting the two given nodes, the edge attributes are also
+   * given.
+   */
+  void AddEdge(Node* srcnode, Node* dstnode,
+      const std::map<string, string>& attrs);
+  /**
+   * Add an edge connecting the two nodes with the given names, the edge
+   * attributes are also given, which are used for printing.
+   * http://www.graphviz.org/content/attrs
+   */
+  void AddEdge(const string& src, const std::string& dst,
+      const std::map<string, string>& attrs);
+
+  /**
+   * Remove the edge connecting the two given nodes.
+   */
   void RemoveEdge(Node* src, Node* dst);
-  void RemoveEdge(const std::string &src, const std::string& dst);
+  /**
+   * Remove the edge connecting two nodes with the given names.
+   */
+  void RemoveEdge(const string &src, const std::string& dst);
   /**
    * Dump the graph into json string which can be used to draw a picture by
-   * graphviz
+   * graphviz.
+   *
+   * It calls ToJson(const std::map<std::string, std::string>& label) with
+   * empty label mapping.
    */
-  std::string ToJson() const;
+  string ToJson() const;
   /**
    * \copybreif ToJson()
    *
-   * @param info info associated with each node
+   * @param label information to be displayed as label for each node
    */
-  std::string ToJson(const std::map<std::string, std::string>& info) const;
+  string ToJson(const map<std::string, std::string>& label) const;
   /**
    * Do topology sort for all nodes of the graph.
    */
   void Sort();
 
  private:
+  /**
+   *
+   * @return the name of the edge connecting src to dst
+   */
+  const string GetEdgeName(const string& src, const string& dst) const {
+    return src + "-->" + dst;
+  }
+
+ private:
   std::vector<Node*> nodes_;
-  std::map<std::string, Node*> name2node_;
+  std::map<string, Node*> name2node_;
+  std::map<string, std::map<string, string>> edge_attrs_;
 };
 
 }  // namespace singa

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -201,6 +201,8 @@ void Driver::Train(const JobProto& job_conf) {
   }
 
   NeuralNet* net = NeuralNet::Create(job_conf.neuralnet(), kTrain, grp_size);
+  WriteStringToTextFile(cluster->vis_folder() + "/train_net.json",
+      net->ToGraph(true).ToJson());
   const vector<Worker*> workers = CreateWorkers(job_conf, net);
   const vector<Server*> servers = CreateServers(job_conf, net);
 

--- a/src/neuralnet/connection_layer/slice.cc
+++ b/src/neuralnet/connection_layer/slice.cc
@@ -20,6 +20,7 @@
 *************************************************************/
 
 #include "singa/neuralnet/connection_layer.h"
+#include "singa/utils/math_blob.h"
 
 namespace singa {
 
@@ -118,5 +119,18 @@ Blob<float>* SliceLayer::mutable_grad(const Layer* from) {
   CHECK_LT(from->partition_id(), num_partitions());
   return gradvec_[from->partition_id()];
 }
-
+const std::string SliceLayer::ToString(bool debug, int flag) {
+  if (!debug)
+    return "";
+  string ret = "";
+  if ((flag & kForward) == kForward && data_.count() !=0) {
+    for (unsigned k = 0; k < datavec_.size(); k++)
+      ret += StringPrintf("data-%u :%13.9f ", k, Asum(*datavec_.at(k)));
+  }
+  if ((flag & kBackward) == kBackward && grad_.count() != 0) {
+    for (unsigned k = 0; k < gradvec_.size(); k++)
+    ret += StringPrintf("grad-%u:%13.9f ", k, Asum(*gradvec_.at(k)));
+  }
+  return ret;
+}
 }  // namespace singa

--- a/src/neuralnet/connection_layer/split.cc
+++ b/src/neuralnet/connection_layer/split.cc
@@ -20,6 +20,7 @@
 *************************************************************/
 
 #include "singa/neuralnet/connection_layer.h"
+#include "singa/utils/math_blob.h"
 
 namespace singa {
 
@@ -72,5 +73,17 @@ Blob<float>* SplitLayer::mutable_grad(const Layer* from) {
   CHECK_LT(from->partition_id(), num_partitions());
   return gradvec_[from->partition_id()];
 }
-
+const std::string SplitLayer::ToString(bool debug, int flag) {
+  if (!debug)
+    return "";
+  string ret = "";
+  if ((flag & kForward) == kForward && data_.count() !=0) {
+    ret += StringPrintf("data:%13.9f ", Asum(data_));
+  }
+  if ((flag & kBackward) == kBackward && grad_.count() != 0) {
+    for (unsigned k = 0; k < gradvec_.size(); k++)
+    ret += StringPrintf("grad-%u:%13.9f ", k, Asum(*gradvec_.at(k)));
+  }
+  return ret;
+}
 }  // namespace singa

--- a/src/neuralnet/layer.cc
+++ b/src/neuralnet/layer.cc
@@ -46,19 +46,18 @@ Layer* Layer::Create(const LayerProto& proto) {
 const std::string Layer::ToString(bool debug, int flag) {
   if (!debug)
     return "";
-  string ret = StringPrintf("Layer %10s ", name().c_str());
+  string ret = "";
   if ((flag & kForward) == kForward && data_.count() !=0) {
-    ret += StringPrintf("data norm1 %13.9f", Asum(data_));
+    ret += StringPrintf("data:%13.9f ", Asum(data_));
+    for (Param* p : GetParams())
+      ret += StringPrintf("%s:%13.9f ",
+          p->name().c_str(), Asum(p->data()));
   }
   if ((flag & kBackward) == kBackward && grad_.count() != 0) {
-      ret += StringPrintf("grad norm1 %13.9f\n", Asum(grad_));
-  }
-  if ((flag & kTrain) == kTrain) {
-    for (Param* p : GetParams()) {
-      ret += StringPrintf(
-          "param id %2d, name %10s, value norm1 %13.9f, grad norm1 %13.9f\n",
-          p->id(), p->name().c_str(), Asum(p->data()), Asum(p->grad()));
-    }
+    ret += StringPrintf("grad:%13.9f ", Asum(grad_));
+    for (Param* p : GetParams())
+      ret += StringPrintf("%s:%13.9f ",
+          p->name().c_str(), Asum(p->grad()));
   }
   return ret;
 }

--- a/src/utils/common.cc
+++ b/src/utils/common.cc
@@ -78,6 +78,8 @@
 #include <fcntl.h>
 #include <cfloat>
 
+#include <fstream>
+
 #include <glog/logging.h>
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
@@ -85,8 +87,6 @@
 
 namespace singa {
 
-using std::string;
-using std::vector;
 const int kBufLen = 1024;
 
 string IntVecToString(const vector<int>& vec) {
@@ -142,7 +142,7 @@ const vector<vector<int>> Slice(int num, const vector<int>& sizes) {
       avg += x;
   avg = avg / num + avg % num;
   int diff = avg / 10;
-  LOG(INFO) << "Slicer, param avg = " << avg << ", diff = " << diff;
+  // DLOG(INFO) << "Slicer, param avg = " << avg << ", diff = " << diff;
 
   int capacity = avg, nbox = 0;
   for (int x : sizes) {
@@ -172,7 +172,7 @@ const vector<vector<int>> Slice(int num, const vector<int>& sizes) {
         slicestr += ", " + std::to_string(size);
       }
     }
-    LOG(INFO) << slicestr;
+    // DLOG(INFO) << slicestr;
     slices.push_back(slice);
   }
   CHECK_LE(nbox, num);
@@ -213,8 +213,7 @@ const vector<int> PartitionSlices(int num, const vector<int>& slices) {
     }
     disp += " " + std::to_string(slices[i]);
   }
-  LOG(INFO) << "partition slice (avg = " << avg
-            << ", num = " << num << "):" << disp;
+  // DLOG(INFO) << "partition slice (avg = " << avg << ", num = " << num << "):" << disp;
   return slice2box;
 }
 
@@ -560,5 +559,16 @@ void WriteProtoToBinaryFile(const Message& proto, const char* filename) {
   int fd = open(filename, O_CREAT|O_WRONLY|O_TRUNC, 0644);
   CHECK_NE(fd, -1) << "File cannot open: " << filename;
   CHECK(proto.SerializeToFileDescriptor(fd));
+}
+
+
+
+void WriteStringToTextFile(const string& filename, const string& context) {
+  std::ofstream ofs;
+  ofs.open(filename);
+  CHECK(ofs.is_open()) << "Can't write to file: " << filename;
+  ofs << context;
+  ofs.flush();
+  ofs.close();
 }
 }  // namespace singa

--- a/src/utils/graph.cc
+++ b/src/utils/graph.cc
@@ -7,9 +7,9 @@
 * to you under the Apache License, Version 2.0 (the
 * "License"); you may not use this file except in compliance
 * with the License.  You may obtain a copy of the License at
-* 
+*
 *   http://www.apache.org/licenses/LICENSE-2.0
-* 
+*
 * Unless required by applicable law or agreed to in writing,
 * software distributed under the License is distributed on an
 * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -20,6 +20,7 @@
 *************************************************************/
 
 #include "singa/utils/graph.h"
+#include "singa/utils/common.h"
 
 #include <glog/logging.h>
 #include <algorithm>
@@ -32,8 +33,15 @@ using std::map;
 using std::string;
 using std::vector;
 
+/**************************************************************************
+ * Implementation for Node class
+ *************************************************************************/
 Node::Node(string name) {
   this->name = name;
+}
+Node::Node(string name, const std::map<string, string>& attrs) {
+  this->name = name;
+  this->attrs = attrs;
 }
 
 Node::Node(const string& name, const string& origin, int id, void* proto) {
@@ -67,6 +75,10 @@ void Node::RemoveSrcNode(Node* src) {
   srcnodes.erase(iter);
 }
 
+/****************************************************************************
+ * Implementation for Graph class
+ ****************************************************************************/
+
 Graph::~Graph() {
   for (Node* node : nodes_)
     delete node;
@@ -85,6 +97,13 @@ Node* Graph::AddNode(const string& name) {
   return node;
 }
 
+Node* Graph::AddNode(const string& name, const std::map<string, string>& attrs)
+{
+  Node* node = new Node(name, attrs);
+  AddNode(node);
+  return node;
+}
+
 void Graph::AddEdge(Node* srcnode, Node* dstnode) {
   srcnode->AddDstNode(dstnode);
   dstnode->AddSrcNode(srcnode);
@@ -96,6 +115,16 @@ void Graph::AddEdge(const string& src, const string& dst) {
   auto dstnode = name2node_.find(dst);
   CHECK(dstnode != name2node_.end()) << "can't find dst node " << dst;
   AddEdge(srcnode->second, dstnode->second);
+}
+void Graph::AddEdge(Node* srcnode, Node* dstnode,
+      const std::map<string, string>& attrs) {
+  AddEdge(srcnode, dstnode);
+  edge_attrs_[GetEdgeName(srcnode->name, dstnode->name)] = attrs;
+}
+void Graph::AddEdge(const string& src, const std::string& dst,
+      const std::map<string, string>& attrs) {
+  AddEdge(src, dst);
+  edge_attrs_[GetEdgeName(src, dst)] = attrs;
 }
 
 void Graph::RemoveEdge(Node* src, Node* dst) {
@@ -112,10 +141,11 @@ void Graph::RemoveEdge(const string &src, const string& dst) {
 }
 
 string Graph::ToJson() const {
-  map<string, string> info;
-  return ToJson(info);
+  map<string, string> label;
+  return ToJson(label);
 }
 
+/*
 string Graph::ToJson(const map<string, string>& info) const {
   map<string, int> nodeid;
   string disp = "{\"directed\":1,\n";
@@ -126,7 +156,7 @@ string Graph::ToJson(const map<string, string>& info) const {
   vector<string> colors = {"red", "blue", "black", "green"};
 
   // see for more shapes at http://www.graphviz.org/doc/info/shapes.html
-  vector<string> shapes = {"box", "ellipse"};
+  // vector<string> shapes = {"box", "ellipse"};
   int id = 0;
   for (auto node : nodes_) {
     char str[1024];
@@ -134,14 +164,10 @@ string Graph::ToJson(const map<string, string>& info) const {
     string color = colors[(node->partition_id)%colors.size()];
     string shape;
     string origin = node->origin;
-    if (origin.find("##") != string::npos)
-      shape = shapes[1];
-    else
-      shape = shapes[0];
     snprintf(str, sizeof(str),
         "{\"id\":\"%s%s\", \"color\":\"%s\",\"shape\":\"%s\"}\n", name.c_str(),
         info.find(name) != info.end() ? info.at(name).c_str() : "",
-        color.c_str(), shape.c_str());
+        color.c_str(), "box");
     if (!first)
       disp += ",";
     else
@@ -170,6 +196,7 @@ string Graph::ToJson(const map<string, string>& info) const {
   disp += "]\n";
   return disp+"}";
 }
+*/
 
 // sort to make `bottom' nodes be placed in the front positions
 void Graph::Sort() {
@@ -227,11 +254,73 @@ void Graph::Sort() {
       visiting_nodes.push(node);
     }
   }
-  for (auto node : nodes_) {
-    LOG(INFO) << "nodes: " << node->name;
-  }
-  LOG(INFO) << "finish printing nodes ";
   CHECK_EQ(nodes_.size(), n);
 }
 
+const Graph Graph::Reverse() const {
+  Graph g;
+  for (Node* n : nodes_)
+    g.AddNode(n->name, n->attrs);
+  for (Node* src : nodes_)
+    for (Node* dst : src->dstnodes) {
+      map<string, string> attrs;
+      const string edge = GetEdgeName(src->name, dst->name);
+      if (edge_attrs_.find(edge) != edge_attrs_.end())
+        attrs = edge_attrs_.at(edge);
+      g.AddEdge(dst->name, src->name, attrs);
+    }
+  return g;
+}
+
+string Graph::ToJson(const map<string, string>& label) const {
+  string disp = "{\"directed\":1,\n";
+
+  // add nodes
+  disp += "\"nodes\":[\n";
+
+  bool first = true;
+  map<string, int> node_id;
+  int id = 0;
+  for (auto node : nodes_) {
+    string name = node->name;
+    string lbl = name + " -- ";
+    if (label.find(name) != label.end())
+      lbl += label.at(name);
+    if (node->attrs.find("label") != node->attrs.end())
+      lbl += node->attrs.at("label");
+    disp += StringPrintf("%c{\"id\":\"%s\", \"label\":\"%s\"",
+        !first ? ',' : ' ', name.c_str(), lbl.c_str());
+    for (const auto& attr : node->attrs)
+      if (attr.first != "label")
+        disp += StringPrintf(", \"%s\":\"%s\"",
+            attr.first.c_str(), attr.second.c_str());
+    disp += "}\n";
+    first = false;
+    node_id[name] = id++;
+  }
+  disp += "]\n,\n";
+
+  // add edges
+  disp += "\"links\":[\n";
+  first = true;
+  for (auto src : nodes_) {
+    for (auto dst : src->dstnodes) {
+      const string edge_name = GetEdgeName(src->name, dst->name);
+      string lbl = "";
+      if (label.find(edge_name) != label.end())
+        lbl = label.at(edge_name);
+      disp += StringPrintf("%c{\"source\":%d, \"target\":%d, \"label\": \"%s\"",
+          !first ? ',' : ' ', node_id[src->name], node_id[dst->name],
+          lbl.c_str());
+      if (edge_attrs_.find(edge_name) != edge_attrs_.end()) {
+        for (const auto& attr : edge_attrs_.at(edge_name))
+          disp += StringPrintf(", \"%s\":\"%s\"",
+              attr.first.c_str(), attr.second.c_str());
+      }
+      disp += "}\n";
+      first = false;
+    }
+  }
+  return disp + "]}";
+}
 }  // namespace singa


### PR DESCRIPTION
* Updated the Graph class to format the string representation in ToJson function.
* The Layer::ToString function is updated to generate string for debug info, e.g., layer data and gradient norm.
* Insert code to collect debug info from layers forward and backward function in BPWorker class.
* Add NeuralNet::ToGraph function to convert a neualnet into a Graph which can converted into a string using ToJson function.

To test this pull request,

1. run the cifar10 example, get the `train_net.json` file from `example/cifar10/visualization/`, visualize the neural net by 

        python tool/graph.py examples/cifar10/visualization/train_net.json train_net.jpg

2. run the cifar10 example for a few steps without test and with debug enabled. 
      
        // job.conf 
        train_steps: 5
        test_steps: 0
        debug: true

  Visualize the neural net with debug info recorded in `examples/cifar10/visualization/*.json` in the same way as 1.

