### PR TITLE
SINGA-98 Add Support for AlexNet ImageNet Classification Model 

### DIFF
--- a/examples/alexnet/Makefile.example
+++ b/examples/alexnet/Makefile.example
@@ -1,0 +1,31 @@
+#/**
+# * Copyright 2015 The Apache Software Foundation
+# *
+# * Licensed to the Apache Software Foundation (ASF) under one
+# * or more contributor license agreements.  See the NOTICE file
+# * distributed with this work for additional information
+# * regarding copyright ownership.  The ASF licenses this file
+# * to you under the Apache License, Version 2.0 (the
+# * "License"); you may not use this file except in compliance
+# * with the License.  You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# */
+
+libs :=singa glog protobuf
+
+.PHONY: all create
+
+create:
+	$(CXX) im2rec.cc `pkg-config opencv --cflags --libs` -std=c++11 -lsinga -lprotobuf -lglog \
+		-I../../include -L../../.libs/ -Wl,-unresolved-symbols=ignore-in-shared-libs \
+		-Wl,-rpath=../../.libs/  -o im2rec.bin
+	$(CXX) rec2im_test.cc `pkg-config opencv --cflags --libs` -std=c++11 -lsinga -lprotobuf -lglog \
+		-I../../include -L../../.libs/ -Wl,-unresolved-symbols=ignore-in-shared-libs \
+		-Wl,-rpath=../../.libs/  -o rec2im_test.bin

--- a/examples/alexnet/cudnn.conf
+++ b/examples/alexnet/cudnn.conf
@@ -1,8 +1,11 @@
 name: "alexnet"
-train_steps: 100
-test_steps: 0
-test_freq: 300
-disp_freq: 5
+train_steps: 450000
+#test_steps: 500
+#test_freq: 1000
+disp_freq: 20
+checkpoint_freq: 100000
+checkpoint_after: 100000
+gpu: 2
 #debug: true
 #checkpoint_path: "examples/alexnet/checkpoint/step10000-worker0"
 train_one_batch {
@@ -13,8 +16,12 @@ updater{
   weight_decay: 0.0005
   momentum: 0.9
   learning_rate {
-    type: kFixed
+    type: kStep
     base_lr: 0.01
+    step_conf {
+      gamma: 0.1
+      change_freq: 100000
+    }
   }
 }
 neuralnet {
@@ -25,22 +32,22 @@ neuralnet {
       backend: "kvfile"
       path :"/data/dataset/imagenet/train_record.bin"
       mean_file: "/data/dataset/imagenet/image_mean.bin"
-      batchsize: 32
-      #random_skip: 5000
+      batchsize: 256
+      #random_skip: 1000
       shape: 3
       shape: 256
       shape: 256
     }
-      include: kTrain
+    include: kTrain
   }
   layer{
     name: "data"
     type: kRecordInput
     store_conf {
       backend: "kvfile"
-      path :"/data/dataset/val_record.bin"
-      mean_file: "/data/dataset/image_mean.bin"
-      batchsize: 256
+      path :"/data/dataset/imagenet/val_record.bin"
+      mean_file: "/data/dataset/imagenet/image_mean.bin"
+      batchsize: 100
       shape: 3
       shape: 256
       shape: 256
@@ -59,7 +66,7 @@ neuralnet {
   }
   layer{
     name: "conv1"
-    type: kCConvolution
+    type: kCudnnConv
     srclayers: "image"
     convolution_conf {
       num_filters: 96
@@ -86,13 +93,17 @@ neuralnet {
   }
   layer {
     name: "relu1"
-    type: kReLU
+    type: kCudnnActivation
+    activation_conf {
+      type: RELU
+    }
+    share_src_blobs: true
     srclayers: "conv1"
 #    partition_dim: 0
   }
   layer {
     name: "pool1"
-    type: kCPooling
+    type: kCudnnPool
     pooling_conf {
       pool: MAX
       kernel: 3
@@ -103,12 +114,12 @@ neuralnet {
   }
   layer {
     name: "norm1"
-    type: kLRN
+    type: kCudnnLRN
     lrn_conf {
       local_size: 5
       alpha: 0.0001
       beta: 0.75
-      knorm: 2
+      knorm: 1
     }
     srclayers: "pool1"
 #    partition_dim: 0
@@ -116,7 +127,7 @@ neuralnet {
 
   layer{
     name: "conv2"
-    type: kCConvolution
+    type: kCudnnConv
     srclayers: "norm1"
     convolution_conf {
       num_filters: 256
@@ -143,13 +154,17 @@ neuralnet {
   }
   layer {
     name: "relu2"
-    type: kReLU
+    type: kCudnnActivation
+    activation_conf {
+      type: RELU
+    }
+    share_src_blobs: true
     srclayers: "conv2"
 #    partition_dim: 0
   }
   layer {
     name: "pool2"
-    type: kCPooling
+    type: kCudnnPool
     pooling_conf {
       pool: MAX
       kernel: 3
@@ -161,19 +176,19 @@ neuralnet {
 
   layer {
     name: "norm2"
-    type: kLRN
+    type: kCudnnLRN
     lrn_conf {
       local_size: 5
       alpha: 0.0001
       beta: 0.75
-      knorm: 2
+      knorm: 1
     }
     srclayers: "pool2"
 #    partition_dim: 0
   }
   layer{
     name: "conv3"
-    type: kCConvolution
+    type: kCudnnConv
     srclayers: "norm2"
     convolution_conf {
       num_filters: 384
@@ -200,13 +215,17 @@ neuralnet {
   }
   layer {
     name: "relu3"
-    type: kReLU
+    type: kCudnnActivation
+    activation_conf {
+      type: RELU
+    }
+    share_src_blobs: true
     srclayers: "conv3"
 #    partition_dim: 0
   }
   layer{
     name: "conv4"
-    type: kCConvolution
+    type: kCudnnConv
     srclayers: "relu3"
     convolution_conf {
       num_filters: 384
@@ -233,13 +252,17 @@ neuralnet {
   }
   layer {
     name: "relu4"
-    type: kReLU
+    type: kCudnnActivation
+    activation_conf {
+      type: RELU
+    }
+    share_src_blobs: true
     srclayers: "conv4"
 #    partition_dim: 0
   }
   layer{
     name: "conv5"
-    type: kCConvolution
+    type: kCudnnConv
     srclayers: "relu4"
     convolution_conf {
       num_filters: 256
@@ -266,13 +289,17 @@ neuralnet {
   }
   layer {
     name: "relu5"
-    type: kReLU
+    type: kCudnnActivation
+    activation_conf {
+      type: RELU
+    }
+    share_src_blobs: true
     srclayers: "conv5"
 #    partition_dim: 0
   }
   layer {
     name: "pool5"
-    type: kCPooling
+    type: kCudnnPool
     pooling_conf {
       pool: MAX
       kernel: 3
@@ -308,7 +335,11 @@ neuralnet {
   }
   layer {
     name: "relu6"
-    type: kReLU
+    type: kCudnnActivation
+    activation_conf {
+      type: RELU
+    }
+    share_src_blobs: true
     srclayers: "ip6"
 #    partition_dim: 1
   }
@@ -345,7 +376,11 @@ neuralnet {
   }
   layer {
     name: "relu7"
-    type: kReLU
+    type: kCudnnActivation
+    activation_conf {
+      type: RELU
+    }
+    share_src_blobs: true
     srclayers: "ip7"
 #    partition_dim: 1
   }
@@ -382,7 +417,7 @@ neuralnet {
   }
   layer {
     name: "loss"
-    type: kSoftmaxLoss
+    type: kCudnnSoftmaxLoss
     softmaxloss_conf {
       topk:1
     }

--- a/examples/alexnet/cudnn.conf
+++ b/examples/alexnet/cudnn.conf
@@ -1,7 +1,7 @@
 name: "alexnet"
 train_steps: 450000
-#test_steps: 500
-#test_freq: 1000
+test_steps: 500
+test_freq: 1000
 disp_freq: 20
 checkpoint_freq: 100000
 checkpoint_after: 100000
@@ -423,6 +423,20 @@ neuralnet {
     }
     srclayers: "ip8"
     srclayers: "data"
+    include: kTrain
+  }
+  layer {
+   name : "softmax"
+   type: kCudnnSoftmax
+   srclayers: "ip8"
+   include: kTest
+  }
+  layer {
+   name : "accuracy"
+   type: kAccuracy
+   srclayers: "softmax"
+   srclayers: "data"
+   include: kTest
   }
 }
 cluster {

--- a/examples/alexnet/im2rec.cc
+++ b/examples/alexnet/im2rec.cc
@@ -1,4 +1,27 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+
+
 #include <glog/logging.h>
+#include <opencv2/opencv.hpp>
 #include <algorithm>
 #include <random>
 #include <chrono>
@@ -7,7 +30,6 @@
 #include <cstdint>
 #include <iostream>
 #include <vector>
-#include <opencv2/opencv.hpp>
 
 #include "singa/io/store.h"
 #include "singa/proto/common.pb.h"
@@ -20,8 +42,7 @@ const int kImageNBytes = 256*256*3;
 void create_data(const string& image_list,
     const string& input_folder,
     const string& output_folder,
-    const string& backend = "kvfile")
-{
+    const string& backend = "kvfile") {
   singa::RecordProto image;
   image.add_shape(3);
   image.add_shape(kImageSize);
@@ -49,12 +70,12 @@ void create_data(const string& image_list,
   string rec_buf;
   cv::Mat img, res;
   std::vector<std::pair<string, int>> file_list;
-  while(image_list_file >> image_file_name >> label)
+  while (image_list_file >> image_file_name >> label)
     file_list.push_back(std::make_pair(image_file_name, label));
   LOG(INFO) << "Data Shuffling";
   unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
   std::shuffle(file_list.begin(), file_list.end()
-      ,std::default_random_engine());
+      , std::default_random_engine());
   LOG(INFO) << "Total number of images is " << file_list.size();
   int ImageNum = file_list.size();
 
@@ -120,8 +141,8 @@ void create_data(const string& image_list,
 
 int main(int argc, char** argv) {
   if (argc < 4) {
-    std::cout << "Create Datashard for ImageNet dataset.\n"
-      << "Usage: <image_list> <input_folder> <output_folder>"
+    std::cout << "Create data stores for ImageNet dataset.\n"
+      << "Usage: <image_list_file> <input_image_folder> <output_folder>"
       << " <Optional: backend {lmdb, kvfile} default: kvfile>\n";
   } else {
     google::InitGoogleLogging(argv[0]);

--- a/examples/alexnet/im2rec.cc
+++ b/examples/alexnet/im2rec.cc
@@ -1,0 +1,136 @@
+#include <glog/logging.h>
+#include <algorithm>
+#include <random>
+#include <chrono>
+#include <fstream>
+#include <string>
+#include <cstdint>
+#include <iostream>
+#include <vector>
+#include <opencv2/opencv.hpp>
+
+#include "singa/io/store.h"
+#include "singa/proto/common.pb.h"
+
+using std::string;
+
+const int kImageSize = 256;
+const int kImageNBytes = 256*256*3;
+
+void create_data(const string& image_list,
+    const string& input_folder,
+    const string& output_folder,
+    const string& backend = "kvfile")
+{
+  singa::RecordProto image;
+  image.add_shape(3);
+  image.add_shape(kImageSize);
+  image.add_shape(kImageSize);
+
+  singa::RecordProto mean;
+  mean.CopyFrom(image);
+  for (int i = 0; i < kImageNBytes; ++i)
+    mean.add_data(0.f);
+
+  auto store = singa::io::CreateStore(backend);
+  if (backend == "lmdb")
+    CHECK(store->Open(output_folder + "/image_record", singa::io::kCreate));
+  else
+    CHECK(store->Open(output_folder + "/image_record.bin", singa::io::kCreate));
+
+  LOG(INFO) << "Generating image record";
+
+  std::ifstream image_list_file(image_list.c_str(), std::ios::in);
+  CHECK(image_list_file.is_open()) << "Unable to open image list";
+
+  string image_file_name;
+  int label;
+  char str_buffer[kImageNBytes];
+  string rec_buf;
+  cv::Mat img, res;
+  std::vector<std::pair<string, int>> file_list;
+  while(image_list_file >> image_file_name >> label)
+    file_list.push_back(std::make_pair(image_file_name, label));
+  LOG(INFO) << "Data Shuffling";
+  unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
+  std::shuffle(file_list.begin(), file_list.end()
+      ,std::default_random_engine());
+  LOG(INFO) << "Total number of images is " << file_list.size();
+  int ImageNum = file_list.size();
+
+  for (int imageid = 0; imageid < ImageNum; ++imageid) {
+    string path = input_folder + "/" + file_list[imageid].first;
+    img = cv::imread(path, CV_LOAD_IMAGE_COLOR);
+    CHECK(img.data != NULL) << "OpenCV load image fail" << path;
+    cv::resize(img, res, cv::Size(kImageSize, kImageSize),
+        0, 0, CV_INTER_LINEAR);
+    for (int h = 0; h < kImageSize; ++h) {
+      const uchar* ptr = res.ptr<uchar>(h);
+      int img_index = 0;
+      for (int w = 0; w < kImageSize; ++w)
+        for (int c = 0; c < 3; ++c)
+          str_buffer[(c*kImageSize+h)*kImageSize+w] =
+            static_cast<uint8_t>(ptr[img_index++]);
+    }
+    /*
+    for (int i = 0; i < kImageSize; ++i) {
+      for (int j = 0; j < kImageSize; ++j) {
+        cv::Vec3b pixel = res.at<cv::Vec3b>(j, i);
+        str_buffer[i*kImageSize+j] = static_cast<uint8_t>(pixel.val[2]);
+        str_buffer[kImageSize*kImageSize+i*kImageSize+j] = static_cast<uint8_t>(pixel.val[1]);
+        str_buffer[kImageSize*kImageSize*2+i*kImageSize+j] = static_cast<uint8_t>(pixel.val[0]);
+      }
+    }
+    */
+    image.set_label(file_list[imageid].second);
+    image.set_pixel(str_buffer, kImageNBytes);
+    image.SerializeToString(&rec_buf);
+
+    int length = snprintf(str_buffer, kImageNBytes, "%08d", imageid);
+    CHECK(store->Write(string(str_buffer, length), rec_buf));
+    if ((imageid+1) % 1000 == 0) {
+      store->Flush();
+      LOG(INFO) << imageid+1 << " files processed.";
+    }
+    const string& pixels = image.pixel();
+    for (int i = 0; i < kImageNBytes; ++i)
+      mean.set_data(i, mean.data(i) + static_cast<uint8_t>(pixels[i]));
+  }
+  if (ImageNum % 1000 != 0)
+      LOG(INFO) << ImageNum << " files processed.";
+
+  store->Flush();
+  store->Close();
+
+  LOG(INFO) << "Create image mean";
+  if (backend == "lmdb")
+    CHECK(store->Open(output_folder + "/image_mean", singa::io::kCreate));
+  else
+    CHECK(store->Open(output_folder + "/image_mean.bin", singa::io::kCreate));
+  for (int i = 0; i < kImageNBytes; i++)
+    mean.set_data(i, mean.data(i) / ImageNum);
+  mean.SerializeToString(&rec_buf);
+  store->Write("mean", rec_buf);
+  store->Flush();
+  store->Close();
+  delete store;
+
+  LOG(INFO) << "Done!";
+}
+
+int main(int argc, char** argv) {
+  if (argc < 4) {
+    std::cout << "Create Datashard for ImageNet dataset.\n"
+      << "Usage: <image_list> <input_folder> <output_folder>"
+      << " <Optional: backend {lmdb, kvfile} default: kvfile>\n";
+  } else {
+    google::InitGoogleLogging(argv[0]);
+    FLAGS_alsologtostderr = 1;
+    if (argc == 4)
+      create_data(string(argv[1]), string(argv[2]), string(argv[3]));
+    else
+      create_data(string(argv[1]), string(argv[2]),
+          string(argv[3]), string(argv[4]));
+  }
+  return 0;
+}

--- a/examples/alexnet/job.conf
+++ b/examples/alexnet/job.conf
@@ -1,10 +1,10 @@
 name: "alexnet"
-train_steps: 100
-test_steps: 0
-test_freq: 300
-disp_freq: 5
-#debug: true
-#checkpoint_path: "examples/alexnet/checkpoint/step10000-worker0"
+train_steps: 450000
+test_steps: 500
+test_freq: 1000
+disp_freq: 20
+checkpoint_freq: 100000
+checkpoint_after: 100000
 train_one_batch {
   alg: kBP
 }
@@ -13,8 +13,12 @@ updater{
   weight_decay: 0.0005
   momentum: 0.9
   learning_rate {
-    type: kFixed
+    type: kStep
     base_lr: 0.01
+    step_conf {
+      gamma: 0.1
+      change_freq: 100000
+    }
   }
 }
 neuralnet {
@@ -25,22 +29,22 @@ neuralnet {
       backend: "kvfile"
       path :"/data/dataset/imagenet/train_record.bin"
       mean_file: "/data/dataset/imagenet/image_mean.bin"
-      batchsize: 32
-      #random_skip: 5000
+      batchsize: 256
+      #random_skip: 1000
       shape: 3
       shape: 256
       shape: 256
     }
-      include: kTrain
+    include: kTrain
   }
   layer{
     name: "data"
     type: kRecordInput
     store_conf {
       backend: "kvfile"
-      path :"/data/dataset/val_record.bin"
-      mean_file: "/data/dataset/image_mean.bin"
-      batchsize: 256
+      path :"/data/dataset/imagenet/val_record.bin"
+      mean_file: "/data/dataset/imagenet/image_mean.bin"
+      batchsize: 100
       shape: 3
       shape: 256
       shape: 256
@@ -59,7 +63,7 @@ neuralnet {
   }
   layer{
     name: "conv1"
-    type: kCConvolution
+    type: kConvolution
     srclayers: "image"
     convolution_conf {
       num_filters: 96
@@ -92,7 +96,7 @@ neuralnet {
   }
   layer {
     name: "pool1"
-    type: kCPooling
+    type: kPooling
     pooling_conf {
       pool: MAX
       kernel: 3
@@ -108,7 +112,7 @@ neuralnet {
       local_size: 5
       alpha: 0.0001
       beta: 0.75
-      knorm: 2
+      knorm: 1
     }
     srclayers: "pool1"
 #    partition_dim: 0
@@ -116,7 +120,7 @@ neuralnet {
 
   layer{
     name: "conv2"
-    type: kCConvolution
+    type: kConvolution
     srclayers: "norm1"
     convolution_conf {
       num_filters: 256
@@ -149,7 +153,7 @@ neuralnet {
   }
   layer {
     name: "pool2"
-    type: kCPooling
+    type: kPooling
     pooling_conf {
       pool: MAX
       kernel: 3
@@ -166,14 +170,14 @@ neuralnet {
       local_size: 5
       alpha: 0.0001
       beta: 0.75
-      knorm: 2
+      knorm: 1
     }
     srclayers: "pool2"
 #    partition_dim: 0
   }
   layer{
     name: "conv3"
-    type: kCConvolution
+    type: kConvolution
     srclayers: "norm2"
     convolution_conf {
       num_filters: 384
@@ -206,7 +210,7 @@ neuralnet {
   }
   layer{
     name: "conv4"
-    type: kCConvolution
+    type: kConvolution
     srclayers: "relu3"
     convolution_conf {
       num_filters: 384
@@ -239,7 +243,7 @@ neuralnet {
   }
   layer{
     name: "conv5"
-    type: kCConvolution
+    type: kConvolution
     srclayers: "relu4"
     convolution_conf {
       num_filters: 256
@@ -272,7 +276,7 @@ neuralnet {
   }
   layer {
     name: "pool5"
-    type: kCPooling
+    type: kPooling
     pooling_conf {
       pool: MAX
       kernel: 3

--- a/examples/alexnet/job.conf
+++ b/examples/alexnet/job.conf
@@ -1,0 +1,380 @@
+name: "alexnet"
+train_steps: 100000
+test_steps: 10
+test_freq: 300
+disp_freq: 100
+#checkpoint_path: "examples/alexnet/checkpoint/step10000-worker0"
+train_one_batch {
+  alg: kBP
+}
+updater{
+  type: kSGD
+  weight_decay: 0.0005
+  momentum: 0.9
+  learning_rate {
+    type: kFixed
+    base_lr: 0.9
+  }
+}
+neuralnet {
+  layer{
+    name: "data"
+    type: kRecordInput
+    store_conf {
+      backend: "kvfile"
+      path :"/data/dataset/train_record.bin"
+      mean_file: "/data/dataset/train_mean.bin"
+      batchsize: 256
+      random_skip: 5000
+      shape: 3
+      shape: 256
+      shape: 256
+    }
+      include: kTrain
+  }
+  layer{
+    name: "data"
+    type: kRecordInput
+    store_conf {
+      backend: "kvfile"
+      path :"/data/dataset/val_record.bin"
+      mean_file: "/data/dataset/val_mean.bin"
+      batchsize: 256
+      shape: 3
+      shape: 256
+      shape: 256
+    }
+      include: kTest
+  }
+  layer{
+    name: "image"
+    type: kImagePreprocess
+    rgbimage_conf {
+      cropsize: 227
+      mirror: true
+    }
+#    partition_dim: 0
+    srclayers: "data"
+  }
+  layer{
+    name: "conv1"
+    type: kCConvolution
+    srclayers: "image"
+    convolution_conf {
+      num_filters: 96
+      kernel: 11
+      stride: 4
+    }
+#    partition_dim: 0
+    param {
+      name: "w1"
+      init {
+        type: kGaussian
+        std: 0.01
+      }
+    }
+    param {
+      name: "b1"
+      init {
+        type: kConstant
+        value: 0
+      }
+    }
+  }
+  layer {
+    name: "relu1"
+    type: kReLU
+    srclayers: "conv1"
+#    partition_dim: 0
+  }
+  layer {
+    name: "norm1"
+    type: kLRN
+    lrn_conf {
+      local_size: 5
+      alpha: 0.0001
+      beta: 0.75
+      knorm: 2
+    }
+    srclayers: "relu1"
+#    partition_dim: 0
+  }
+  layer {
+    name: "pool1"
+    type: kCPooling
+    pooling_conf {
+      pool: MAX
+      kernel: 3
+      stride: 2
+    }
+    srclayers: "norm1"
+#    partition_dim: 0
+  }
+  layer{
+    name: "conv2"
+    type: kCConvolution
+    srclayers: "pool1"
+    convolution_conf {
+      num_filters: 256
+      kernel: 5
+      pad: 2
+    }
+#    partition_dim: 0
+    param {
+      name: "w2"
+      init {
+        type: kGaussian
+        std: 0.01
+      }
+    }
+    param {
+      name: "b2"
+      init {
+        type: kConstant
+        value: 0
+      }
+    }
+  }
+  layer {
+    name: "relu2"
+    type: kReLU
+    srclayers: "conv2"
+#    partition_dim: 0
+  }
+  layer {
+    name: "norm2"
+    type: kLRN
+    lrn_conf {
+      local_size: 5
+      alpha: 0.0001
+      beta: 0.75
+      knorm: 2
+    }
+    srclayers: "relu2"
+#    partition_dim: 0
+  }
+  layer {
+    name: "pool2"
+    type: kCPooling
+    pooling_conf {
+      pool: MAX
+      kernel: 3
+      stride: 2
+    }
+    srclayers: "norm2"
+#    partition_dim: 0
+  }
+  layer{
+    name: "conv3"
+    type: kCConvolution
+    srclayers: "pool2"
+    convolution_conf {
+      num_filters: 384
+      kernel: 3
+      pad: 1
+    }
+#    partition_dim: 0
+    param {
+      name: "w3"
+      init {
+        type: kGaussian
+        std: 0.01
+      }
+    }
+    param {
+      name: "b3"
+      init {
+        type: kConstant
+        value: 0
+      }
+    }
+  }
+  layer {
+    name: "relu3"
+    type: kReLU
+    srclayers: "conv3"
+#    partition_dim: 0
+  }
+  layer{
+    name: "conv4"
+    type: kCConvolution
+    srclayers: "relu3"
+    convolution_conf {
+      num_filters: 384
+      kernel: 3
+      pad: 1
+    }
+#    partition_dim: 0
+    param {
+      name: "w4"
+      init {
+        type: kGaussian
+        std: 0.01
+      }
+    }
+    param {
+      name: "b4"
+      init {
+        type: kConstant
+        value: 0
+      }
+    }
+  }
+  layer {
+    name: "relu4"
+    type: kReLU
+    srclayers: "conv4"
+#    partition_dim: 0
+  }
+  layer{
+    name: "conv5"
+    type: kCConvolution
+    srclayers: "relu4"
+    convolution_conf {
+      num_filters: 256
+      kernel: 3
+      pad: 1
+    }
+#    partition_dim: 0
+    param {
+      name: "w5"
+      init {
+        type: kGaussian
+        std: 0.01
+      }
+    }
+    param {
+      name: "b5"
+      init {
+        type: kConstant
+        value: 0
+      }
+    }
+  }
+  layer {
+    name: "relu5"
+    type: kReLU
+    srclayers: "conv5"
+#    partition_dim: 0
+  }
+  layer {
+    name: "pool5"
+    type: kCPooling
+    pooling_conf {
+      pool: MAX
+      kernel: 3
+      stride: 2
+    }
+    srclayers: "relu5"
+#    partition_dim: 0
+  }
+  layer {
+    name: "ip6"
+    type: kInnerProduct
+    innerproduct_conf {
+      num_output: 4096
+    }
+    param {
+      name: "w6"
+      init {
+        type: kGaussian
+        std: 0.01
+      }
+    }
+    param {
+      name: "b6"
+      init {
+        type: kConstant
+        value: 1
+      }
+    }
+    srclayers: "pool5"
+#    partition_dim: 1
+  }
+  layer {
+    name: "relu6"
+    type: kReLU
+    srclayers: "ip6"
+#    partition_dim: 1
+  }
+  layer {
+    name: "drop6"
+    type: kDropout
+    srclayers: "relu6"
+#    partition_dim: 1
+  }
+  layer {
+    name: "ip7"
+    type: kInnerProduct
+    innerproduct_conf {
+      num_output: 4096
+    }
+#    partition_dim: 1
+    param {
+      name: "w7"
+      init {
+        type: kGaussian
+        std: 0.01
+      }
+    }
+    param {
+      name: "b7"
+      init {
+        type: kConstant
+        value: 1
+      }
+    }
+    srclayers: "drop6"
+  }
+  layer {
+    name: "relu7"
+    type: kReLU
+    srclayers: "ip7"
+#    partition_dim: 1
+  }
+  layer {
+    name: "drop7"
+    type: kDropout
+    srclayers: "relu7"
+#    partition_dim: 1
+  }
+  layer {
+    name: "ip8"
+    type: kInnerProduct
+    innerproduct_conf {
+      num_output: 1000
+    }
+#    partition_dim: 1
+    param {
+      name: "w8"
+      init {
+        type: kGaussian
+        std: 0.01
+      }
+    }
+    param {
+      name: "b8"
+      init {
+        type: kConstant
+        value: 1
+      }
+    }
+    srclayers: "drop7"
+  }
+  layer {
+    name: "loss"
+    type: kSoftmaxLoss
+    softmaxloss_conf {
+      topk:1
+    }
+    srclayers: "ip8"
+    srclayers: "data"
+  }
+}
+cluster {
+  nworker_groups: 1
+  nserver_groups: 1
+  nworkers_per_group: 1
+  nworkers_per_procs: 1
+  workspace: "examples/alexnet"
+}

--- a/examples/alexnet/rec2im_test.cc
+++ b/examples/alexnet/rec2im_test.cc
@@ -1,0 +1,95 @@
+#include <glog/logging.h>
+#include <algorithm>
+#include <random>
+#include <chrono>
+#include <fstream>
+#include <string>
+#include <cstdint>
+#include <iostream>
+#include <vector>
+#include <opencv2/opencv.hpp>
+
+#include "singa/io/store.h"
+#include "singa/proto/common.pb.h"
+
+using std::string;
+
+const int kImageSize = 256;
+const int kImageNBytes = 256*256*3;
+
+void generate_image(const string& output_folder,
+    const string& key,
+    const string& val)
+{
+  float image_buf[kImageNBytes];
+  singa::RecordProto image;
+  image.ParseFromString(val);
+  cv::Mat img = cv::Mat::zeros(kImageSize, kImageSize, CV_8UC3);
+  string pixel = image.pixel();
+  int label = image.label();
+  string image_name = output_folder+"/"+key+"_"+std::to_string(label)+".jpg";
+  std::cout << "Writing to " << image_name << "...\n";
+  for (int h = 0; h < kImageSize; ++h) {
+    uchar* ptr = img.ptr<uchar>(h);
+    int img_index = 0;
+    for (int w = 0; w < kImageSize; ++w) {
+      for (int c = 0; c < 3; ++c)
+        ptr[img_index++] =
+          static_cast<uchar>(
+              static_cast<uint8_t>(
+                pixel[(c * kImageSize + h) * kImageSize + w]));
+  }
+
+  cv::imwrite(image_name, img);
+}
+
+void visualize(const string& input_file,
+    const string& output_folder,
+    const string& id_list)
+{
+  auto store = singa::io::OpenStore("kvfile", input_file,
+      singa::io::kRead);
+
+  std::vector<int> image_id_list;
+
+  std::ifstream id_list_file(id_list.c_str(), std::ios::in);
+  CHECK(id_list_file.is_open()) << "Unable to open image id list";
+  string id_;
+  while(id_list_file >> id_) {
+    int x;
+    x = std::stoi(id_);
+    image_id_list.push_back(x);
+  }
+  std::sort(image_id_list.begin(), image_id_list.end());
+
+  string key, val;
+  for (int i = 0; i < image_id_list[0]; ++i)
+    if (!store->Read(&key, &val)) {
+      store->SeekToFirst();
+      CHECK(store->Read(&key, &val));
+    }
+  generate_image(output_folder, key, val);
+
+  for (size_t i = 1; i != image_id_list.size(); ++i) {
+    for (int j = 0; j < image_id_list[i]-image_id_list[i-1]; ++j)
+      if (!store->Read(&key, &val)) {
+        store->SeekToFirst();
+        CHECK(store->Read(&key, &val));
+      }
+    generate_image(output_folder, key, val);
+  }
+}
+
+int main(int argc, char** argv)
+{
+  if (argc != 4) {
+    std::cout << "Visualize images from binary kvfile record.\n"
+      << "Usage: <input_file> <output_folder> <id_list>\n";
+  } else {
+    google::InitGoogleLogging(argv[0]);
+    FLAGS_alsologtostderr = 1;
+    visualize(string(argv[1]), string(argv[2]), string(argv[3]));
+  }
+
+  return 0;
+}

--- a/examples/alexnet/rec2im_test.cc
+++ b/examples/alexnet/rec2im_test.cc
@@ -1,4 +1,28 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+
+
 #include <glog/logging.h>
+#include <opencv2/opencv.hpp>
+
 #include <algorithm>
 #include <random>
 #include <chrono>
@@ -7,7 +31,6 @@
 #include <cstdint>
 #include <iostream>
 #include <vector>
-#include <opencv2/opencv.hpp>
 
 #include "singa/io/store.h"
 #include "singa/proto/common.pb.h"
@@ -19,8 +42,7 @@ const int kImageNBytes = 256*256*3;
 
 void generate_image(const string& output_folder,
     const string& key,
-    const string& val)
-{
+    const string& val) {
   float image_buf[kImageNBytes];
   singa::RecordProto image;
   image.ParseFromString(val);
@@ -38,6 +60,7 @@ void generate_image(const string& output_folder,
           static_cast<uchar>(
               static_cast<uint8_t>(
                 pixel[(c * kImageSize + h) * kImageSize + w]));
+    }
   }
 
   cv::imwrite(image_name, img);
@@ -45,8 +68,7 @@ void generate_image(const string& output_folder,
 
 void visualize(const string& input_file,
     const string& output_folder,
-    const string& id_list)
-{
+    const string& id_list) {
   auto store = singa::io::OpenStore("kvfile", input_file,
       singa::io::kRead);
 
@@ -55,7 +77,7 @@ void visualize(const string& input_file,
   std::ifstream id_list_file(id_list.c_str(), std::ios::in);
   CHECK(id_list_file.is_open()) << "Unable to open image id list";
   string id_;
-  while(id_list_file >> id_) {
+  while (id_list_file >> id_) {
     int x;
     x = std::stoi(id_);
     image_id_list.push_back(x);
@@ -80,10 +102,9 @@ void visualize(const string& input_file,
   }
 }
 
-int main(int argc, char** argv)
-{
+int main(int argc, char** argv) {
   if (argc != 4) {
-    std::cout << "Visualize images from binary kvfile record.\n"
+    std::cout << "Visualize images from binary kvfile records.\n"
       << "Usage: <input_file> <output_folder> <id_list>\n";
   } else {
     google::InitGoogleLogging(argv[0]);

--- a/examples/cifar10/cudnn.conf
+++ b/examples/cifar10/cudnn.conf
@@ -5,7 +5,7 @@ test_freq: 1000
 #validate_steps: 100
 #validate_freq: 300
 disp_freq: 200
-gpu: 0
+gpu: 2
 #checkpoint_path: "examples/cifar10/checkpoint/step1000-worker0"
 train_one_batch {
   alg: kBP
@@ -116,6 +116,7 @@ neuralnet {
     activation_conf {
       type: RELU
     }
+    share_src_blobs: true
     srclayers:"pool1"
   }
   layer {
@@ -161,6 +162,7 @@ neuralnet {
     activation_conf {
       type: RELU
     }
+    share_src_blobs: true
     srclayers:"conv2"
   }
   layer {
@@ -216,6 +218,7 @@ neuralnet {
     activation_conf {
       type: RELU
     }
+    share_src_blobs: true
     srclayers:"conv3"
   }
   layer {

--- a/include/singa/utils/math_blob.h
+++ b/include/singa/utils/math_blob.h
@@ -306,6 +306,9 @@ void Map(Dtype alpha, const Blob<Dtype>& A, Blob<Dtype>* B) {
     cpu_e_f<Op>(A.count(), alpha, A.cpu_data(), B->mutable_cpu_data());
   } else {
 #ifdef USE_GPU
+    gpu_e_f<Op>(A.count(), A.gpu_data(), alpha, B->mutable_gpu_data());
+#else
+    LOG(FATAL) << "Not implemented";
 #endif  // USE_GPU
   }
 }
@@ -324,6 +327,7 @@ void Map(Dtype alpha, const Blob<Dtype>& A, const Blob<Dtype>& B,
         C->mutable_cpu_data());
   } else {
 #ifdef USE_GPU
+    LOG(ERROR) << "Not implemented";
 #endif  // USE_GPU
   }
 }
@@ -670,6 +674,8 @@ void SampleUniform(Dtype low, Dtype high, Blob<Dtype>* A) {
 #ifdef USE_GPU
     gpu_sample_uniform(context->curand_generator(thread), A->count(), low, high,
         A->mutable_gpu_data());
+#else
+    LOG(FATAL) << "Not implemented";
 #endif
   }
 }

--- a/include/singa/utils/math_kernel.h
+++ b/include/singa/utils/math_kernel.h
@@ -79,7 +79,8 @@ extern "C" {
 
   void singa_gpu_set_value(float *data, float value, int n);
 
-  void singa_gpu_threshold(const float *src_data, float *des_data, int n);
+  void singa_gpu_threshold(const float *src_data, float *des_data,
+      float alpha, int n);
 };
 
 }  // namespace singa

--- a/src/neuralnet/connection_layer/slice.cc
+++ b/src/neuralnet/connection_layer/slice.cc
@@ -155,11 +155,11 @@ const std::string SliceLayer::ToString(bool debug, int flag) {
   string ret = "";
   if ((flag & kForward) == kForward && data_.count() !=0) {
     for (unsigned k = 0; k < datavec_.size(); k++)
-      ret += StringPrintf("data-%u :%13.9f ", k, Asum(*datavec_.at(k)));
+      ret += StringPrintf("data-%u :%e ", k, Asum(*datavec_.at(k)));
   }
   if ((flag & kBackward) == kBackward && grad_.count() != 0) {
     for (unsigned k = 0; k < gradvec_.size(); k++)
-    ret += StringPrintf("grad-%u:%13.9f ", k, Asum(*gradvec_.at(k)));
+    ret += StringPrintf("grad-%u:%e ", k, Asum(*gradvec_.at(k)));
   }
   return ret;
 }

--- a/src/neuralnet/input_layer/record.cc
+++ b/src/neuralnet/input_layer/record.cc
@@ -32,7 +32,7 @@ void RecordInputLayer::Setup(const LayerProto& conf,
 }
 
 void RecordInputLayer::LoadRecord(const string& backend,
-    const string&path, Blob<float>* to) {
+    const string& path, Blob<float>* to) {
   io::Store* store = io::OpenStore(backend, path, io::kRead);
   string key, val;
   CHECK(store->Read(&key, &val));

--- a/src/neuralnet/layer.cc
+++ b/src/neuralnet/layer.cc
@@ -48,15 +48,15 @@ const std::string Layer::ToString(bool debug, int flag) {
     return "";
   string ret = "";
   if ((flag & kForward) == kForward && data_.count() !=0) {
-    ret += StringPrintf("data:%13.9f ", Asum(data_));
+    ret += StringPrintf("data:%e ", Asum(data_));
     for (Param* p : GetParams())
       ret += StringPrintf("%s:%13.9f ",
           p->name().c_str(), Asum(p->data()));
   }
   if ((flag & kBackward) == kBackward && grad_.count() != 0) {
-    ret += StringPrintf("grad:%13.9f ", Asum(grad_));
+    ret += StringPrintf("grad:%e ", Asum(grad_));
     for (Param* p : GetParams())
-      ret += StringPrintf("%s:%13.9f ",
+      ret += StringPrintf("%13.9f ",
           p->name().c_str(), Asum(p->grad()));
   }
   return ret;

--- a/src/neuralnet/layer.cc
+++ b/src/neuralnet/layer.cc
@@ -56,7 +56,7 @@ const std::string Layer::ToString(bool debug, int flag) {
   if ((flag & kBackward) == kBackward && grad_.count() != 0) {
     ret += StringPrintf("grad:%e ", Asum(grad_));
     for (Param* p : GetParams())
-      ret += StringPrintf("%13.9f ",
+      ret += StringPrintf("%s:%13.9f ",
           p->name().c_str(), Asum(p->grad()));
   }
   return ret;

--- a/src/neuralnet/neuron_layer/cudnn_lrn.cc
+++ b/src/neuralnet/neuron_layer/cudnn_lrn.cc
@@ -37,7 +37,6 @@ void CudnnLRNLayer::InitCudnn() {
         alpha_,
         beta_,
         knorm_));
-  CHECK_CUDNN(cudnnCreateTensorDescriptor(&src_desc_));
   CHECK_CUDNN(cudnnSetTensor4dDescriptor(src_desc_,
       CUDNN_TENSOR_NCHW,
       CUDNN_DATA_FLOAT,
@@ -45,7 +44,6 @@ void CudnnLRNLayer::InitCudnn() {
       channels_,
       height_,
       width_));
-  CHECK_CUDNN(cudnnCreateTensorDescriptor(&my_desc_));
   CHECK_CUDNN(cudnnSetTensor4dDescriptor(my_desc_,
       CUDNN_TENSOR_NCHW,
       CUDNN_DATA_FLOAT,

--- a/src/neuralnet/neuron_layer/dropout.cc
+++ b/src/neuralnet/neuron_layer/dropout.cc
@@ -48,12 +48,14 @@ void DropoutLayer::ComputeFeature(int flag, const vector<Layer*>& srclayers) {
   Blob<float> rand(data_.count());
   SampleUniform(0.0f, 1.0f, &rand);
   Map<op::Threshold<float>, float>(pkeep, rand, &mask_);
+  // scale the mask to avoid scaling in ComputeGradient
   Scale(1.0f / pkeep, &mask_);
   Mult(srclayers[0]->data(this), mask_, &data_);
 }
 
 void DropoutLayer::ComputeGradient(int flag, const vector<Layer*>& srclayers)  {
   Mult(grad_, mask_, srclayers[0]->mutable_grad(this));
+  // no need to mult scale as mask is scaled already.
 }
 
 }  // namespace singa

--- a/src/neuralnet/neuron_layer/lrn.cc
+++ b/src/neuralnet/neuron_layer/lrn.cc
@@ -64,12 +64,11 @@ void LRNLayer::ComputeGradient(int flag, const vector<Layer*>& srclayers) {
   auto grad = Tensor4(&grad_);
   auto gsrc = Tensor4(srclayers[0]->mutable_grad(this));
 
-  gsrc = grad * expr::F<op::power>(norm, -beta_ );
+  gsrc = grad * expr::F<op::power>(norm, -beta_);
   Tensor<cpu, 4> tmp(gsrc.shape);
   AllocSpace(tmp);
   tmp = gsrc * src / norm;
-  gsrc += ( - 2.0f * beta_ * salpha ) * expr::chpool<red::sum>(tmp, lsize_ )
-    * src;
+  gsrc += (- 2.0f * beta_ * salpha) * expr::chpool<red::sum>(tmp, lsize_) * src;
   FreeSpace(tmp);
 }
 

--- a/src/neuralnet/neuron_layer/lrn.cc
+++ b/src/neuralnet/neuron_layer/lrn.cc
@@ -64,9 +64,13 @@ void LRNLayer::ComputeGradient(int flag, const vector<Layer*>& srclayers) {
   auto grad = Tensor4(&grad_);
   auto gsrc = Tensor4(srclayers[0]->mutable_grad(this));
 
-  gsrc = grad * expr::F<op::power>(norm, -beta_);
-  gsrc += (- 2.0f * beta_ * salpha) * expr::chpool<red::sum>(
-      grad * src * expr::F<op::power>(norm, -beta_ - 1.0f), lsize_)  * src;
+  gsrc = grad * expr::F<op::power>(norm, -beta_ );
+  Tensor<cpu, 4> tmp(gsrc.shape);
+  AllocSpace(tmp);
+  tmp = gsrc * src / norm;
+  gsrc += ( - 2.0f * beta_ * salpha ) * expr::chpool<red::sum>(tmp, lsize_ )
+    * src;
+  FreeSpace(tmp);
 }
 
 }  // namespace singa

--- a/src/proto/job.proto
+++ b/src/proto/job.proto
@@ -189,6 +189,9 @@ message LayerProto {
   optional LayerType type = 20 [default = kUserLayer];
   // type of user layer
   optional string user_type =21;
+  // share data and grad blob with the single src layer, e.g., relu layer can
+  // share blobs from conv layer. It is useful for saving memory space.
+  optional bool share_src_blobs = 22 [default = false];
 
   // proto for the specific layer
   // configuration for input layers

--- a/src/utils/image_transform.cc
+++ b/src/utils/image_transform.cc
@@ -26,11 +26,11 @@ void ImageTransform(const float* in, const float* mean, bool mirror, int h_crop,
     int w_crop, int h_offset, int w_offset, int channel, int height, int width,
     float scale, float* out) {
   if (h_crop == 0) {
-    CHECK_NE(h_offset, 0);
+    CHECK_EQ(h_offset, 0);
     h_crop = height;
   }
   if (w_crop ==0) {
-    CHECK_NE(w_offset, 0);
+    CHECK_EQ(w_offset, 0);
     w_crop = width;
   }
   CHECK_NE(scale, 0);

--- a/src/utils/updater.cc
+++ b/src/utils/updater.cc
@@ -7,9 +7,9 @@
 * to you under the Apache License, Version 2.0 (the
 * "License"); you may not use this file except in compliance
 * with the License.  You may obtain a copy of the License at
-* 
+*
 *   http://www.apache.org/licenses/LICENSE-2.0
-* 
+*
 * Unless required by applicable law or agreed to in writing,
 * software distributed under the License is distributed on an
 * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -59,7 +59,10 @@ float FixedStepLRGen::Get(int step) {
 float StepLRGen::Get(int step) {
   // do not cast int to float
   int freq = proto_.step_conf().change_freq();
-  return  proto_.base_lr() * pow(proto_.step_conf().gamma(), step / freq);
+  float lr = proto_.base_lr() * pow(proto_.step_conf().gamma(), step / freq);
+  LOG_IF(ERROR, step % freq == 0) << "Update learning rate to " << lr
+    << " @ step " << step;
+  return lr;
 }
 
 float LinearLRGen::Get(int step) {

--- a/src/utils/updater.cc
+++ b/src/utils/updater.cc
@@ -60,7 +60,7 @@ float StepLRGen::Get(int step) {
   // do not cast int to float
   int freq = proto_.step_conf().change_freq();
   float lr = proto_.base_lr() * pow(proto_.step_conf().gamma(), step / freq);
-  LOG_IF(ERROR, step % freq == 0) << "Update learning rate to " << lr
+  LOG_IF(INFO, step % freq == 0) << "Update learning rate to " << lr
     << " @ step " << step;
   return lr;
 }

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -344,7 +344,7 @@ void BPWorker::Forward(int step, Phase phase, NeuralNet* net) {
           Collect(step, p);
         }
       }
-      // LOG(ERROR) << layer->name() << " forward";
+      // DLOG(ERROR) << "Forward " << layer->name();
       layer->ComputeFeature(phase | kForward, net->srclayers(layer));
       if (job_conf_.debug() && grp_id_ == 0)
         label[layer->name()] = layer->ToString(true, phase | kForward);


### PR DESCRIPTION
Update the code and add configuration files for training the AlexNet model over the ImageNet dataset.
The examples/alexnet/ folder is created to include 
* the configuration files, job.conf for CPU training and cudnn.conf for GPU training with CUDNN V3, which are set following [Caffe](https://github.com/BVLC/caffe/tree/master/models/bvlc_reference_caffenet).
* the im2rec.cc creates the data stores for training and validation from raw images extracted from ImageNet. rec2im_test.cc randomly generates images from records in data stores to check the correctness of im2rec.cc.

To test this pull request, 
  1. Download and extract the (ImageNet dataset])(http://www.image-net.org/)
  2. Compile the im2rec.cc and rec2im_test.cc,
        
        cp Makefile.example Makefile
        make create

  3. Create the training and validation data stores using im2rec.bin. Usage info will be displayed if you execute the program without any arguments. You can inspect the created data stores by sampling some records and visualize them via rec2im_test.bin.
  4. After compiling SINGA, you can start the training, e.g., on GPU #105 

        ./bin/singa-run.sh -conf examples/alexnet/cudnn.conf

  you may need to update the paths and gpu device id correspondingly.

The training loss would decrease after about 3000 iterations.
TODO reduce the memory footprint and optimize the training speed using multiple GPUs later.


