### PR TITLE
SINGA-155 Remove zookeeper for single-process training

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -100,7 +100,10 @@ SINGA_SRCS := src/driver.cc \
               src/utils/param.cc \
               src/utils/updater.cc \
               src/utils/blob.cc \
-              src/utils/image_transform.cc
+              src/utils/image_transform.cc \
+              src/utils/job_manager.cc \
+              src/utils/zk_service.cc 
+
 
 SINGA_HDRS := include/singa.h \
 			  include/singa/utils/math_blob.h \
@@ -118,6 +121,8 @@ SINGA_HDRS := include/singa.h \
               include/utils/tinydir.h \
               include/utils/tokenizer.h \
               include/utils/image_transform.h \
+              include/utils/job_manager.cc \
+              include/utils/zk_service.cc \
               include/server.h \
               include/worker.h \
               include/stub.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -32,19 +32,22 @@ CUDA_OBJS := src/utils/math_kernel.o
 CUDA_HDRS := include/singa/utils/math_kernel.h
 
 CUDNN_SRCS := src/neuralnet/loss_layer/cudnn_softmaxloss.cc \
-			  src/neuralnet/neuron_layer/cudnn_softmax.cc \
-			  src/neuralnet/neuron_layer/cudnn_pooling.cc \
-			  src/neuralnet/neuron_layer/cudnn_activation.cc \
-			  src/neuralnet/neuron_layer/cudnn_lrn.cc \
-			  src/neuralnet/neuron_layer/cudnn_convolution.cc
+              src/neuralnet/neuron_layer/cudnn_softmax.cc \
+              src/neuralnet/neuron_layer/cudnn_pooling.cc \
+              src/neuralnet/neuron_layer/cudnn_activation.cc \
+              src/neuralnet/neuron_layer/cudnn_lrn.cc \
+              src/neuralnet/neuron_layer/cudnn_convolution.cc
 
 PY_SRCS := tool/python/singa/driver_wrap.cxx \
-		   src/driver.cc
+           src/driver.cc
+
+ZOOKEEPER_SRCS := src/utils/zk_service.cc
+ZOOKEEPER_HDRS := include/singa/utils/zk_service.h
 
 HDFS_SRCS := src/io/hdfsfile.cc \
-			 src/io/hdfsfile_store.cc
+             src/io/hdfsfile_store.cc
 HDFS_HDRS := include/singa/io/hdfsfile.h \
-			 include/singa/io/hdfsfile_store.h
+             include/singa/io/hdfsfile_store.h
 
 SINGA_SRCS := src/driver.cc \
               src/server.cc \
@@ -101,14 +104,13 @@ SINGA_SRCS := src/driver.cc \
               src/utils/updater.cc \
               src/utils/blob.cc \
               src/utils/image_transform.cc \
-              src/utils/job_manager.cc \
-              src/utils/zk_service.cc 
+              src/utils/job_manager.cc 
 
 
 SINGA_HDRS := include/singa.h \
-			  include/singa/utils/math_blob.h \
-			  include/singa/utils/math_addr.h \
-			  include/singa/utils/cluster.h \
+              include/singa/utils/math_blob.h \
+              include/singa/utils/math_addr.h \
+              include/singa/utils/cluster.h \
               include/utils/cluster_rt.h \
               include/utils/param.h \
               include/utils/common.h \
@@ -121,8 +123,7 @@ SINGA_HDRS := include/singa.h \
               include/utils/tinydir.h \
               include/utils/tokenizer.h \
               include/utils/image_transform.h \
-              include/utils/job_manager.cc \
-              include/utils/zk_service.cc \
+              include/utils/job_manager.h \
               include/server.h \
               include/worker.h \
               include/stub.h \
@@ -151,19 +152,19 @@ SINGA_HDRS := include/singa.h \
 GTEST_SRCS := include/gtest/gtest-all.cc
 GTEST_HRDS := include/gtest/gtest.h
 TEST_SRCS := include/gtest/gtest_main.cc \
-						 src/test/test_cluster.cc \
-						 src/test/test_common.cc \
-						 src/test/test_msg.cc \
-						 src/test/test_math.cc \
-						 src/test/test_neuralnet.cc \
-						 src/test/test_paramslicer.cc \
-						 src/test/test_kvfile.cc \
-						 src/test/test_store.cc \
-						 src/test/test_connection_layers.cc \
-						 src/test/test_record_input_layer.cc \
-						 src/test/test_csv_input_layer.cc \
-             					 src/test/test_gru_layer.cc \
-						 src/test/test_unrolling.cc
+             src/test/test_cluster.cc \
+             src/test/test_common.cc \
+             src/test/test_msg.cc \
+             src/test/test_math.cc \
+             src/test/test_neuralnet.cc \
+             src/test/test_paramslicer.cc \
+             src/test/test_kvfile.cc \
+             src/test/test_store.cc \
+             src/test/test_connection_layers.cc \
+             src/test/test_record_input_layer.cc \
+             src/test/test_csv_input_layer.cc \
+             src/test/test_gru_layer.cc \
+             src/test/test_unrolling.cc
 
 #EXTRA_PROGRAMS = $(PROGS)
 EXTRA_PROGRAMS = singatest test
@@ -194,6 +195,11 @@ libsinga_la_SOURCES += $(CUDNN_SRCS)
 libsinga_la_CXXFLAGS += $(CUDNN_CFLAGS)
 libsinga_la_LDFLAGS += $(CUDNN_LDFLAGS) $(CUDNN_LIBS)
 endif
+if DZOOKEEPER
+libsinga_la_SOURCES += $(ZOOKEEPER_SRCS)
+libsinga_la_CXXFLAGS += $(ZOOKEEPER_CFLAGS)
+libsinga_la_LDFLAGS += $(ZOOKEEPER_LDFLAGS) $(ZOOKEEPER_LIBS)
+endif
 
 if DHDFS
 libsinga_la_SOURCES += $(HDFS_SRCS)
@@ -209,8 +215,7 @@ singa_LDFLAGS = -lsinga \
                 -lprotobuf \
                 -lopenblas \
                 -lzmq \
-                -lczmq \
-                -lzookeeper_mt
+                -lczmq 
 if LMDB
 singa_LDFLAGS += -llmdb
 endif
@@ -219,6 +224,12 @@ if DCUDA
 singa_SOURCES += $(CUDA_SRCS) $(CUDA_HDRS)
 singa_CXXFLAGS += $(CUDA_CFLAGS)
 singa_LDFLAGS += $(CUDA_LDFLAGS) $(CUDA_LIBS)
+endif
+
+if DZOOKEEPER
+singa_SOURCES += $(ZOOKEEPER_SRCS)
+singa_CXXFLAGS += $(ZOOKEEPER_CFLAGS)
+singa_LDFLAGS += $(ZOOKEEPER_LDFLAGS) $(ZOOKEEPER_LIBS)
 endif
 
 if DCUDNN
@@ -235,17 +246,17 @@ endif
 #bin_PROGRAMS += singatool
 singatool_SOURCES = src/utils/tool.cc #$(CUDA_SRCS) $(CUDA_HDRS) $(CUDNN_SRCS)
 singatool_CXXFLAGS = -Wall -pthread -fPIC -std=c++11 -MMD -Wno-unknown-pragmas \
-					 -funroll-loops -DTHREADED -I$(top_srcdir)/include $(DEFAULT_FLAGS)
+              -funroll-loops -DTHREADED -I$(top_srcdir)/include $(DEFAULT_FLAGS)
 singatool_LDFLAGS = -lsinga \
                     -lglog  \
-                    -lprotobuf \
-                    -lzookeeper_mt
+                    -lprotobuf 
 
-if DHDFS
-singatool_SOURCES += $(HDFS_SRCS)
-singatool_CXXFLAGS += $(HDFS_CFLAGS)
-singatool_LDFLAGS += $(HDFS_LDFLAGS) $(HDFS_LIBS)
+if DZOOKEEPER
+singatool_SOURCES += $(ZOOKEEPER_SRCS)
+singatool_CXXFLAGS += $(ZOOKEEPER_CFLAGS)
+singatool_LDFLAGS += $(ZOOKEEPER_LDFLAGS) $(ZOOKEEPER_LIBS)
 endif
+
 #lib_LTLIBRARIES += libgtest.la
 libgtest_la_SOURCES = $(GTEST_HDRS) $(GTEST_SRCS)
 libgtest_la_CXXFLAGS = $(DEFAULT_FLAGS) -msse3 -fpermissive -I$(top_srcdir)/include
@@ -265,8 +276,7 @@ singatest_LDFLAGS = -lsinga \
                 -lopenblas \
                 -lzmq \
                 -lczmq \
-                -lzookeeper_mt \
-			    -lgtest
+                -lgtest
 if LMDB
 singatest_LDFLAGS += -llmdb
 endif
@@ -281,6 +291,12 @@ if DCUDNN
 singatest_SOURCES += $(CUDNN_SRCS)
 singatest_CXXFLAGS += $(CUDNN_CFLAGS)
 singatest_LDFLAGS += $(CUDNN_LDFLAGS) $(CUDNN_LIBS)
+endif
+
+if DZOOKEEPER
+singatest_SOURCES += $(ZOOKEEPER_SRCS)
+singatest_CXXFLAGS += $(ZOOKEEPER_CFLAGS)
+singatest_LDFLAGS += $(ZOOKEEPER_LDFLAGS) $(ZOOKEEPER_LIBS)
 endif
 
 _driver_la_SOURCES = $(PY_SRCS)

--- a/configure.ac
+++ b/configure.ac
@@ -36,13 +36,32 @@ AC_PROG_CC
 AC_DISABLE_STATIC
 AC_PROG_LIBTOOL
 
+# Checks for libraries.
+AC_SEARCH_LIBS([cblas_sgemm], [openblas], [], [
+  AC_MSG_ERROR([unable to find cblas_sgemm() function])
+  ])
+AC_SEARCH_LIBS([zmq_ctx_new], [zmq], [], [
+  AC_MSG_ERROR([unable to find zmq_ctx_new() function])
+    ])
+AC_SEARCH_LIBS([zmsg_new], [czmq], [], [
+  AC_MSG_ERROR([unable to find zmsg_new() function])
+  ])
+AC_CHECK_LIB([glog], [main], [], [
+  AC_MSG_ERROR([unable to find glog library])
+  ])
+AC_CHECK_LIB([protobuf], [main], [], [
+  AC_MSG_ERROR([unable to find protobuf library])
+  ])
+
+PROGS=''
+LTLIBS=''
+
 # Setup custom CUDA paths
 AC_ARG_ENABLE(cuda,
   [AS_HELP_STRING(--enable-cuda,enable CUDA support)],
     cudaval="yes",
     cudaval="no")
 AM_CONDITIONAL(DCUDA, [test "$cudaval" = "yes"])
-
 AC_ARG_WITH([cuda],
    [AS_HELP_STRING(
         [--with-cuda=PATH],
@@ -54,7 +73,6 @@ if test "$cuda_prefix" == "yes"; then
         cuda_prefix="/usr/local/cuda"
     fi
 fi
-
 if test x"$cudaval" = x"yes"; then
     AC_MSG_CHECKING([nvcc in $cuda_prefix/bin])
     if test -x "$cuda_prefix/bin/nvcc"; then
@@ -100,7 +118,6 @@ AC_ARG_ENABLE([cudnn],
     [AS_HELP_STRING(--enable-cudnn,enable CUDNN support)],
     [enable_cudnn=yes], [enable_cudnn=no])
 AM_CONDITIONAL(DCUDNN, [test "$enable_cudnn" = "yes"])
-
 AC_ARG_WITH([cudnn],
     [AS_HELP_STRING([--with-cudnn=PATH], [prefix where CUDNN is installed])],
     [cudnn_prefix=$withval], [cudnn_prefix="/usr/local/cuda"])
@@ -109,7 +126,6 @@ if test "$cudnn_prefix" == "yes"; then
         cudnn_prefix="/usr/local/cuda"
     fi
 fi
-
 if test x"$enable_cudnn" == x"yes"; then
     CUDNN_CFLAGS="-I$cudnn_prefix/include"
     CUDNN_LDFLAGS="-L$cudnn_prefix/lib64 -L$cudnn_prefix/lib"
@@ -126,27 +142,42 @@ else
     CUDNN_LDFLAGS=""
     CUDNN_LIBS=""
 fi
-
 AC_SUBST(CUDNN_CFLAGS)
 AC_SUBST(CUDNN_LDFLAGS)
 AC_SUBST(CUDNN_LIBS)
 
-# Checks for libraries.
-AC_SEARCH_LIBS([cblas_sgemm], [openblas], [], [
-  AC_MSG_ERROR([unable to find cblas_sgemm() function])
-  ])
-AC_SEARCH_LIBS([zmq_ctx_new], [zmq], [], [
-  AC_MSG_ERROR([unable to find zmq_ctx_new() function])
-    ])
-AC_SEARCH_LIBS([zmsg_new], [czmq], [], [
-  AC_MSG_ERROR([unable to find zmsg_new() function])
-  ])
-AC_CHECK_LIB([glog], [main], [], [
-  AC_MSG_ERROR([unable to find glog library])
-  ])
-AC_CHECK_LIB([protobuf], [main], [], [
-  AC_MSG_ERROR([unable to find protobuf library])
-  ])
+# Setup custom zookeeper paths 
+AC_ARG_ENABLE(zookeeper,
+  AS_HELP_STRING([--enable-zookeeper],[enable zookeeper support]),
+  [enable_zookeeper=yes],[enable_zookeeper=no])
+AM_CONDITIONAL(DZOOKEEPER, test "$enable_zookeeper" = yes)
+AC_ARG_WITH([zookeeper],
+    [AS_HELP_STRING([--with-zookeeper=PATH], [prefix where zookeeper is installed])],
+    [zookeeper_prefix=$withval], [zookeeper_prefix="/usr/local"])
+if test "$zookeeper_prefix" == "yes"; then
+    if test "$withval" == "yes"; then
+        cudnn_prefix="/usr/local"
+    fi
+fi
+if test x"$enable_zookeeper" != x"no"; then
+  ZOOKEEPER_CFLAGS="-I$zookeeper_prefix/include"
+  ZOOKEEPER_LDFLAGS="-L$zookeeper_prefix/lib"
+  ZOOKEEPER_LIBS="-lzookeeper_mt"
+  LIBS="$LIBS $ZOOKEEPER_LIBS"
+  LDFLAGS="$LDFLAGS $ZOOKEEPER_LDFLAGS"
+  DEBUG+=" -DUSE_ZOOKEEPER"
+  AC_DEFINE(DZOOKEEPER,[1],[Defined if zookeeper should be used])
+  AC_CHECK_LIB([zookeeper_mt], [main], [], [
+      AC_MSG_ERROR([unable to find zookeeper library])
+      ])
+else
+  ZOOKEEPER_CFLAGS=""
+  ZOOKEEPER_LDFLAGS=""
+  ZOOKEEPER_LIBS=""
+fi
+AC_SUBST(ZOOKEEPER_CFLAGS)
+AC_SUBST(ZOOKEEPER_LDFLAGS)
+AC_SUBST(ZOOKEEPER_LIBS)
 
 # Setup custom lmdb paths 
 AC_ARG_ENABLE(lmdb,
@@ -160,14 +191,11 @@ if test x"$enable_lmdb" = x"yes"; then
   AC_DEFINE(LMDB, 1, [Enable Option layer])
 fi
 
-PROGS=''
-LTLIBS=''
 # Setup custom libhdfs paths 
 AC_ARG_ENABLE(hdfs,
   AS_HELP_STRING([--enable-hdfs],[enable hdfs support]),
   [enable_hdfs=yes],[enable_hdfs=no])
 AM_CONDITIONAL(DHDFS, test "$enable_hdfs" = yes)
-
 AC_ARG_WITH([libhdfs],
     [AS_HELP_STRING([--with-libhdfs=PATH], [prefix where libhdfs is installed])],
     [hdfs_prefix=$withval], [hdfs_prefix="/usr/local"])
@@ -176,7 +204,6 @@ if test "$hdfs_prefix" == "yes"; then
         cudnn_prefix="/usr/local"
     fi
 fi
-
 if test x"$enable_hdfs" != x"no"; then
   HDFS_CFLAGS="-I$hdfs_prefix/include"
   HDFS_LDFLAGS="-L$hdfs_prefix/lib"
@@ -193,7 +220,6 @@ else
   HDFS_LDFLAGS=""
   HDFS_LIBS=""
 fi
-
 AC_SUBST(HDFS_CFLAGS)
 AC_SUBST(HDFS_LDFLAGS)
 AC_SUBST(HDFS_LIBS)
@@ -246,8 +272,6 @@ if test "$python_prefix" == "yes"; then
         python_prefix="/usr/include/python`python -V 2>&1 | awk '{print substr($2,1,3)}'`"
     fi
 fi
-
-
 if test x"$enable_python" != x"no"; then
     AC_MSG_CHECKING([Python.h in $python_prefix])
     if test -f "$python_prefix/Python.h"; then
@@ -264,26 +288,11 @@ else
     PY_PROGS=''
     PYFLAGS=''
 fi
-
 AC_SUBST([PROGS])
 AC_SUBST([LTLIBS])
 AC_SUBST([DEBUG])
 AC_SUBST([PYFLAGS])
 AC_SUBST([PY_PROGS])
-
-# Setup for opencv libs
-#AC_CHECK_LIB([opencv_imgproc], [main], [], [
-#  AC_MSG_ERROR([unable to find opencv_imgproc lib])
-#  ])
-#AC_CHECK_LIB([opencv_highgui], [main], [], [
-#  AC_MSG_ERROR([unable to find opencv_highgui lib])
-#  ])
-#AC_CHECK_LIB([opencv_core], [main], [], [
-#  AC_MSG_ERROR([unable to find opencv_core lib])
-#  ])
-AC_CHECK_LIB([zookeeper_mt], [main], [], [
-  AC_MSG_ERROR([unable to find zookeeper])
-  ])
 
 # Checks for header files.
 AC_HEADER_STDC

--- a/include/singa/utils/cluster_rt.h
+++ b/include/singa/utils/cluster_rt.h
@@ -44,6 +44,9 @@ struct RTCallback {
  */
 class ClusterRuntime {
  public:
+  // ClusterRuntime have different implementation determined when compiling
+  static ClusterRuntime* Create(const std::string&host, int job_id);
+
   virtual ~ClusterRuntime() {}
   /**
    * Initialize the runtime instance

--- a/include/singa/utils/job_manager.h
+++ b/include/singa/utils/job_manager.h
@@ -1,0 +1,79 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+* 
+*   http://www.apache.org/licenses/LICENSE-2.0
+* 
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+
+#ifndef SINGA_UTILS_JOB_MANAGER_H_
+#define SINGA_UTILS_JOB_MANAGER_H_
+
+#include <string>
+#include <vector>
+
+#ifdef USE_ZOOKEEPER
+#include "singa/utils/zk_service.h"
+#endif
+
+namespace singa {
+
+struct JobInfo {
+  int id;
+  int procs;
+  std::string name;
+};
+
+class JobManager {
+ public:
+  // host is comma separated host:port pairs, each corresponding to a zk server.
+  // e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002"
+  explicit JobManager(const std::string& host);
+
+  // NOTICE: Init must be called once, before start to use other functions
+  bool Init();
+  // generate a unique job id
+  bool GenerateJobID(int* id);
+  // generate a list of hosts for a job conf
+  bool GenerateHostList(const char* host_file, const char* job_file,
+                        std::vector<std::string>* list);
+  // list all jobs recorded in zk
+  bool ListJobs(std::vector<JobInfo>* jobs);
+  // list running processes for a job
+  bool ListJobProcs(int job, std::vector<std::string>* procs);
+  // remove a job path in zk
+  bool Remove(int job);
+  // remove all job paths in zk
+  bool RemoveAllJobs();
+  // remove all singa related paths in zk
+  bool CleanUp();
+
+ private:
+  const int kJobsNotRemoved = 10;
+
+  bool CleanPath(const std::string& path, bool remove);
+  std::string ExtractClusterConf(const char* job_file);
+
+  std::string host_ = "";
+#ifdef USE_ZOOKEEPER
+  int timeout_ = 30000;
+  ZKService zk_;
+#endif
+};
+
+}  // namespace singa
+
+#endif  // SINGA_UTILS_JOB_MANAGER_H_

--- a/include/singa/utils/zk_service.h
+++ b/include/singa/utils/zk_service.h
@@ -1,0 +1,116 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+* 
+*   http://www.apache.org/licenses/LICENSE-2.0
+* 
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+
+#ifndef SINGA_UTILS_ZK_SERVICE_H_
+#define SINGA_UTILS_ZK_SERVICE_H_
+
+#include <zookeeper/zookeeper.h>
+#include <string>
+#include <vector>
+
+#include "singa/utils/cluster_rt.h"
+
+namespace singa {
+
+const int kZKBufSize = 100;
+// following paths are global
+const std::string kZKPathSinga = "/singa";
+const std::string kZKPathSys =   "/singa/sys";
+const std::string kZKPathJLock = "/singa/sys/job-lock";
+const std::string kZKPathHostIdx = "/singa/sys/host-idx";
+const std::string kZKPathApp =   "/singa/app";
+const std::string kZKPathJob =   "/singa/app/job-";
+// following paths are local under /singa/app/job-X
+const std::string kZKPathJobGroup = "/group";
+const std::string kZKPathJobProc =  "/proc";
+const std::string kZKPathJobPLock = "/proc-lock";
+
+inline std::string GetZKJobWorkspace(int job_id) {
+  char buf[kZKBufSize];
+  snprintf(buf, kZKBufSize, "%010d", job_id);
+  return kZKPathJob + buf;
+}
+
+/*
+ * A wrapper for zookeeper service which handles error code and reconnections
+ */
+class ZKService {
+ public:
+  static void ChildChanges(zhandle_t* zh, int type, int state,
+                           const char *path, void* watcherCtx);
+
+  ~ZKService();
+  bool Init(const std::string& host, int timeout);
+  bool CreateNode(const char* path, const char* val, int flag, char* output);
+  bool DeleteNode(const char* path);
+  bool Exist(const char* path);
+  bool UpdateNode(const char* path, const char* val);
+  bool GetNode(const char* path, char* output);
+  bool GetChild(const char* path, std::vector<std::string>* vt);
+  bool WGetChild(const char* path, std::vector<std::string>* vt,
+                   RTCallback *cb);
+
+ private:
+  const int kNumRetry = 5;
+  const int kSleepSec = 1;
+
+  static void WatcherGlobal(zhandle_t* zh, int type, int state,
+                            const char *path, void* watcherCtx);
+
+  zhandle_t* zkhandle_ = nullptr;
+};
+
+/*
+ * A ClusterRuntime implementation using zookeeper
+ */
+class ZKClusterRT : public ClusterRuntime {
+ public:
+  ZKClusterRT(const std::string& host, int job_id);
+  ~ZKClusterRT();
+
+  bool Init() override;
+  int RegistProc(const std::string& host_addr, int pid) override;
+  std::string GetProcHost(int proc_id) override;
+  bool WatchSGroup(int gid, int sid, rt_callback fn, void* ctx) override;
+  bool JoinSGroup(int gid, int wid, int s_group) override;
+  bool LeaveSGroup(int gid, int wid, int s_group) override;
+
+ private:
+  inline std::string groupPath(int gid) {
+    return group_path_ + "/sg" + std::to_string(gid);
+  }
+  inline std::string workerPath(int gid, int wid) {
+    return "/g" + std::to_string(gid) + "_w" + std::to_string(wid);
+  }
+
+  int timeout_ = 30000;
+  std::string host_ = "";
+  ZKService zk_;
+  std::string workspace_ = "";
+  std::string group_path_ = "";
+  std::string proc_path_ = "";
+  std::string proc_lock_path_ = "";
+  std::vector<RTCallback*> cb_vec_;
+};
+
+}  // namespace singa
+
+#endif  // SINGA_UTILS_ZK_SERVICE_H_

--- a/src/utils/cluster.cc
+++ b/src/utils/cluster.cc
@@ -82,7 +82,8 @@ void Cluster::Init(int job, const SingaProto& singaConf,
     }
   }
   // cluster_rt_ = new ZKClusterRT(singa_.zookeeper_host(), job);
-  cluster_rt_ = new SPClusterRT();
+  // cluster_rt_ = new SPClusterRT();
+  cluster_rt_ = ClusterRuntime::Create(singa_.zookeeper_host(), job);
   cluster_rt_->Init();
   hostip_ = GetHostIP();
 }

--- a/src/utils/cluster.cc
+++ b/src/utils/cluster.cc
@@ -81,7 +81,8 @@ void Cluster::Init(int job, const SingaProto& singaConf,
           (i * grp_size + j) / cluster_.nservers_per_procs() + offset;
     }
   }
-  cluster_rt_ = new ClusterRuntime(singa_.zookeeper_host(), job);
+  // cluster_rt_ = new ZKClusterRT(singa_.zookeeper_host(), job);
+  cluster_rt_ = new SPClusterRT();
   cluster_rt_->Init();
   hostip_ = GetHostIP();
 }

--- a/src/utils/cluster_rt.cc
+++ b/src/utils/cluster_rt.cc
@@ -29,11 +29,23 @@
 #include <iostream>
 #include "singa/proto/job.pb.h"
 
+#ifdef USE_ZOOKEEPER
+#include "singa/utils/zk_service.h"
+#endif
+
 using std::string;
 using std::to_string;
 using std::vector;
 
 namespace singa {
+
+ClusterRuntime* ClusterRuntime::Create(const std::string&host, int job_id) {
+#ifdef USE_ZOOKEEPER
+  return new ZKClusterRT(host, job_id);
+#else
+  return new SPClusterRT();
+#endif
+}
 
 SPClusterRT::~SPClusterRT() {
   // release callback vector

--- a/src/utils/cluster_rt.cc
+++ b/src/utils/cluster_rt.cc
@@ -35,505 +35,64 @@ using std::vector;
 
 namespace singa {
 
-void ZKService::ChildChanges(zhandle_t *zh, int type, int state,
-                               const char *path, void *watcherCtx) {
-  // check if already callback
-  RTCallback *cb = static_cast<RTCallback*>(watcherCtx);
-  if (cb->fn == nullptr) return;
-  if (type == ZOO_CHILD_EVENT) {
-    struct String_vector child;
-    // check the child list and put another watcher
-    int ret = zoo_wget_children(zh, path, ChildChanges, watcherCtx, &child);
-    if (ret == ZOK) {
-      if (child.count == 0) {
-        LOG(INFO) << "child.count = 0 in path: " << path;
-        // all workers leave, we do callback now
-        (*cb->fn)(cb->ctx);
-        cb->fn = nullptr;
-      }
-    } else {
-      LOG(FATAL) << "Unhandled ZK error code: " << ret
-                 << " (zoo_wget_children " << path << ")";
-    }
-  } else {
-    LOG(FATAL) << "Unhandled callback type code: "<< type;
-  }
-}
-
-ZKService::~ZKService() {
-  // close zookeeper handler
-  zookeeper_close(zkhandle_);
-}
-
-char zk_cxt[] = "ClusterRuntime";
-
-bool ZKService::Init(const string& host, int timeout) {
-  zoo_set_debug_level(ZOO_LOG_LEVEL_ERROR);
-  zkhandle_ = zookeeper_init(host.c_str(), WatcherGlobal, timeout, 0,
-                             static_cast<void *>(zk_cxt), 0);
-  if (zkhandle_ == NULL) {
-    LOG(ERROR) << "Error when connecting to zookeeper servers...";
-    LOG(ERROR) << "Please ensure zookeeper service is up in host(s):";
-    LOG(ERROR) << host.c_str();
-    return false;
-  }
-
-  return true;
-}
-
-bool ZKService::CreateNode(const char* path, const char* val, int flag,
-                               char* output) {
-  CHECK(zkhandle_) << "zk handler not initialized";
-  char buf[kZKBufSize];
-  int ret = 0;
-  // send the zk request
-  for (int i = 0; i < kNumRetry; ++i) {
-    ret = zoo_create(zkhandle_, path, val, val == nullptr ? -1 : strlen(val),
-                     &ZOO_OPEN_ACL_UNSAFE, flag, buf, kZKBufSize);
-    if (ret == ZNONODE) {
-      LOG(WARNING) << "zookeeper parent node of " << path
-                  << " not exist, retry later";
-    } else if (ret == ZCONNECTIONLOSS) {
-      LOG(WARNING) << "zookeeper disconnected, retry later";
-    } else {
-      break;
-    }
-    sleep(kSleepSec);
-  }
-  // copy the node name to output
-  if (output != nullptr && (ret == ZOK || ret == ZNODEEXISTS)) {
-    snprintf(output, kZKBufSize, "%s", buf);
-    // use snprintf instead of strcpy
-    // strcpy(output, buf);
-  }
-  if (ret == ZOK) {
-    LOG(INFO) << "created zookeeper node " << buf
-              << " (" << (val == nullptr ? "NULL" : val) << ")";
-    return true;
-  } else if (ret == ZNODEEXISTS) {
-    LOG(WARNING) << "zookeeper node " << path << " already exists";
-    return true;
-  } else if (ret == ZCONNECTIONLOSS) {
-    LOG(ERROR) << "Cannot connect to zookeeper, "
-               << "please ensure it is running properly...\n"
-               << "If want to use zookeeper in our thirdparty folder, "
-               << "you can start it by:\n"
-               << "$ ./bin/zk-service.sh start";
-    return false;
-  }
-  LOG(FATAL) << "Unhandled ZK error code: " << ret
-             << " (zoo_create " << path << ")";
-  return false;
-}
-
-bool ZKService::DeleteNode(const char* path) {
-  CHECK(zkhandle_) << "zk handler not initialized";
-  int ret = zoo_delete(zkhandle_, path, -1);
-  if (ret == ZOK) {
-    LOG(INFO) << "deleted zookeeper node " << path;
-    return true;
-  } else if (ret == ZNONODE) {
-    LOG(WARNING) << "try to delete an non-existing zookeeper node " << path;
-    return true;
-  }
-  LOG(FATAL) << "Unhandled ZK error code: " << ret
-             << " (zoo_delete " << path << ")";
-  return false;
-}
-
-bool ZKService::Exist(const char* path) {
-  CHECK(zkhandle_) << "zk handler not initialized";
-  struct Stat stat;
-  int ret = zoo_exists(zkhandle_, path, 0, &stat);
-  if (ret == ZOK) return true;
-  else if (ret == ZNONODE) return false;
-  LOG(WARNING) << "Unhandled ZK error code: " << ret << " (zoo_exists)";
-  return false;
-}
-
-bool ZKService::UpdateNode(const char* path, const char* val) {
-  CHECK(zkhandle_) << "zk handler not initialized";
-  // set version = -1, do not check content version
-  int ret = zoo_set(zkhandle_, path, val, strlen(val), -1);
-  if (ret == ZOK) {
-    return true;
-  } else if (ret == ZNONODE) {
-    LOG(ERROR) << "zk node " << path << " does not exist";
-    return false;
-  }
-  LOG(FATAL) << "Unhandled ZK error code: " << ret
-             << " (zoo_get " << path << ")";
-  return false;
-}
-
-bool ZKService::GetNode(const char* path, char* output) {
-  CHECK(zkhandle_) << "zk handler not initialized";
-  struct Stat stat;
-  int val_len = kZKBufSize;
-  int ret = zoo_get(zkhandle_, path, 0, output, &val_len, &stat);
-  if (ret == ZOK) {
-    output[val_len] = '\0';
-    return true;
-  } else if (ret == ZNONODE) {
-    LOG(ERROR) << "zk node " << path << " does not exist";
-    return false;
-  }
-  LOG(FATAL) << "Unhandled ZK error code: " << ret
-             << " (zoo_get " << path << ")";
-  return false;
-}
-
-bool ZKService::GetChild(const char* path, vector<string>* vt) {
-  CHECK(zkhandle_) << "zk handler not initialized";
-  struct String_vector child;
-  int ret = zoo_get_children(zkhandle_, path, 0, &child);
-  if (ret == ZOK) {
-    vt->clear();
-    for (int i = 0; i < child.count; ++i) vt->push_back(child.data[i]);
-    return true;
-  }
-  LOG(FATAL) << "Unhandled ZK error code: " << ret
-             << " (zoo_get_children " << path << ")";
-  return false;
-}
-
-bool ZKService::WGetChild(const char* path, vector<string>* vt,
-                            RTCallback *cb) {
-  CHECK(zkhandle_) << "zk handler not initialized";
-  struct String_vector child;
-  int ret = zoo_wget_children(zkhandle_, path, ChildChanges, cb, &child);
-  if (ret == ZOK) {
-    vt->clear();
-    for (int i = 0; i < child.count; ++i) vt->push_back(child.data[i]);
-    return true;
-  }
-  LOG(FATAL) << "Unhandled ZK error code: " << ret
-             << " (zoo_get_children " << path << ")";
-  return false;
-}
-
-
-void ZKService::WatcherGlobal(zhandle_t * zh, int type, int state,
-                                const char *path, void *watcherCtx) {
-  if (type == ZOO_SESSION_EVENT) {
-    if (state == ZOO_CONNECTED_STATE)
-      LOG(INFO) << "GLOBAL_WATCHER connected to zookeeper successfully!";
-    else if (state == ZOO_EXPIRED_SESSION_STATE)
-      LOG(INFO) << "GLOBAL_WATCHER zookeeper session expired!";
-  }
-}
-
-ClusterRuntime::ClusterRuntime(const string& host, int job_id)
-    : ClusterRuntime(host, job_id, 30000) {}
-
-ClusterRuntime::ClusterRuntime(const string& host, int job_id, int timeout) {
-  host_ = host;
-  timeout_ = timeout;
-  workspace_ = GetZKJobWorkspace(job_id);
-  group_path_ = workspace_ + kZKPathJobGroup;
-  proc_path_ = workspace_ + kZKPathJobProc;
-  proc_lock_path_ = workspace_ + kZKPathJobPLock;
-}
-
-ClusterRuntime::~ClusterRuntime() {
+SPClusterRT::~SPClusterRT() {
   // release callback vector
-  for (RTCallback* p : cb_vec_) {
+  for (auto list : grp_callbacks_)
+    for (RTCallback* p : list.second) {
     delete p;
   }
 }
 
-bool ClusterRuntime::Init() {
-  if (!zk_.Init(host_, timeout_)) return false;
-  if (!zk_.CreateNode(kZKPathSinga.c_str(), nullptr, 0, nullptr))
-    return false;
-  if (!zk_.CreateNode(kZKPathApp.c_str(), nullptr, 0, nullptr))
-    return false;
-  if (!zk_.CreateNode(workspace_.c_str(), nullptr, 0, nullptr))
-    return false;
-  if (!zk_.CreateNode(group_path_.c_str(), nullptr, 0, nullptr))
-    return false;
-  if (!zk_.CreateNode(proc_path_.c_str(), nullptr, 0, nullptr))
-    return false;
-  if (!zk_.CreateNode(proc_lock_path_.c_str(), nullptr, 0, nullptr))
-    return false;
+bool SPClusterRT::Init() {
   return true;
 }
 
-int ClusterRuntime::RegistProc(const string& host_addr, int pid) {
-  char buf[kZKBufSize];
-  string lock = proc_lock_path_ + "/lock-";
-  if (!zk_.CreateNode(lock.c_str(), nullptr,
-                        ZOO_EPHEMERAL | ZOO_SEQUENCE, buf)) {
-    return -1;
-  }
-  // get all children in lock folder
-  vector<string> vt;
-  if (!zk_.GetChild(proc_lock_path_.c_str(), &vt)) {
-    return -1;
-  }
-  // find own position among all locks
-  int id = -1;
-  std::sort(vt.begin(), vt.end());
-  for (int i = 0; i < static_cast<int>(vt.size()); ++i) {
-    if (proc_lock_path_+"/"+vt[i] == buf) {
-      id = i;
-      break;
-    }
-  }
-  if (id == -1) {
-    LOG(ERROR) << "cannot find own node " << buf;
-    return -1;
-  }
-  // create a new node in proc path
-  string path = proc_path_ + "/proc-" + to_string(id);
-  string content = host_addr + "|" + to_string(pid);
-  if (!zk_.CreateNode(path.c_str(), content.c_str(), ZOO_EPHEMERAL,
-                      nullptr)) {
-    return -1;
-  }
-  return id;
+int SPClusterRT::RegistProc(const string& host_addr, int pid) {
+  int ret;
+  lock_.lock();
+  proc_list_.push_back(host_addr + std::to_string(pid));
+  ret = proc_list_.size()-1;
+  lock_.unlock();
+  return ret;
 }
 
-bool ClusterRuntime::WatchSGroup(int gid, int sid, rt_callback fn, void *ctx) {
-  CHECK_NOTNULL(fn);
-  string path = groupPath(gid);
-  // create zk node
-  if (!zk_.CreateNode(path.c_str(), nullptr, 0, nullptr)) return false;
-  vector<string> child;
+string SPClusterRT::GetProcHost(int proc_id) {
+  if (proc_list_.size() < (unsigned)proc_id + 1) return "";
+  return proc_list_[proc_id];
+}
+
+bool SPClusterRT::WatchSGroup(int gid, int sid, rt_callback fn, void* ctx) {
   // store the callback function and context for later usage
   RTCallback *cb = new RTCallback;
   cb->fn = fn;
   cb->ctx = ctx;
-  cb_vec_.push_back(cb);
-  // start to watch on the zk node, does not care about the first return value
-  return zk_.WGetChild(path.c_str(), &child, cb);
-}
-
-std::string ClusterRuntime::GetProcHost(int proc_id) {
-  char val[kZKBufSize];
-  // construct file name
-  string path = proc_path_ + "/proc-" + to_string(proc_id);
-  if (!zk_.GetNode(path.c_str(), val)) return "";
-  int len = strlen(val) - 1;
-  while (len && val[len] != '|') --len;
-  CHECK(len);
-  val[len] = '\0';
-  return string(val);
-}
-
-bool ClusterRuntime::JoinSGroup(int gid, int wid, int s_group) {
-  string path = groupPath(s_group) + workerPath(gid, wid);
-  // try to create an ephemeral node under server group path
-  return zk_.CreateNode(path.c_str(), nullptr, ZOO_EPHEMERAL, nullptr);
-}
-
-bool ClusterRuntime::LeaveSGroup(int gid, int wid, int s_group) {
-  string path = groupPath(s_group) + workerPath(gid, wid);
-  return zk_.DeleteNode(path.c_str());
-}
-
-JobManager::JobManager(const string& host) : JobManager(host, 30000) {}
-
-JobManager::JobManager(const string& host, int timeout) {
-  host_ = host;
-  timeout_ = timeout;
-}
-
-bool JobManager::Init() {
-  if (!zk_.Init(host_, timeout_)) return false;
-  if (!zk_.CreateNode(kZKPathSinga.c_str(), nullptr, 0, nullptr))
-    return false;
-  if (!zk_.CreateNode(kZKPathSys.c_str(), nullptr, 0, nullptr))
-    return false;
-  if (!zk_.CreateNode(kZKPathJLock.c_str(), nullptr, 0, nullptr))
-    return false;
-  if (!zk_.CreateNode(kZKPathHostIdx.c_str(), "0", 0, nullptr))
-    return false;
-  if (!zk_.CreateNode(kZKPathApp.c_str(), nullptr, 0, nullptr))
-    return false;
+  lock_.lock();
+  if (grp_callbacks_.count(gid) == 0)
+    grp_callbacks_[gid] = vector<RTCallback*>{};
+  grp_callbacks_[gid].push_back(cb);
+  lock_.unlock();
   return true;
 }
 
-bool JobManager::GenerateJobID(int* id) {
-  char buf[kZKBufSize];
-  string lock = kZKPathJLock + "/lock-";
-  if (!zk_.CreateNode(lock.c_str(), nullptr,
-                        ZOO_EPHEMERAL | ZOO_SEQUENCE, buf)) {
-    return false;
-  }
-  *id = atoi(buf + strlen(buf) - 10);
+bool SPClusterRT::JoinSGroup(int gid, int wid, int s_group) {
+  lock_.lock();
+  if (grp_count_.count(gid) == 0)
+    grp_count_[gid] = 0;
+  grp_count_[gid]++;
+  lock_.unlock();
   return true;
 }
 
-bool JobManager::GenerateHostList(const char* host_file, const char* job_file,
-                                  vector<string>* list) {
-  int nprocs = 1;
-  // compute required #process from job conf
-  if (job_file != nullptr) {
-    ClusterProto cluster;
-    google::protobuf::TextFormat::ParseFromString(ExtractClusterConf(job_file),
-                                                  &cluster);
-    int nworker_procs = cluster.nworker_groups() * cluster.nworkers_per_group()
-                        / cluster.nworkers_per_procs();
-    int nserver_procs = cluster.nserver_groups() * cluster.nservers_per_group()
-                        / cluster.nservers_per_procs();
-    if (cluster.server_worker_separate())
-      nprocs = nworker_procs + nserver_procs;
-    else
-      nprocs = std::max(nworker_procs, nserver_procs);
-  }
-  // get available host list from global conf
-  std::ifstream hostfile(host_file);
-  if (!hostfile.is_open()) {
-    LOG(FATAL) << "Cannot open file: " << host_file;
-  }
-  vector<string> hosts;
-  string host;
-  while (!hostfile.eof()) {
-    getline(hostfile, host);
-    if (!host.length() || host[0] == '#') continue;
-    hosts.push_back(host);
-  }
-  if (!hosts.size()) {
-    LOG(FATAL) << "Empty host file";
-  }
-  // read next host index
-  char val[kZKBufSize];
-  if (!zk_.GetNode(kZKPathHostIdx.c_str(), val)) return false;
-  int next = atoi(val);
-  // generate host list
-  list->clear();
-  for (int i = 0; i < nprocs; ++i) {
-    list->push_back(hosts[(next + i) % hosts.size()]);
-  }
-  // write next host index
-  next = (next + nprocs) % hosts.size();
-  snprintf(val, kZKBufSize, "%d", next);
-  if (!zk_.UpdateNode(kZKPathHostIdx.c_str(), val)) return false;
-  return true;
-}
-
-bool JobManager::ListJobProcs(int job, vector<string>* procs) {
-  procs->clear();
-  string job_path = GetZKJobWorkspace(job);
-  // check job path
-  if (!zk_.Exist(job_path.c_str())) {
-    LOG(ERROR) << "job " << job << " not exists";
-    return true;
-  }
-  string proc_path = job_path + kZKPathJobProc;
-  vector<string> vt;
-  // check job proc path
-  if (!zk_.GetChild(proc_path.c_str(), &vt)) {
-    return false;
-  }
-  char buf[singa::kZKBufSize];
-  for (string pname : vt) {
-    pname = proc_path + "/" + pname;
-    if (!zk_.GetNode(pname.c_str(), buf)) continue;
-    std::string proc = "";
-    for (int i = 0; buf[i] != '\0'; ++i) {
-      if (buf[i] == ':') {
-        buf[i] = '\0';
-        proc += buf;
-      } else if (buf[i] == '|') {
-        proc += buf + i;
+bool SPClusterRT::LeaveSGroup(int gid, int wid, int s_group) {
+  lock_.lock();
+  if (--grp_count_[gid] == 0) {
+      for (RTCallback* cb : grp_callbacks_[gid]) {
+        (*cb->fn)(cb->ctx);
+        cb->fn = nullptr;
       }
-    }
-    procs->push_back(proc);
   }
-  if (!procs->size()) LOG(ERROR) << "job " << job << " not exists";
+  lock_.unlock();
   return true;
-}
-
-bool JobManager::ListJobs(vector<JobInfo>* jobs) {
-  // get all children in app path
-  jobs->clear();
-  vector<string> vt;
-  if (!zk_.GetChild(kZKPathApp.c_str(), &vt)) {
-    return false;
-  }
-  std::sort(vt.begin(), vt.end());
-  int size = static_cast<int>(vt.size());
-  vector<string> procs;
-  for (int i = 0; i < size; ++i) {
-    string path = kZKPathApp + "/" + vt[i] + kZKPathJobProc;
-    if (!zk_.GetChild(path.c_str(), &procs)) continue;
-    JobInfo job;
-    string jid = vt[i].substr(vt[i].length()-10);
-    job.id = atoi(jid.c_str());
-    job.procs = procs.size();
-    jobs->push_back(job);
-    // may need to delete it
-    if (!job.procs && (i + kJobsNotRemoved < size))
-        CleanPath(kZKPathApp + "/" + vt[i], true);
-  }
-  return true;
-}
-
-bool JobManager::Remove(int job) {
-  string path = GetZKJobWorkspace(job) + kZKPathJobProc;
-  if (zk_.Exist(path.c_str())) {
-    return CleanPath(path.c_str(), false);
-  }
-  return true;
-}
-
-bool JobManager::RemoveAllJobs() {
-  if (zk_.Exist(kZKPathApp.c_str())) {
-    return CleanPath(kZKPathApp.c_str(), false);
-  }
-  return true;
-}
-
-bool JobManager::CleanUp() {
-  if (zk_.Exist(kZKPathSinga.c_str())) {
-    return CleanPath(kZKPathSinga.c_str(), true);
-  }
-  return true;
-}
-
-bool JobManager::CleanPath(const string& path, bool remove) {
-  vector<string> child;
-  if (!zk_.GetChild(path.c_str(), &child)) return false;
-  for (string c : child) {
-    if (!CleanPath(path + "/" + c, true)) return false;
-  }
-  if (remove) return zk_.DeleteNode(path.c_str());
-  return true;
-}
-
-// extract cluster configuration part from the job config file
-// TODO(wangsh) improve this function to make it robust
-string JobManager::ExtractClusterConf(const char* job_file) {
-  std::ifstream fin(job_file);
-  CHECK(fin.is_open()) << "cannot open job conf file " << job_file;
-  string line;
-  string cluster;
-  bool in_cluster = false;
-  while (!fin.eof()) {
-    std::getline(fin, line);
-    if (in_cluster == false) {
-      size_t pos = line.find("cluster");
-      if (pos == std::string::npos) continue;
-      in_cluster = true;
-      line = line.substr(pos);
-      cluster = "";
-    }
-    if (in_cluster == true) {
-      cluster += line + "\n";
-      if (line.find("}") != std::string::npos)
-        in_cluster = false;
-    }
-  }
-  LOG(INFO) << "cluster configure: " << cluster;
-  size_t s_pos = cluster.find("{");
-  size_t e_pos = cluster.find("}");
-  if (s_pos == std::string::npos || e_pos == std::string::npos) {
-    LOG(FATAL) << "cannot extract valid cluster configuration in file: "
-               << job_file;
-  }
-  return cluster.substr(s_pos + 1, e_pos - s_pos-1);
 }
 
 }  // namespace singa

--- a/src/utils/job_manager.cc
+++ b/src/utils/job_manager.cc
@@ -1,0 +1,271 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+* 
+*   http://www.apache.org/licenses/LICENSE-2.0
+* 
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+
+#include "singa/utils/job_manager.h"
+
+#include <glog/logging.h>
+#include <google/protobuf/text_format.h>
+#include <stdlib.h>
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include "singa/proto/job.pb.h"
+
+using std::string;
+using std::vector;
+
+namespace singa {
+
+JobManager::JobManager(const string& host) {
+  host_ = host;
+}
+
+bool JobManager::Init() {
+#ifdef USE_ZOOKEEPER
+  if (!zk_.Init(host_, timeout_)) return false;
+  if (!zk_.CreateNode(kZKPathSinga.c_str(), nullptr, 0, nullptr))
+    return false;
+  if (!zk_.CreateNode(kZKPathSys.c_str(), nullptr, 0, nullptr))
+    return false;
+  if (!zk_.CreateNode(kZKPathJLock.c_str(), nullptr, 0, nullptr))
+    return false;
+  if (!zk_.CreateNode(kZKPathHostIdx.c_str(), "0", 0, nullptr))
+    return false;
+  if (!zk_.CreateNode(kZKPathApp.c_str(), nullptr, 0, nullptr))
+    return false;
+#endif
+  return true;
+}
+
+bool JobManager::GenerateJobID(int* id) {
+#ifdef USE_ZOOKEEPER
+  char buf[kZKBufSize];
+  string lock = kZKPathJLock + "/lock-";
+  if (!zk_.CreateNode(lock.c_str(), nullptr,
+                        ZOO_EPHEMERAL | ZOO_SEQUENCE, buf)) {
+    return false;
+  }
+  *id = atoi(buf + strlen(buf) - 10);
+#else
+  *id = 0;
+#endif
+  return true;
+}
+
+bool JobManager::GenerateHostList(const char* host_file, const char* job_file,
+                                  vector<string>* list) {
+  int nprocs = 1;
+  list->clear();
+  // compute required #process from job conf
+  if (job_file != nullptr) {
+    ClusterProto cluster;
+    google::protobuf::TextFormat::ParseFromString(ExtractClusterConf(job_file),
+                                                  &cluster);
+    int nworker_procs = cluster.nworker_groups() * cluster.nworkers_per_group()
+                        / cluster.nworkers_per_procs();
+    int nserver_procs = cluster.nserver_groups() * cluster.nservers_per_group()
+                        / cluster.nservers_per_procs();
+    if (cluster.server_worker_separate())
+      nprocs = nworker_procs + nserver_procs;
+    else
+      nprocs = std::max(nworker_procs, nserver_procs);
+  }
+#ifdef USE_ZOOKEEPER
+  // get available host list from global conf
+  std::ifstream hostfile(host_file);
+  if (!hostfile.is_open()) {
+    LOG(FATAL) << "Cannot open file: " << host_file;
+  }
+  vector<string> hosts;
+  string host;
+  while (!hostfile.eof()) {
+    getline(hostfile, host);
+    if (!host.length() || host[0] == '#') continue;
+    hosts.push_back(host);
+  }
+  if (!hosts.size()) {
+    LOG(FATAL) << "Empty host file";
+  }
+  // read next host index
+  char val[kZKBufSize];
+  if (!zk_.GetNode(kZKPathHostIdx.c_str(), val)) return false;
+  int next = atoi(val);
+  // generate host list
+  for (int i = 0; i < nprocs; ++i) {
+    list->push_back(hosts[(next + i) % hosts.size()]);
+  }
+  // write next host index
+  next = (next + nprocs) % hosts.size();
+  snprintf(val, kZKBufSize, "%d", next);
+  if (!zk_.UpdateNode(kZKPathHostIdx.c_str(), val)) return false;
+#else
+  CHECK_EQ(nprocs, 1) << "To run multi-process job, please enable zookeeper";
+  list->push_back("localhost");
+#endif
+  return true;
+}
+
+bool JobManager::ListJobProcs(int job, vector<string>* procs) {
+  procs->clear();
+#ifdef USE_ZOOKEEPER
+  string job_path = GetZKJobWorkspace(job);
+  // check job path
+  if (!zk_.Exist(job_path.c_str())) {
+    LOG(ERROR) << "job " << job << " not exists";
+    return true;
+  }
+  string proc_path = job_path + kZKPathJobProc;
+  vector<string> vt;
+  // check job proc path
+  if (!zk_.GetChild(proc_path.c_str(), &vt)) {
+    return false;
+  }
+  char buf[singa::kZKBufSize];
+  for (string pname : vt) {
+    pname = proc_path + "/" + pname;
+    if (!zk_.GetNode(pname.c_str(), buf)) continue;
+    std::string proc = "";
+    for (int i = 0; buf[i] != '\0'; ++i) {
+      if (buf[i] == ':') {
+        buf[i] = '\0';
+        proc += buf;
+      } else if (buf[i] == '|') {
+        proc += buf + i;
+      }
+    }
+    procs->push_back(proc);
+  }
+  if (!procs->size()) LOG(ERROR) << "job " << job << " not exists";
+#endif
+  return true;
+}
+
+bool JobManager::ListJobs(vector<JobInfo>* jobs) {
+  jobs->clear();
+#ifdef USE_ZOOKEEPER
+  vector<string> vt;
+  // get all children in app path
+  if (!zk_.GetChild(kZKPathApp.c_str(), &vt)) {
+    return false;
+  }
+  std::sort(vt.begin(), vt.end());
+  int size = static_cast<int>(vt.size());
+  vector<string> procs;
+  for (int i = 0; i < size; ++i) {
+    string path = kZKPathApp + "/" + vt[i] + kZKPathJobProc;
+    if (!zk_.GetChild(path.c_str(), &procs)) continue;
+    JobInfo job;
+    string jid = vt[i].substr(vt[i].length()-10);
+    job.id = atoi(jid.c_str());
+    job.procs = procs.size();
+    jobs->push_back(job);
+    // may need to delete it
+    if (!job.procs && (i + kJobsNotRemoved < size))
+        CleanPath(kZKPathApp + "/" + vt[i], true);
+  }
+#else
+  LOG(ERROR) << "Not supported without zookeeper";
+#endif
+  return true;
+}
+
+bool JobManager::Remove(int job) {
+#ifdef USE_ZOOKEEPER
+  string path = GetZKJobWorkspace(job) + kZKPathJobProc;
+  if (zk_.Exist(path.c_str())) {
+    return CleanPath(path.c_str(), false);
+  }
+#else
+  LOG(ERROR) << "Not supported without zookeeper";
+#endif
+  return true;
+}
+
+bool JobManager::RemoveAllJobs() {
+#ifdef USE_ZOOKEEPER
+  if (zk_.Exist(kZKPathApp.c_str())) {
+    return CleanPath(kZKPathApp.c_str(), false);
+  }
+#else
+  LOG(ERROR) << "Not supported without zookeeper";
+#endif
+  return true;
+}
+
+bool JobManager::CleanUp() {
+#ifdef USE_ZOOKEEPER
+  if (zk_.Exist(kZKPathSinga.c_str())) {
+    return CleanPath(kZKPathSinga.c_str(), true);
+  }
+#else
+  LOG(ERROR) << "Not supported without zookeeper";
+#endif
+  return true;
+}
+
+bool JobManager::CleanPath(const string& path, bool remove) {
+#ifdef USE_ZOOKEEPER
+  vector<string> child;
+  if (!zk_.GetChild(path.c_str(), &child)) return false;
+  for (string c : child) {
+    if (!CleanPath(path + "/" + c, true)) return false;
+  }
+  if (remove) return zk_.DeleteNode(path.c_str());
+#else
+  LOG(ERROR) << "Not supported without zookeeper";
+#endif
+  return true;
+}
+
+// extract cluster configuration part from the job config file
+// TODO(wangsh) improve this function to make it robust
+string JobManager::ExtractClusterConf(const char* job_file) {
+  std::ifstream fin(job_file);
+  CHECK(fin.is_open()) << "cannot open job conf file " << job_file;
+  string line;
+  string cluster;
+  bool in_cluster = false;
+  while (!fin.eof()) {
+    std::getline(fin, line);
+    if (in_cluster == false) {
+      size_t pos = line.find("cluster");
+      if (pos == std::string::npos) continue;
+      in_cluster = true;
+      line = line.substr(pos);
+      cluster = "";
+    }
+    if (in_cluster == true) {
+      cluster += line + "\n";
+      if (line.find("}") != std::string::npos)
+        in_cluster = false;
+    }
+  }
+  LOG(INFO) << "cluster configure: " << cluster;
+  size_t s_pos = cluster.find("{");
+  size_t e_pos = cluster.find("}");
+  if (s_pos == std::string::npos || e_pos == std::string::npos) {
+    LOG(FATAL) << "cannot extract valid cluster configuration in file: "
+               << job_file;
+  }
+  return cluster.substr(s_pos + 1, e_pos - s_pos-1);
+}
+
+}  // namespace singa

--- a/src/utils/tool.cc
+++ b/src/utils/tool.cc
@@ -24,8 +24,8 @@
 #include <string>
 #include <vector>
 #include "singa/proto/singa.pb.h"
-#include "singa/utils/cluster_rt.h"
 #include "singa/utils/common.h"
+#include "singa/utils/job_manager.h"
 
 std::string conf_dir;
 singa::SingaProto global;

--- a/src/utils/zk_service.cc
+++ b/src/utils/zk_service.cc
@@ -1,0 +1,326 @@
+/************************************************************
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+* 
+*   http://www.apache.org/licenses/LICENSE-2.0
+* 
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*************************************************************/
+
+#include "singa/utils/zk_service.h"
+
+#include <glog/logging.h>
+#include <algorithm>
+
+using std::string;
+using std::to_string;
+using std::vector;
+
+namespace singa {
+
+void ZKService::ChildChanges(zhandle_t *zh, int type, int state,
+                               const char *path, void *watcherCtx) {
+  // check if already callback
+  RTCallback *cb = static_cast<RTCallback*>(watcherCtx);
+  if (cb->fn == nullptr) return;
+  if (type == ZOO_CHILD_EVENT) {
+    struct String_vector child;
+    // check the child list and put another watcher
+    int ret = zoo_wget_children(zh, path, ChildChanges, watcherCtx, &child);
+    if (ret == ZOK) {
+      if (child.count == 0) {
+        LOG(INFO) << "child.count = 0 in path: " << path;
+        // all workers leave, we do callback now
+        (*cb->fn)(cb->ctx);
+        cb->fn = nullptr;
+      }
+    } else {
+      LOG(FATAL) << "Unhandled ZK error code: " << ret
+                 << " (zoo_wget_children " << path << ")";
+    }
+  } else {
+    LOG(FATAL) << "Unhandled callback type code: "<< type;
+  }
+}
+
+ZKService::~ZKService() {
+  // close zookeeper handler
+  zookeeper_close(zkhandle_);
+}
+
+char zk_cxt[] = "ZKClusterRT";
+
+bool ZKService::Init(const string& host, int timeout) {
+  zoo_set_debug_level(ZOO_LOG_LEVEL_ERROR);
+  zkhandle_ = zookeeper_init(host.c_str(), WatcherGlobal, timeout, 0,
+                             static_cast<void *>(zk_cxt), 0);
+  if (zkhandle_ == NULL) {
+    LOG(ERROR) << "Error when connecting to zookeeper servers...";
+    LOG(ERROR) << "Please ensure zookeeper service is up in host(s):";
+    LOG(ERROR) << host.c_str();
+    return false;
+  }
+
+  return true;
+}
+
+bool ZKService::CreateNode(const char* path, const char* val, int flag,
+                               char* output) {
+  CHECK(zkhandle_) << "zk handler not initialized";
+  char buf[kZKBufSize];
+  int ret = 0;
+  // send the zk request
+  for (int i = 0; i < kNumRetry; ++i) {
+    ret = zoo_create(zkhandle_, path, val, val == nullptr ? -1 : strlen(val),
+                     &ZOO_OPEN_ACL_UNSAFE, flag, buf, kZKBufSize);
+    if (ret == ZNONODE) {
+      LOG(WARNING) << "zookeeper parent node of " << path
+                  << " not exist, retry later";
+    } else if (ret == ZCONNECTIONLOSS) {
+      LOG(WARNING) << "zookeeper disconnected, retry later";
+    } else {
+      break;
+    }
+    sleep(kSleepSec);
+  }
+  // copy the node name to output
+  if (output != nullptr && (ret == ZOK || ret == ZNODEEXISTS)) {
+    snprintf(output, kZKBufSize, "%s", buf);
+    // use snprintf instead of strcpy
+    // strcpy(output, buf);
+  }
+  if (ret == ZOK) {
+    LOG(INFO) << "created zookeeper node " << buf
+              << " (" << (val == nullptr ? "NULL" : val) << ")";
+    return true;
+  } else if (ret == ZNODEEXISTS) {
+    LOG(WARNING) << "zookeeper node " << path << " already exists";
+    return true;
+  } else if (ret == ZCONNECTIONLOSS) {
+    LOG(ERROR) << "Cannot connect to zookeeper, "
+               << "please ensure it is running properly...\n"
+               << "If want to use zookeeper in our thirdparty folder, "
+               << "you can start it by:\n"
+               << "$ ./bin/zk-service.sh start";
+    return false;
+  }
+  LOG(FATAL) << "Unhandled ZK error code: " << ret
+             << " (zoo_create " << path << ")";
+  return false;
+}
+
+bool ZKService::DeleteNode(const char* path) {
+  CHECK(zkhandle_) << "zk handler not initialized";
+  int ret = zoo_delete(zkhandle_, path, -1);
+  if (ret == ZOK) {
+    LOG(INFO) << "deleted zookeeper node " << path;
+    return true;
+  } else if (ret == ZNONODE) {
+    LOG(WARNING) << "try to delete an non-existing zookeeper node " << path;
+    return true;
+  }
+  LOG(FATAL) << "Unhandled ZK error code: " << ret
+             << " (zoo_delete " << path << ")";
+  return false;
+}
+
+bool ZKService::Exist(const char* path) {
+  CHECK(zkhandle_) << "zk handler not initialized";
+  struct Stat stat;
+  int ret = zoo_exists(zkhandle_, path, 0, &stat);
+  if (ret == ZOK) return true;
+  else if (ret == ZNONODE) return false;
+  LOG(WARNING) << "Unhandled ZK error code: " << ret << " (zoo_exists)";
+  return false;
+}
+
+bool ZKService::UpdateNode(const char* path, const char* val) {
+  CHECK(zkhandle_) << "zk handler not initialized";
+  // set version = -1, do not check content version
+  int ret = zoo_set(zkhandle_, path, val, strlen(val), -1);
+  if (ret == ZOK) {
+    return true;
+  } else if (ret == ZNONODE) {
+    LOG(ERROR) << "zk node " << path << " does not exist";
+    return false;
+  }
+  LOG(FATAL) << "Unhandled ZK error code: " << ret
+             << " (zoo_get " << path << ")";
+  return false;
+}
+
+bool ZKService::GetNode(const char* path, char* output) {
+  CHECK(zkhandle_) << "zk handler not initialized";
+  struct Stat stat;
+  int val_len = kZKBufSize;
+  int ret = zoo_get(zkhandle_, path, 0, output, &val_len, &stat);
+  if (ret == ZOK) {
+    output[val_len] = '\0';
+    return true;
+  } else if (ret == ZNONODE) {
+    LOG(ERROR) << "zk node " << path << " does not exist";
+    return false;
+  }
+  LOG(FATAL) << "Unhandled ZK error code: " << ret
+             << " (zoo_get " << path << ")";
+  return false;
+}
+
+bool ZKService::GetChild(const char* path, vector<string>* vt) {
+  CHECK(zkhandle_) << "zk handler not initialized";
+  struct String_vector child;
+  int ret = zoo_get_children(zkhandle_, path, 0, &child);
+  if (ret == ZOK) {
+    vt->clear();
+    for (int i = 0; i < child.count; ++i) vt->push_back(child.data[i]);
+    return true;
+  }
+  LOG(FATAL) << "Unhandled ZK error code: " << ret
+             << " (zoo_get_children " << path << ")";
+  return false;
+}
+
+bool ZKService::WGetChild(const char* path, vector<string>* vt,
+                            RTCallback *cb) {
+  CHECK(zkhandle_) << "zk handler not initialized";
+  struct String_vector child;
+  int ret = zoo_wget_children(zkhandle_, path, ChildChanges, cb, &child);
+  if (ret == ZOK) {
+    vt->clear();
+    for (int i = 0; i < child.count; ++i) vt->push_back(child.data[i]);
+    return true;
+  }
+  LOG(FATAL) << "Unhandled ZK error code: " << ret
+             << " (zoo_get_children " << path << ")";
+  return false;
+}
+
+
+void ZKService::WatcherGlobal(zhandle_t * zh, int type, int state,
+                                const char *path, void *watcherCtx) {
+  if (type == ZOO_SESSION_EVENT) {
+    if (state == ZOO_CONNECTED_STATE)
+      LOG(INFO) << "GLOBAL_WATCHER connected to zookeeper successfully!";
+    else if (state == ZOO_EXPIRED_SESSION_STATE)
+      LOG(INFO) << "GLOBAL_WATCHER zookeeper session expired!";
+  }
+}
+
+ZKClusterRT::ZKClusterRT(const string& host, int job_id) {
+  host_ = host;
+  workspace_ = GetZKJobWorkspace(job_id);
+  group_path_ = workspace_ + kZKPathJobGroup;
+  proc_path_ = workspace_ + kZKPathJobProc;
+  proc_lock_path_ = workspace_ + kZKPathJobPLock;
+}
+
+ZKClusterRT::~ZKClusterRT() {
+  // release callback vector
+  for (RTCallback* p : cb_vec_) {
+    delete p;
+  }
+}
+
+bool ZKClusterRT::Init() {
+  if (!zk_.Init(host_, timeout_)) return false;
+  if (!zk_.CreateNode(kZKPathSinga.c_str(), nullptr, 0, nullptr))
+    return false;
+  if (!zk_.CreateNode(kZKPathApp.c_str(), nullptr, 0, nullptr))
+    return false;
+  if (!zk_.CreateNode(workspace_.c_str(), nullptr, 0, nullptr))
+    return false;
+  if (!zk_.CreateNode(group_path_.c_str(), nullptr, 0, nullptr))
+    return false;
+  if (!zk_.CreateNode(proc_path_.c_str(), nullptr, 0, nullptr))
+    return false;
+  if (!zk_.CreateNode(proc_lock_path_.c_str(), nullptr, 0, nullptr))
+    return false;
+  return true;
+}
+
+int ZKClusterRT::RegistProc(const string& host_addr, int pid) {
+  char buf[kZKBufSize];
+  string lock = proc_lock_path_ + "/lock-";
+  if (!zk_.CreateNode(lock.c_str(), nullptr,
+                        ZOO_EPHEMERAL | ZOO_SEQUENCE, buf)) {
+    return -1;
+  }
+  // get all children in lock folder
+  vector<string> vt;
+  if (!zk_.GetChild(proc_lock_path_.c_str(), &vt)) {
+    return -1;
+  }
+  // find own position among all locks
+  int id = -1;
+  std::sort(vt.begin(), vt.end());
+  for (int i = 0; i < static_cast<int>(vt.size()); ++i) {
+    if (proc_lock_path_+"/"+vt[i] == buf) {
+      id = i;
+      break;
+    }
+  }
+  if (id == -1) {
+    LOG(ERROR) << "cannot find own node " << buf;
+    return -1;
+  }
+  // create a new node in proc path
+  string path = proc_path_ + "/proc-" + to_string(id);
+  string content = host_addr + "|" + to_string(pid);
+  if (!zk_.CreateNode(path.c_str(), content.c_str(), ZOO_EPHEMERAL,
+                      nullptr)) {
+    return -1;
+  }
+  return id;
+}
+
+std::string ZKClusterRT::GetProcHost(int proc_id) {
+  char val[kZKBufSize];
+  // construct file name
+  string path = proc_path_ + "/proc-" + to_string(proc_id);
+  if (!zk_.GetNode(path.c_str(), val)) return "";
+  int len = strlen(val) - 1;
+  while (len && val[len] != '|') --len;
+  CHECK(len);
+  val[len] = '\0';
+  return string(val);
+}
+
+bool ZKClusterRT::WatchSGroup(int gid, int sid, rt_callback fn, void *ctx) {
+  CHECK_NOTNULL(fn);
+  string path = groupPath(gid);
+  // create zk node
+  if (!zk_.CreateNode(path.c_str(), nullptr, 0, nullptr)) return false;
+  vector<string> child;
+  // store the callback function and context for later usage
+  RTCallback *cb = new RTCallback;
+  cb->fn = fn;
+  cb->ctx = ctx;
+  cb_vec_.push_back(cb);
+  // start to watch on the zk node, does not care about the first return value
+  return zk_.WGetChild(path.c_str(), &child, cb);
+}
+
+bool ZKClusterRT::JoinSGroup(int gid, int wid, int s_group) {
+  string path = groupPath(s_group) + workerPath(gid, wid);
+  // try to create an ephemeral node under server group path
+  return zk_.CreateNode(path.c_str(), nullptr, ZOO_EPHEMERAL, nullptr);
+}
+
+bool ZKClusterRT::LeaveSGroup(int gid, int wid, int s_group) {
+  string path = groupPath(s_group) + workerPath(gid, wid);
+  return zk_.DeleteNode(path.c_str());
+}
+
+}  // namespace singa


### PR DESCRIPTION
Make zookeeper a optional dependency.
By default, we only support single-process training.

To enable distributed training, please install zookeeper and configure with:
./configure --enable-zookeeper