### PR TITLE
SINGA-149 Docker build fail

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -332,7 +332,9 @@ libsingagpu.so: $(CUDA_OBJS)
 # Create python class files
 install-pyLTLIBRARIES: $(py_LTLIBRARIES)
 	touch tool/python/singa/__init__.py
-	cp -f .libs/_driver.so tool/python/singa/
+	@if [ -f ".libs/_driver.so" ]; then \
+	  cp -f .libs/_driver.so tool/python/singa/;\
+	fi
 
 uninstall-pyLTLIBRARIES:
 	rm -f tool/python/singa/__init__.py


### PR DESCRIPTION
Docker build failed during `make install`.

The error is caused by the `install-pyLTLIBRARIES` target in the Makefile fails to check for the
exitence of `.libs/_driver.so`.

The fix simply adds the the check to `Makefile.am`.