### PR TITLE
SINGA-116 Fix a bug in InnerProductLayer caused by weight matrix sharing

### DIFF
--- a/src/neuralnet/neuron_layer/inner_product.cc
+++ b/src/neuralnet/neuron_layer/inner_product.cc
@@ -57,7 +57,10 @@ void InnerProductLayer::Setup(const LayerProto& conf,
 
 void InnerProductLayer::ComputeFeature(int flag,
     const vector<Layer*>& srclayers) {
-  MMDot(srclayers[0]->data(this), weight_->data().T(), &data_);
+  if (transpose_)
+    MMDot(srclayers[0]->data(this), weight_->data(), &data_);
+  else
+    MMDot(srclayers[0]->data(this), weight_->data().T(), &data_);
   MVAddRow(bias_->data(), &data_);
 }
 
@@ -65,9 +68,15 @@ void InnerProductLayer::ComputeGradient(int flag,
     const vector<Layer*>& srclayers) {
 
   MVSumRow(1.0f, 0.0f, grad_, bias_->mutable_grad());
-  MMDot(grad_.T(), srclayers[0]->data(this), weight_->mutable_grad());
+  if (transpose_)
+    MMDot(srclayers[0]->data(this).T(), grad_, weight_->mutable_grad());
+  else
+    MMDot(grad_.T(), srclayers[0]->data(this), weight_->mutable_grad());
   if (srclayers[0]->mutable_grad(this) != nullptr) {
-    MMDot(grad_, weight_->data(), srclayers[0]->mutable_grad(this));
+    if (transpose_)
+      MMDot(grad_, weight_->data().T(), srclayers[0]->mutable_grad(this));
+    else
+      MMDot(grad_, weight_->data(), srclayers[0]->mutable_grad(this));
   }
 }
 }  // namespace singa

--- a/src/neuralnet/neuron_layer/rbm.cc
+++ b/src/neuralnet/neuron_layer/rbm.cc
@@ -114,7 +114,7 @@ void RBMVisLayer::ComputeFeature(int flag, const vector<Layer*>& srclayers) {
     }
     first_gibbs_ = false;
   }
-  counter_ += batchsize_;
+  counter_ += 1;
 }
 
 void RBMVisLayer::ComputeGradient(int flag, const vector<Layer*>& srclayers) {

--- a/src/utils/param.cc
+++ b/src/utils/param.cc
@@ -168,7 +168,7 @@ void Param::InitValues(int version) {
 
 void Param::ShareFrom(Param* other, bool cpu_only) {
   proto_.set_owner(other->owner());
-  CHECK(data_.shape() == other->data_.shape());
+  CHECK_EQ(data_.count(), other->data_.count());
   data_.ShareData(&(other->data_), cpu_only);
   if (grad_.count() == 0)
     grad_.Reshape(data_.shape());


### PR DESCRIPTION
There is a bug in the implementation of InnerProductLayer, which appears when training the auto-encoder example.
The weight matrix in inner-product layer in the encoder is shared by another layer in the decoder. But the decoder uses transposed version.
The current code does not handle matrix transposition.
The bug can be fixed considering the transpose_ field explicitly.
We may later handle it implicitly using a Tensor class that handles transposition automatically.

To test this pull request, run the rbm example.
