### PR TITLE
SINGA-148 Race condition between Worker threads and Driver

### DIFF
--- a/examples/cifar10/cudnn_hybrid.conf
+++ b/examples/cifar10/cudnn_hybrid.conf
@@ -1,10 +1,10 @@
 name: "cifar10-convnet"
-train_steps: 10000
+train_steps: 1000
 test_steps: 0
 test_freq: 200
 #validate_steps: 100
 #validate_freq: 300
-disp_freq: 200
+disp_freq: 50
 gpu: 0
 gpu: 1
 #debug: true
@@ -43,7 +43,6 @@ neuralnet {
       shape: 32
     }
     include: kTrain
-    partition_dim: 0
   }
 #  layer{
 #    name: "data"
@@ -73,7 +72,6 @@ neuralnet {
       shape: 32
     }
     include: kTest
-    partition_dim: 0
   }
 
   layer {

--- a/examples/cifar10/gpu.conf
+++ b/examples/cifar10/gpu.conf
@@ -1,0 +1,282 @@
+name: "cifar10-convnet"
+train_steps: 1000
+test_steps: 100
+test_freq: 200
+#validate_steps: 100
+#validate_freq: 300
+disp_freq: 50
+gpu:0
+
+
+#checkpoint_path: "examples/cifar10/checkpoint/step1000-worker0"
+train_one_batch {
+  alg: kBP
+}
+updater{
+  type: kSGD
+  weight_decay:0.004
+  momentum:0.9
+  learning_rate {
+    type: kFixedStep
+    fixedstep_conf:{
+      step:0
+      step:60000
+      step:65000
+      step_lr:0.001
+      step_lr:0.0001
+      step_lr:0.00001
+    }
+  }
+}
+neuralnet {
+  layer{
+    name: "data"
+    type: kRecordInput
+    store_conf {
+      backend: "kvfile"
+      path: "examples/cifar10/train_data.bin"
+      mean_file: "examples/cifar10/image_mean.bin"
+      batchsize: 100
+      #random_skip: 5000
+      shape: 3
+      shape: 32
+      shape: 32
+    }
+    include: kTrain
+  }
+#  layer{
+#    name: "data"
+#    type: kRecordInput
+#    store_conf {
+#      backend: "kvfile"
+#      path: "examples/cifar10/val_data.bin"
+#      mean_file: "examples/cifar10/image_mean.bin"
+#      batchsize: 64
+#      random_skip: 5000
+#      shape: 3
+#      shape: 32
+#      shape: 32
+#    }
+#    include: kVal
+#  }
+  layer{
+    name: "data"
+    type: kRecordInput
+    store_conf {
+      backend: "kvfile"
+      path: "examples/cifar10/test_data.bin"
+      mean_file: "examples/cifar10/image_mean.bin"
+      batchsize: 100
+      shape: 3
+      shape: 32
+      shape: 32
+    }
+    include: kTest
+  }
+
+  layer {
+    name: "conv1"
+    type: kCConvolution
+    srclayers: "data"
+    convolution_conf {
+      num_filters: 32
+      kernel: 5
+      stride: 1
+      pad:2
+    }
+    param {
+      name: "w1"
+      init {
+        type:kGaussian
+        std:0.0001
+      }
+    }
+    param {
+      name: "b1"
+      lr_scale:2.0
+      init {
+        type: kConstant
+        value:0
+      }
+    }
+  }
+
+  layer {
+    name: "pool1"
+    type: kCPooling
+    srclayers: "conv1"
+    pooling_conf {
+      pool: MAX
+      kernel: 3
+      stride: 2
+    }
+  }
+  layer {
+    name: "relu1"
+    type: kReLU
+    srclayers:"pool1"
+  }
+  layer {
+    name: "norm1"
+    type: kLRN
+    lrn_conf {
+      local_size: 3
+      alpha: 5e-05
+      beta: 0.75
+    }
+    srclayers:"relu1"
+  }
+  layer {
+    name: "conv2"
+    type: kCConvolution
+    srclayers: "norm1"
+    convolution_conf {
+      num_filters: 32
+      kernel: 5
+      stride: 1
+      pad:2
+    }
+    param {
+      name: "w2"
+      init {
+        type:kGaussian
+        std:0.01
+      }
+    }
+    param {
+      name: "b2"
+      lr_scale:2.0
+      init {
+        type: kConstant
+        value:0
+      }
+    }
+  }
+  layer {
+    name: "relu2"
+    type: kReLU
+    srclayers:"conv2"
+  }
+  layer {
+    name: "pool2"
+    type: kCPooling
+    srclayers: "relu2"
+    pooling_conf {
+      pool: AVG
+      kernel: 3
+      stride: 2
+    }
+  }
+  layer {
+    name: "norm2"
+    type: kLRN
+    lrn_conf {
+      local_size: 3
+      alpha: 5e-05
+      beta: 0.75
+    }
+    srclayers:"pool2"
+  }
+  layer {
+    name: "conv3"
+    type: kCConvolution
+    srclayers: "norm2"
+    convolution_conf {
+      num_filters: 64
+      kernel: 5
+      stride: 1
+      pad:2
+    }
+    param {
+      name: "w3"
+      init {
+        type:kGaussian
+        std:0.01
+      }
+    }
+    param {
+      name: "b3"
+      init {
+        type: kConstant
+        value:0
+      }
+    }
+  }
+  layer {
+    name: "relu3"
+    type: kReLU
+    srclayers:"conv3"
+  }
+  layer {
+    name: "pool3"
+    type: kCPooling
+    srclayers: "relu3"
+    pooling_conf {
+      pool: AVG
+      kernel: 3
+      stride: 2
+    }
+  }
+  layer {
+    name: "ip1"
+    type: kInnerProduct
+    srclayers:"pool3"
+    innerproduct_conf {
+      num_output: 10
+    }
+    param {
+      name: "w4"
+      wd_scale:250
+      init {
+        type:kGaussian
+        std:0.01
+      }
+    }
+    param {
+      name: "b4"
+      lr_scale:2.0
+      wd_scale:0
+      init {
+        type: kConstant
+        value:0
+      }
+    }
+  }
+#  layer {
+#   name : "softmax"
+#   type: kSoftmax
+#   srclayers: "ip1"
+#  }
+#
+#  layer {
+#   name : "argsort"
+#   type: kArgSort
+#   srclayers: "softmax"
+#  }
+  layer{
+    name: "loss"
+    type: kSoftmaxLoss
+    softmaxloss_conf{
+      topk:1
+    }
+    srclayers:"ip1"
+    srclayers: "data"
+  }
+# uncomment "softmax", "argsort", "output" layer and comment "loss" layer
+# to extract features from argsort
+#  layer {
+#    name : "output"
+#    type: kCSVOutput
+#    srclayers: "argsort"
+#    store_conf {
+#      path: "examples/cifar10/out.csv"
+#    }
+#  }
+}
+cluster {
+  nworker_groups: 1
+  nserver_groups: 1
+  nworkers_per_group: 1
+  nworkers_per_procs: 1
+  workspace: "examples/cifar10"
+}

--- a/examples/cifar10/hybrid.conf
+++ b/examples/cifar10/hybrid.conf
@@ -4,7 +4,9 @@ test_steps: 0
 test_freq: 200
 #validate_steps: 100
 #validate_freq: 300
-disp_freq: 30
+disp_freq: 50
+
+
 #debug: true
 #checkpoint_path: "examples/cifar10/checkpoint/step1000-worker0"
 train_one_batch {

--- a/examples/cifar10/job.conf
+++ b/examples/cifar10/job.conf
@@ -5,6 +5,9 @@ test_freq: 200
 #validate_steps: 100
 #validate_freq: 300
 disp_freq: 50
+
+
+
 #checkpoint_path: "examples/cifar10/checkpoint/step1000-worker0"
 train_one_batch {
   alg: kBP

--- a/examples/mnist/2x2.conf
+++ b/examples/mnist/2x2.conf
@@ -1,0 +1,261 @@
+name: "mlp"
+train_steps: 1000
+test_steps:0
+test_freq:500
+disp_freq:100
+gpu:0
+gpu:1
+
+train_one_batch {
+  alg: kBP
+}
+
+updater{
+  type: kSGD
+  learning_rate{
+    type : kStep
+    base_lr: 0.001
+    step_conf{
+      change_freq: 60
+      gamma: 0.997
+    }
+  }
+}
+
+neuralnet {
+  layer {
+    name: "data"
+    type: kRecordInput
+    store_conf {
+      backend: "kvfile"
+      path: "examples/mnist/train_data.bin"
+      random_skip: 5000
+      batchsize: 64
+      shape: 784
+      std_value: 127.5
+      mean_value: 127.5
+      ratio: 5
+    }
+    include: kTrain
+  }
+
+  layer {
+    name: "data"
+    type: kRecordInput
+    store_conf {
+      backend: "kvfile"
+      path: "examples/mnist/test_data.bin"
+      batchsize: 100
+      shape: 784
+      std_value: 127.5
+      mean_value: 127.5
+    }
+    include: kTest
+  }
+
+  layer{
+    name: "fc1"
+    partition_dim: 0
+    type: kInnerProduct
+    srclayers:"data"
+    innerproduct_conf{
+      num_output: 2500
+    }
+    param{
+      name: "w1"
+      init {
+        type: kUniform
+        low:-0.05
+        high:0.05
+      }
+    }
+    param{
+      name: "b1"
+      init {
+        type : kUniform
+        low: -0.05
+        high:0.05
+      }
+    }
+  }
+
+  layer{
+    name: "tanh1"
+    partition_dim: 0
+    type: kSTanh
+    srclayers:"fc1"
+  }
+  layer{
+    name: "fc2"
+    partition_dim: 0
+    type: kInnerProduct
+    srclayers:"tanh1"
+    innerproduct_conf{
+      num_output: 2000
+    }
+    param{
+      name: "w2"
+      init {
+        type: kUniform
+        low:-0.05
+        high:0.05
+      }
+    }
+    param{
+      name: "b2"
+      init {
+        type: kUniform
+        low: -0.05
+        high:0.05
+      }
+    }
+  }
+
+  layer{
+    name: "tanh2"
+    partition_dim: 0
+    type: kSTanh
+    srclayers:"fc2"
+  }
+  layer{
+    name: "fc3"
+    partition_dim: 0
+    type:  kInnerProduct
+    srclayers:"tanh2"
+    innerproduct_conf{
+      num_output: 1500
+    }
+    param{
+      name: "w3"
+      init{
+        type: kUniform
+        low:-0.05
+        high:0.05
+      }
+    }
+    param{
+      name: "b3"
+      init {
+        type : kUniform
+        low: -0.05
+        high:0.05
+      }
+    }
+
+  }
+
+  layer{
+    name: "tanh3"
+    partition_dim: 0
+    type: kSTanh
+    srclayers:"fc3"
+  }
+  layer{
+    name: "fc4"
+    partition_dim: 0
+    type: kInnerProduct
+    srclayers:"tanh3"
+    innerproduct_conf{
+      num_output: 1000
+    }
+    param{
+      name: "w4"
+      init {
+        type : kUniform
+        low:-0.05
+        high:0.05
+      }
+    }
+    param{
+      name: "b4"
+      init {
+        type : kUniform
+        low: -0.05
+        high:0.05
+      }
+    }
+
+  }
+
+  layer{
+    name: "tanh4"
+    partition_dim: 0
+    type: kSTanh
+    srclayers:"fc4"
+  }
+  layer{
+    name: "fc5"
+    partition_dim: 0
+    type: kInnerProduct
+    srclayers:"tanh4"
+    innerproduct_conf{
+      num_output: 500
+    }
+    param{
+      name: "w5"
+      init {
+        type : kUniform
+        low:-0.05
+        high:0.05
+      }
+    }
+    param{
+      name: "b5"
+      init {
+        type : kUniform
+        low: -0.05
+        high:0.05
+      }
+    }
+  }
+
+  layer{
+    name: "tanh5"
+    partition_dim: 0
+    type: kSTanh
+    srclayers:"fc5"
+  }
+  layer{
+    name: "fc6"
+    partition_dim: 0
+    type: kInnerProduct
+    srclayers:"tanh5"
+    innerproduct_conf{
+      num_output: 10
+    }
+    param{
+      name: "w6"
+      init {
+        type : kUniform
+        low:-0.05
+        high:0.05
+      }
+    }
+    param{
+      name: "b6"
+      init {
+        type : kUniform
+        low: -0.05
+        high:0.05
+      }
+    }
+  }
+  layer{
+    name: "loss"
+    type:kSoftmaxLoss
+    softmaxloss_conf{
+      topk:1
+    }
+    srclayers:"fc6"
+    srclayers:"data"
+  }
+}
+cluster {
+  nworker_groups: 1
+  nserver_groups: 1
+  nworkers_per_group: 4
+  nworkers_per_procs: 4
+  ngpu_per_group:2
+  workspace: "examples/mnist"
+}
+

--- a/examples/mnist/gpu.conf
+++ b/examples/mnist/gpu.conf
@@ -1,13 +1,13 @@
 name: "mlp"
 train_steps: 1000
-test_steps:0
+test_steps:10
 test_freq:500
 disp_freq:100
+gpu:0
 
 train_one_batch {
   alg: kBP
 }
-
 updater{
   type: kSGD
   learning_rate{
@@ -52,7 +52,6 @@ neuralnet {
 
   layer{
     name: "fc1"
-    partition_dim: 0
     type: kInnerProduct
     srclayers:"data"
     innerproduct_conf{
@@ -78,13 +77,11 @@ neuralnet {
 
   layer{
     name: "tanh1"
-    partition_dim: 0
     type: kSTanh
     srclayers:"fc1"
   }
   layer{
     name: "fc2"
-    partition_dim: 0
     type: kInnerProduct
     srclayers:"tanh1"
     innerproduct_conf{
@@ -110,13 +107,11 @@ neuralnet {
 
   layer{
     name: "tanh2"
-    partition_dim: 0
     type: kSTanh
     srclayers:"fc2"
   }
   layer{
     name: "fc3"
-    partition_dim: 0
     type:  kInnerProduct
     srclayers:"tanh2"
     innerproduct_conf{
@@ -143,13 +138,11 @@ neuralnet {
 
   layer{
     name: "tanh3"
-    partition_dim: 0
     type: kSTanh
     srclayers:"fc3"
   }
   layer{
     name: "fc4"
-    partition_dim: 0
     type: kInnerProduct
     srclayers:"tanh3"
     innerproduct_conf{
@@ -176,13 +169,11 @@ neuralnet {
 
   layer{
     name: "tanh4"
-    partition_dim: 0
     type: kSTanh
     srclayers:"fc4"
   }
   layer{
     name: "fc5"
-    partition_dim: 0
     type: kInnerProduct
     srclayers:"tanh4"
     innerproduct_conf{
@@ -208,13 +199,11 @@ neuralnet {
 
   layer{
     name: "tanh5"
-    partition_dim: 0
     type: kSTanh
     srclayers:"fc5"
   }
   layer{
     name: "fc6"
-    partition_dim: 0
     type: kInnerProduct
     srclayers:"tanh5"
     innerproduct_conf{
@@ -250,7 +239,5 @@ neuralnet {
 cluster {
   nworker_groups: 1
   nserver_groups: 1
-  nworkers_per_group: 2
-  nworkers_per_procs: 2
   workspace: "examples/mnist"
 }

--- a/examples/mnist/hybrid.conf
+++ b/examples/mnist/hybrid.conf
@@ -1,0 +1,256 @@
+name: "mlp"
+train_steps: 1000
+test_steps:0
+test_freq:60
+disp_freq:10
+
+train_one_batch {
+  alg: kBP
+}
+
+updater{
+  type: kSGD
+  learning_rate{
+    type : kStep
+    base_lr: 0.001
+    step_conf{
+      change_freq: 60
+      gamma: 0.997
+    }
+  }
+}
+
+neuralnet {
+  layer {
+    name: "data"
+    type: kRecordInput
+    store_conf {
+      backend: "kvfile"
+      path: "examples/mnist/train_data.bin"
+      random_skip: 5000
+      batchsize: 64
+      shape: 784
+      std_value: 127.5
+      mean_value: 127.5
+    }
+    include: kTrain
+  }
+
+  layer {
+    name: "data"
+    type: kRecordInput
+    store_conf {
+      backend: "kvfile"
+      path: "examples/mnist/test_data.bin"
+      batchsize: 100
+      shape: 784
+      std_value: 127.5
+      mean_value: 127.5
+    }
+    include: kTest
+  }
+
+  layer{
+    name: "fc1"
+    partition_dim: 0
+    type: kInnerProduct
+    srclayers:"data"
+    innerproduct_conf{
+      num_output: 2500
+    }
+    param{
+      name: "w1"
+      init {
+        type: kUniform
+        low:-0.05
+        high:0.05
+      }
+    }
+    param{
+      name: "b1"
+      init {
+        type : kUniform
+        low: -0.05
+        high:0.05
+      }
+    }
+  }
+
+  layer{
+    name: "tanh1"
+    partition_dim: 0
+    type: kSTanh
+    srclayers:"fc1"
+  }
+  layer{
+    name: "fc2"
+    partition_dim: 0
+    type: kInnerProduct
+    srclayers:"tanh1"
+    innerproduct_conf{
+      num_output: 2000
+    }
+    param{
+      name: "w2"
+      init {
+        type: kUniform
+        low:-0.05
+        high:0.05
+      }
+    }
+    param{
+      name: "b2"
+      init {
+        type: kUniform
+        low: -0.05
+        high:0.05
+      }
+    }
+  }
+
+  layer{
+    name: "tanh2"
+    partition_dim: 0
+    type: kSTanh
+    srclayers:"fc2"
+  }
+  layer{
+    name: "fc3"
+    partition_dim: 0
+    type:  kInnerProduct
+    srclayers:"tanh2"
+    innerproduct_conf{
+      num_output: 1500
+    }
+    param{
+      name: "w3"
+      init{
+        type: kUniform
+        low:-0.05
+        high:0.05
+      }
+    }
+    param{
+      name: "b3"
+      init {
+        type : kUniform
+        low: -0.05
+        high:0.05
+      }
+    }
+
+  }
+
+  layer{
+    name: "tanh3"
+    partition_dim: 0
+    type: kSTanh
+    srclayers:"fc3"
+  }
+  layer{
+    name: "fc4"
+    partition_dim: 0
+    type: kInnerProduct
+    srclayers:"tanh3"
+    innerproduct_conf{
+      num_output: 1000
+    }
+    param{
+      name: "w4"
+      init {
+        type : kUniform
+        low:-0.05
+        high:0.05
+      }
+    }
+    param{
+      name: "b4"
+      init {
+        type : kUniform
+        low: -0.05
+        high:0.05
+      }
+    }
+
+  }
+
+  layer{
+    name: "tanh4"
+    partition_dim: 0
+    type: kSTanh
+    srclayers:"fc4"
+  }
+  layer{
+    name: "fc5"
+    partition_dim: 0
+    type: kInnerProduct
+    srclayers:"tanh4"
+    innerproduct_conf{
+      num_output: 500
+    }
+    param{
+      name: "w5"
+      init {
+        type : kUniform
+        low:-0.05
+        high:0.05
+      }
+    }
+    param{
+      name: "b5"
+      init {
+        type : kUniform
+        low: -0.05
+        high:0.05
+      }
+    }
+  }
+
+  layer{
+    name: "tanh5"
+    partition_dim: 0
+    type: kSTanh
+    srclayers:"fc5"
+  }
+  layer{
+    name: "fc6"
+    partition_dim: 0
+    type: kInnerProduct
+    srclayers:"tanh5"
+    innerproduct_conf{
+      num_output: 10
+    }
+    param{
+      name: "w6"
+      init {
+        type : kUniform
+        low:-0.05
+        high:0.05
+      }
+    }
+    param{
+      name: "b6"
+      init {
+        type : kUniform
+        low: -0.05
+        high:0.05
+      }
+    }
+  }
+  layer{
+    name: "loss"
+    type:kSoftmaxLoss
+    softmaxloss_conf{
+      topk:1
+    }
+    srclayers:"fc6"
+    srclayers:"data"
+  }
+}
+cluster {
+  nworker_groups: 1
+  nserver_groups: 1
+  nworkers_per_group: 2
+  nworkers_per_procs: 2
+  workspace: "examples/mnist"
+}

--- a/examples/mnist/hybrid_gpu.conf
+++ b/examples/mnist/hybrid_gpu.conf
@@ -3,6 +3,7 @@ train_steps: 1000
 test_steps:0
 test_freq:500
 disp_freq:100
+gpu:0
 
 train_one_batch {
   alg: kBP

--- a/examples/mnist/hybrid_gpux2.conf
+++ b/examples/mnist/hybrid_gpux2.conf
@@ -3,6 +3,8 @@ train_steps: 1000
 test_steps:0
 test_freq:500
 disp_freq:100
+gpu:0
+gpu:1
 
 train_one_batch {
   alg: kBP

--- a/examples/mnist/job.conf
+++ b/examples/mnist/job.conf
@@ -1,8 +1,10 @@
 name: "mlp"
 train_steps: 1000
 test_steps:10
-test_freq:60
-disp_freq:10
+test_freq:500
+disp_freq:100
+
+
 train_one_batch {
   alg: kBP
 }

--- a/examples/rnnlm/rnnlm.proto
+++ b/examples/rnnlm/rnnlm.proto
@@ -39,9 +39,9 @@ message DataProto {
 }
 
 extend singa.LayerProto {
-  optional EmbeddingProto embedding_conf = 101;
-  optional LossProto loss_conf = 102;
-  optional DataProto data_conf = 103;
+  optional EmbeddingProto embedding_conf = 1001;
+  optional LossProto loss_conf = 1002;
+  optional DataProto data_conf = 1003;
 }
 
 message WordRecord {

--- a/include/singa/driver.h
+++ b/include/singa/driver.h
@@ -18,8 +18,8 @@
 * under the License.
 *
 *************************************************************/
-#ifndef SINGA_SINGA_DRIVER_H_
-#define SINGA_SINGA_DRIVER_H_
+#ifndef SINGA_DRIVER_H_
+#define SINGA_DRIVER_H_
 
 #include <vector>
 #include "singa/proto/job.pb.h"
@@ -74,7 +74,7 @@ class Driver {
    * files.
    * @param[in] str serialized string recorded job configuration.
    */
-  void Train(bool resume, const std::string str); 
+  void Train(bool resume, const std::string str);
   /**
    * Create workers and servers to conduct the training.
    *
@@ -259,4 +259,4 @@ int Driver::RegisterWorker(const Type& type) {
 
 }  // namespace singa
 
-#endif  // SINGA_SINGA_DRIVER_H_
+#endif  // SINGA_DRIVER_H_

--- a/include/singa/utils/cluster.h
+++ b/include/singa/utils/cluster.h
@@ -53,6 +53,7 @@ class Cluster {
   inline int nservers_per_group() const { return cluster_.nservers_per_group();}
   inline int nworkers_per_procs() const { return cluster_.nworkers_per_procs();}
   inline int nservers_per_procs() const { return cluster_.nservers_per_procs();}
+  inline int ngpu_per_group() const { return cluster_.ngpu_per_group();}
   inline int nworker_groups_per_server_group() const {
     if (nserver_groups() == 0 || nservers_per_group() == 0)
       return 1;

--- a/include/singa/utils/context.h
+++ b/include/singa/utils/context.h
@@ -145,7 +145,7 @@ class Context {
   }
 
   /**
-   * \copybreif rand_generator(const std::thread::id&);
+   * \copybrief rand_generator(const std::thread::id&);
    * @return the CPU random generator for the calling thread.
    */
   std::mt19937* rand_generator() {
@@ -170,7 +170,7 @@ class Context {
   }
 #ifdef USE_GPU
   /**
-   * \copybreif cublas_handle_(const std::thread::id&);
+   * \copybrief cublas_handle_(const std::thread::id&);
    * @return cublas handle for the calling thread.
    */
   cublasHandle_t cublas_handle() {

--- a/include/singa/worker.h
+++ b/include/singa/worker.h
@@ -62,6 +62,12 @@ class Worker {
    * @return a pointer to the instance of the Worker subclass.
    */
   static Worker* Create(const AlgProto& conf);
+  /**
+   * Create an instance of the subclass of Worker
+   * with the specified device type.
+   */
+  static Worker* Create(const AlgProto& conf, DeviceType devtype);
+
   virtual ~Worker();
   /**
    * @param[in] grp_id global worker group ID
@@ -267,11 +273,21 @@ class Worker {
    */
   inline int id() const { return id_; }
 
+  /**
+   * @return The type of device this thread currently is assigned to.
+   */
+  inline DeviceType device_type() { return device_type_; }
+
+  inline DeviceType device_type(DeviceType devtype) { 
+    device_type_ = devtype;
+    return device_type_;
+  }
+
  protected:
   int grp_id_ = -1, id_ = -1;
   int step_ = 0;
   JobProto job_conf_;
-  DeviceType device_type;
+  DeviceType device_type_;
   NeuralNet* train_net_ = nullptr;
   NeuralNet* test_net_ = nullptr;
   NeuralNet* val_net_ = nullptr;

--- a/include/singa/worker.h
+++ b/include/singa/worker.h
@@ -263,7 +263,7 @@ class Worker {
    */
   inline int grp_id() const { return grp_id_; }
   /**
-   * @reutrn worker ID within the worker group.
+   * @return worker ID within the worker group.
    */
   inline int id() const { return id_; }
 
@@ -271,6 +271,7 @@ class Worker {
   int grp_id_ = -1, id_ = -1;
   int step_ = 0;
   JobProto job_conf_;
+  DeviceType device_type;
   NeuralNet* train_net_ = nullptr;
   NeuralNet* test_net_ = nullptr;
   NeuralNet* val_net_ = nullptr;

--- a/include/singa/worker.h
+++ b/include/singa/worker.h
@@ -66,7 +66,7 @@ class Worker {
    * Create an instance of the subclass of Worker
    * with the specified device type.
    */
-  static Worker* Create(const AlgProto& conf, DeviceType devtype);
+  static Worker* Create(const AlgProto& conf, int devid);
 
   virtual ~Worker();
   /**
@@ -274,20 +274,21 @@ class Worker {
   inline int id() const { return id_; }
 
   /**
-   * @return The type of device this thread currently is assigned to.
+   * @return The device ID of this worker. It is -1 for CPU and >-1 for GPU.
    */
-  inline DeviceType device_type() { return device_type_; }
+  inline int device_id() { return device_id_; }
 
-  inline DeviceType device_type(DeviceType devtype) { 
-    device_type_ = devtype;
-    return device_type_;
-  }
+  /**
+   * @param devid The ID value to assign to this worker.
+   */
+  inline void device_id(int devid) { device_id_ = devid; }
 
  protected:
   int grp_id_ = -1, id_ = -1;
   int step_ = 0;
+  bool execute_;
   JobProto job_conf_;
-  DeviceType device_type_;
+  int device_id_;
   NeuralNet* train_net_ = nullptr;
   NeuralNet* test_net_ = nullptr;
   NeuralNet* val_net_ = nullptr;

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -244,6 +244,7 @@ void Driver::Train(const JobProto& job_conf) {
     threads.push_back(std::thread(&Worker::Run, worker));
     int device_id  = -1;
     if (gpu < job_conf.gpu_size()) {
+      LOG(ERROR) << "Creating GPU...";
       device_id = job_conf.gpu(gpu++);
     }
     context->SetupDevice(threads.back().get_id(), device_id);

--- a/src/neuralnet/input_layer/store.cc
+++ b/src/neuralnet/input_layer/store.cc
@@ -38,6 +38,7 @@ void StoreInputLayer::Setup(const LayerProto& conf,
   if (conf.partition_dim() == 0) {
     batchsize_ /= conf.num_partitions();
   }
+  LOG(ERROR) << "Ratio: " << layer_conf_.store_conf().ratio();
 }
 
 void StoreInputLayer::ComputeFeature(int flag,

--- a/src/proto/common.proto
+++ b/src/proto/common.proto
@@ -50,6 +50,12 @@ enum ConnectionType {
   kOneToMany = 2;
 }
 
+enum DeviceType {
+  kCPU = 0;
+  kGPU = 1;
+  kOther = 2;
+}
+
 // to import caffe's lmdb dataset
 message CaffeDatum {
   optional int32 channels = 1;

--- a/src/proto/job.proto
+++ b/src/proto/job.proto
@@ -166,7 +166,8 @@ message ClusterProto {
   optional int32 nservers_per_group = 4 [default = 1];
   optional int32 nworkers_per_procs = 5 [default = 1];
   optional int32 nservers_per_procs = 6 [default = 1];
-  optional int32 ngpu_per_group = 7 [default=0];
+  optional int32 ngpu_per_group = 7 [default = 0];
+
   // local workspace for checkpoint files and vis files
   //required string workspace = 10;
   optional string workspace = 10;
@@ -380,6 +381,7 @@ message StoreProto {
   optional bool encoded = 10 [default = false];
   optional int32 random_skip = 11 [default = 0];
   optional bool has_label = 12 [default = true];
+  optional int32 ratio = 13 [default = 1];
 }
 message CharRNNProto {
   optional string path = 1;

--- a/src/proto/job.proto
+++ b/src/proto/job.proto
@@ -166,6 +166,7 @@ message ClusterProto {
   optional int32 nservers_per_group = 4 [default = 1];
   optional int32 nworkers_per_procs = 5 [default = 1];
   optional int32 nservers_per_procs = 6 [default = 1];
+  optional int32 ngpu_per_group = 7 [default=0];
   // local workspace for checkpoint files and vis files
   //required string workspace = 10;
   optional string workspace = 10;

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -22,8 +22,6 @@
 #include "singa/worker.h"
 
 #include <glog/logging.h>
-#include <chrono>
-#include <thread>
 #include <typeinfo>
 #include "singa/utils/cluster.h"
 #include "singa/utils/factory.h"

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -62,6 +62,7 @@ Worker::~Worker() {
 }
 
 void Worker::Run() {
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   // setup gpu device
   auto context = Singleton<Context>::Instance();
   int device = context->device_id(std::this_thread::get_id());


### PR DESCRIPTION
In this PR I aim to fix the race condition between Driver and Worker threads.

Included are the additional *.conf files I created to perform testing under various hardware conditions where other variables remain equal. You can ignore them.

The main changes made are in Driver::Train(), Driver::CreateWorkers(), Worker::Run(), and job.proto.
I have added an additional variable to be passed in during the creation of Worker objects so the Worker knows its identity as a CPU or GPU  execution unit.
Worker objects also perform context->SetupDevice() now instead of deferring it to Driver::Train().
The execution flow in Driver::CreateWorkers() has also been straightened out a bit.
