### PR TITLE
SIGNA-141 Undesired Hash collision when locating process id to worker…

### DIFF
--- a/src/utils/cluster.cc
+++ b/src/utils/cluster.cc
@@ -116,8 +116,10 @@ const vector<int> Cluster::ExecutorRng(int pid, int grp_size, int procs_size) {
 int Cluster::Hash(int gid, int id, int flag) {
   int ret = -1;
   if (flag == kServer) {
-    ret = (flag * cluster_.nserver_groups() + gid)
-          * cluster_.nservers_per_group() + id;
+    ret = kServer * cluster_.nworker_groups()
+      * cluster_.nworkers_per_group()
+      + (cluster_.nserver_groups() + gid)
+      * cluster_.nservers_per_group() + id;
   } else {
     ret = (flag * cluster_.nworker_groups() + gid)
           * cluster_.nworkers_per_group() + id;


### PR DESCRIPTION
…s and servers

Circumvent undesired collision in Hash function by adding maximum range from calculating for workers
as the offset when calculating for servers.