### PR TITLE
SINGA-156 Remove the dependency on ZMQ for single process training

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -195,10 +195,10 @@ libsinga_la_SOURCES += $(CUDNN_SRCS)
 libsinga_la_CXXFLAGS += $(CUDNN_CFLAGS)
 libsinga_la_LDFLAGS += $(CUDNN_LDFLAGS) $(CUDNN_LIBS)
 endif
-if DZOOKEEPER
+if DDIST
 libsinga_la_SOURCES += $(ZOOKEEPER_SRCS)
-libsinga_la_CXXFLAGS += $(ZOOKEEPER_CFLAGS)
-libsinga_la_LDFLAGS += $(ZOOKEEPER_LDFLAGS) $(ZOOKEEPER_LIBS)
+libsinga_la_CXXFLAGS += $(DIST_CFLAGS)
+libsinga_la_LDFLAGS += $(DIST_LDFLAGS) $(DIST_LIBS)
 endif
 
 if DHDFS
@@ -214,7 +214,6 @@ singa_LDFLAGS = -lsinga \
                 -lglog  \
                 -lprotobuf \
                 -lopenblas \
-                -lzmq \
                 -lczmq 
 if LMDB
 singa_LDFLAGS += -llmdb
@@ -226,10 +225,10 @@ singa_CXXFLAGS += $(CUDA_CFLAGS)
 singa_LDFLAGS += $(CUDA_LDFLAGS) $(CUDA_LIBS)
 endif
 
-if DZOOKEEPER
+if DDIST
 singa_SOURCES += $(ZOOKEEPER_SRCS)
-singa_CXXFLAGS += $(ZOOKEEPER_CFLAGS)
-singa_LDFLAGS += $(ZOOKEEPER_LDFLAGS) $(ZOOKEEPER_LIBS)
+singa_CXXFLAGS += $(DIST_CFLAGS)
+singa_LDFLAGS += $(DIST_LDFLAGS) $(DIST_LIBS)
 endif
 
 if DCUDNN
@@ -251,10 +250,10 @@ singatool_LDFLAGS = -lsinga \
                     -lglog  \
                     -lprotobuf 
 
-if DZOOKEEPER
+if DDIST
 singatool_SOURCES += $(ZOOKEEPER_SRCS)
-singatool_CXXFLAGS += $(ZOOKEEPER_CFLAGS)
-singatool_LDFLAGS += $(ZOOKEEPER_LDFLAGS) $(ZOOKEEPER_LIBS)
+singatool_CXXFLAGS += $(DIST_CFLAGS)
+singatool_LDFLAGS += $(DIST_LDFLAGS) $(DIST_LIBS)
 endif
 
 #lib_LTLIBRARIES += libgtest.la
@@ -274,7 +273,6 @@ singatest_LDFLAGS = -lsinga \
                 -lglog  \
                 -lprotobuf \
                 -lopenblas \
-                -lzmq \
                 -lczmq \
                 -lgtest
 if LMDB
@@ -293,10 +291,10 @@ singatest_CXXFLAGS += $(CUDNN_CFLAGS)
 singatest_LDFLAGS += $(CUDNN_LDFLAGS) $(CUDNN_LIBS)
 endif
 
-if DZOOKEEPER
+if DDIST
 singatest_SOURCES += $(ZOOKEEPER_SRCS)
-singatest_CXXFLAGS += $(ZOOKEEPER_CFLAGS)
-singatest_LDFLAGS += $(ZOOKEEPER_LDFLAGS) $(ZOOKEEPER_LIBS)
+singatest_CXXFLAGS += $(DIST_CFLAGS)
+singatest_LDFLAGS += $(DIST_LDFLAGS) $(DIST_LIBS)
 endif
 
 _driver_la_SOURCES = $(PY_SRCS)

--- a/configure.ac
+++ b/configure.ac
@@ -40,9 +40,6 @@ AC_PROG_LIBTOOL
 AC_SEARCH_LIBS([cblas_sgemm], [openblas], [], [
   AC_MSG_ERROR([unable to find cblas_sgemm() function])
   ])
-AC_SEARCH_LIBS([zmq_ctx_new], [zmq], [], [
-  AC_MSG_ERROR([unable to find zmq_ctx_new() function])
-    ])
 AC_SEARCH_LIBS([zmsg_new], [czmq], [], [
   AC_MSG_ERROR([unable to find zmsg_new() function])
   ])
@@ -116,7 +113,7 @@ AC_SUBST(CUDA_CFLAGS)
 # Setup custom CUDNN paths
 AC_ARG_ENABLE([cudnn],
     [AS_HELP_STRING(--enable-cudnn,enable CUDNN support)],
-    [enable_cudnn=yes], [enable_cudnn=no])
+    [enable_cudnn="yes"], [enable_cudnn="no"])
 AM_CONDITIONAL(DCUDNN, [test "$enable_cudnn" = "yes"])
 AC_ARG_WITH([cudnn],
     [AS_HELP_STRING([--with-cudnn=PATH], [prefix where CUDNN is installed])],
@@ -147,37 +144,41 @@ AC_SUBST(CUDNN_LDFLAGS)
 AC_SUBST(CUDNN_LIBS)
 
 # Setup custom zookeeper paths 
-AC_ARG_ENABLE(zookeeper,
-  AS_HELP_STRING([--enable-zookeeper],[enable zookeeper support]),
-  [enable_zookeeper=yes],[enable_zookeeper=no])
-AM_CONDITIONAL(DZOOKEEPER, test "$enable_zookeeper" = yes)
-AC_ARG_WITH([zookeeper],
-    [AS_HELP_STRING([--with-zookeeper=PATH], [prefix where zookeeper is installed])],
-    [zookeeper_prefix=$withval], [zookeeper_prefix="/usr/local"])
-if test "$zookeeper_prefix" == "yes"; then
+AC_ARG_ENABLE(dist,
+  AS_HELP_STRING([--enable-dist],[enable dist support]),
+  [enable_dist="yes"],[enable_dist="no"])
+AM_CONDITIONAL(DDIST, test "$enable_dist" = "yes")
+AC_ARG_WITH([dist],
+    [AS_HELP_STRING([--with-dist=PATH], [prefix where dist libraries,i.e.
+     zookeeper/zmq is installed])],
+    [dist_prefix=$withval], [dist_prefix="/usr/local"])
+if test "$dist_prefix" == "yes"; then
     if test "$withval" == "yes"; then
-        cudnn_prefix="/usr/local"
+        dist_prefix="/usr/local"
     fi
 fi
-if test x"$enable_zookeeper" != x"no"; then
-  ZOOKEEPER_CFLAGS="-I$zookeeper_prefix/include"
-  ZOOKEEPER_LDFLAGS="-L$zookeeper_prefix/lib"
-  ZOOKEEPER_LIBS="-lzookeeper_mt"
-  LIBS="$LIBS $ZOOKEEPER_LIBS"
-  LDFLAGS="$LDFLAGS $ZOOKEEPER_LDFLAGS"
-  DEBUG+=" -DUSE_ZOOKEEPER"
-  AC_DEFINE(DZOOKEEPER,[1],[Defined if zookeeper should be used])
-  AC_CHECK_LIB([zookeeper_mt], [main], [], [
-      AC_MSG_ERROR([unable to find zookeeper library])
-      ])
+if test x"$enable_dist" == x"yes"; then
+  AC_CHECK_LIB([zookeeper_mt], [main], [], [ 
+                AC_MSG_ERROR([unable to find zookeeper library])
+        ])
+  AC_SEARCH_LIBS([zmq_ctx_new], [zmq], [], [ 
+                  AC_MSG_ERROR([unable to find zmq_ctx_new() function])
+        ])
+  DIST_CFLAGS="-I$dist_prefix/include"
+  DIST_LDFLAGS="-L$dist_prefix/lib"
+  DIST_LIBS="-lzookeeper_mt -lzmq"
+  LIBS="$LIBS $DIST_LIBS"
+  LDFLAGS="$LDFLAGS $DIST_LDFLAGS"
+  DEBUG+=" -DUSE_ZOOKEEPER -DUSE_ZMQ"
+  AC_DEFINE(DDIST,[1],[Defined if dist should be used])
 else
-  ZOOKEEPER_CFLAGS=""
-  ZOOKEEPER_LDFLAGS=""
-  ZOOKEEPER_LIBS=""
+  DIST_CFLAGS=""
+  DIST_LDFLAGS=""
+  DIST_LIBS=""
 fi
-AC_SUBST(ZOOKEEPER_CFLAGS)
-AC_SUBST(ZOOKEEPER_LDFLAGS)
-AC_SUBST(ZOOKEEPER_LIBS)
+AC_SUBST(DIST_CFLAGS)
+AC_SUBST(DIST_LDFLAGS)
+AC_SUBST(DIST_LIBS)
 
 # Setup custom lmdb paths 
 AC_ARG_ENABLE(lmdb,

--- a/include/singa/comm/msg.h
+++ b/include/singa/comm/msg.h
@@ -25,7 +25,7 @@
 #include <utility>
 
 // TODO(wangwei): make it a compiler argument
-#define USE_ZMQ
+// #define USE_ZMQ
 
 #include <vector>
 #ifdef USE_ZMQ

--- a/include/singa/comm/msg.h
+++ b/include/singa/comm/msg.h
@@ -22,10 +22,12 @@
 #ifndef SINGA_COMM_MSG_H_
 #define SINGA_COMM_MSG_H_
 
+#include <utility>
+
 // TODO(wangwei): make it a compiler argument
 #define USE_ZMQ
 
-#include <utility>
+#include <vector>
 #ifdef USE_ZMQ
 #include <czmq.h>
 #endif
@@ -79,7 +81,7 @@ inline int AddrType(int addr) {
 }
 
 /**
- * Msg used to transfer Param info (gradient or value), feature blob, etc
+ * Msg used to transfer Param info (gradient or value), feature blob, etc.
  * between workers, stubs and servers.
  *
  * Each msg has a source addr and dest addr identified by a unique integer.
@@ -225,6 +227,9 @@ class Msg {
 #ifdef USE_ZMQ
   zmsg_t* msg_ = nullptr;
   zframe_t *frame_ = nullptr;
+#else
+  std::vector<std::pair<void*, int>> frames_;
+  unsigned idx_ = 0;
 #endif
 };
 

--- a/include/singa/comm/socket.h
+++ b/include/singa/comm/socket.h
@@ -43,7 +43,7 @@ class Dealer {
    /**
     * @param id used for identifying the msg queue of this dealer.
     */
-   Dealer(int id) : id_(id) {}
+   Dealer(int id);
   ~Dealer();
   /**
     * Setup the connection with the remote router.
@@ -83,6 +83,7 @@ class Dealer {
 class Router {
  public:
   ~Router();
+  Router();
   /**
    * Bind the router to an endpoint for recv msg from remote dealer.
    * If the router is used for intra-communication only, then no need to call

--- a/include/singa/comm/socket.h
+++ b/include/singa/comm/socket.h
@@ -25,150 +25,98 @@
 #ifdef USE_ZMQ
 #include <czmq.h>
 #endif
+
 #include <map>
 #include <string>
 #include <vector>
+#include <unordered_map>
+#include "singa/utils/safe_queue.h"
 #include "singa/comm/msg.h"
 
 namespace singa {
-
-const std::string kInprocRouterEndpoint = "inproc://router";
-
-class SocketInterface {
+/**
+ * Worker and Server use Dealer to communicate with Stub.
+ * Stub uses Dealer to communicate with remote Stub.
+ */
+class Dealer {
  public:
-  virtual ~SocketInterface() {}
+   /**
+    * @param id used for identifying the msg queue of this dealer.
+    */
+   Dealer(int id) : id_(id) {}
+  ~Dealer();
   /**
-    * Send a message to connected socket(s), non-blocking. The message
-    * will be deallocated after sending, thus should not be used after
-    * calling Send();
+    * Setup the connection with the remote router.
     *
-    * @param msg The message to be sent
-    * @return 1 for success queuing the message for sending, 0 for failure
-    */
-  virtual int Send(Msg** msg) = 0;
-  /**
-    * Receive a message from any connected socket.
+    * For local router, there is no need to connect it.
     *
-    * @return a message pointer if success; nullptr if failure
-    */
-  virtual Msg* Receive() = 0;
-  /**
-   * @return Identifier of the implementation dependent socket. E.g., zsock_t*
-   * for ZeroMQ implementation and rank for MPI implementation.
-   */
-  virtual void* InternalID() const = 0;
-};
-
-class Poller {
- public:
-  Poller();
-  explicit Poller(SocketInterface* socket);
-  /**
-    * Add a socket for polling; Multiple sockets can be polled together by
-    * adding them into the same poller.
-    */
-  void Add(SocketInterface* socket);
-  /**
-    * Poll for all sockets added into this poller.
-    * @param timeout Stop after this number of mseconds
-    * @return pointer To the socket if it has one message in the receiving
-    * queue; nullptr if no message in any sockets,
-    */
-  SocketInterface* Wait(int duration);
-
-  /**
-   * @return true if the poller is terminated due to process interupt
-   */
-  virtual bool Terminated();
-
- protected:
-#ifdef USE_ZMQ
-  zpoller_t *poller_;
-  std::map<zsock_t*, SocketInterface*> zsock2Socket_;
-#endif
-};
-
-class Dealer : public SocketInterface {
- public:
-  /*
-   * @param id Local dealer ID within a procs if the dealer is from worker or
-   * server thread, starts from 1 (0 is used by the router); or the connected
-   * remote procs ID for inter-process dealers from the stub thread.
-   */
-  Dealer();
-  explicit Dealer(int id);
-  ~Dealer() override;
-  /**
-    * Setup the connection with the router.
-    *
-    * @param endpoint Identifier of the router. For intra-process
-    * connection, the endpoint follows the format of ZeroMQ, i.e.,
-    * starting with "inproc://"; in Singa, since each process has one
-    * router, hence we can fix the endpoint to be "inproc://router" for
-    * intra-process. For inter-process, the endpoint follows ZeroMQ's
-    * format, i.e., IP:port, where IP is the connected process.
+    * @param endpoint Identifier of the remote router to connect. It follows
+    * ZeroMQ's format, i.e., IP:port, where IP is the connected process.
     * @return 1 connection sets up successfully; 0 otherwise
     */
   int Connect(const std::string& endpoint);
-  int Send(Msg** msg) override;
-  Msg* Receive() override;
-  void* InternalID() const override;
+  /**
+   * Send a message to the local router (id=-1) or remote outer. It is
+   * non-blocking. The message will be deallocated after sending, thus
+   * should not be used after calling Send();
+   */
+  int Send(Msg** msg);
+  /**
+   * Recv msg from local router.
+   *
+   * @param timeout return if waiting for timeout microseconds.
+   * @return a message pointer if success; nullptr if failure
+   */
+  Msg* Receive(int timeout = 0);
 
  protected:
-  int id_ = -1;
+  std::string endpoint_;
+  int id_;
 #ifdef USE_ZMQ
   zsock_t* dealer_ = nullptr;
-  zpoller_t* poller_ = nullptr;
 #endif
 };
-
-class Router : public SocketInterface {
+/**
+ * In Singa, since each process has one router used by Stub, hence we fix the
+ * router to use the msg queue indexed by -1.
+ */
+class Router {
  public:
-  Router();
+  ~Router();
   /**
-   * There is only one router per procs, hence its local id is 0 and is not set
-   * explicitly.
+   * Bind the router to an endpoint for recv msg from remote dealer.
+   * If the router is used for intra-communication only, then no need to call
+   * Bind.
    *
-   * @param bufsize Buffer at most this number of messages
-   */
-  explicit Router(int bufsize);
-  ~Router() override;
-  /**
-   * Setup the connection with dealers.
-   *
-   * It automatically binds to the endpoint for intra-process communication,
-   * i.e., "inproc://router".
-   *
-   * @param endpoint The identifier for the Dealer socket in other process
+   * @param endpoint identifier for the Dealer socket in other process
    * to connect. It has the format IP:Port, where IP is the host machine.
-   * If endpoint is empty, it means that all connections are
-   * intra-process connection.
    * @return number of connected dealers.
    */
   int Bind(const std::string& endpoint);
   /**
-   * If the destination socket has not connected yet, buffer this the message.
+   * Send msg to local dealers by pushing the msg into the msg queue indexed by
+   * dst of the msg.
    */
-  int Send(Msg** msg) override;
-  Msg* Receive() override;
-  void* InternalID() const override;
+  int Send(Msg** msg);
+  /**
+   * Recv msg from local (msg queue) or remote dealer (via zmq).
+   */
+  Msg* Receive(int timeout = 0);
 
  protected:
-  int nBufmsg_ = 0;
-  int bufsize_ = 100;
+  std::string endpoint_;
 #ifdef USE_ZMQ
   zsock_t* router_ = nullptr;
   zpoller_t* poller_ = nullptr;
-  std::map<int, zframe_t*> id2addr_;
-  std::map<int, std::vector<zmsg_t*>> bufmsg_;
 #endif
 };
 
-#ifdef USE_MPI
-// TODO(wangsheng): add intra-process communication using shared queue
-std::vector<SafeQueue*> MPIQueues;
-#endif
-
+/**
+ * Used for intra-process communication.
+ * Each dealer/router has a SafeQueue for recieving msgs.
+ * The sender pushes msgs onto the queue of the reciever's queue.
+ */
+extern std::unordered_map<int, SafeQueue<Msg*>> msgQueues;
 }  // namespace singa
 
 #endif  // SINGA_COMM_SOCKET_H_

--- a/include/singa/server.h
+++ b/include/singa/server.h
@@ -126,6 +126,8 @@ class Server {
   std::vector<int> n_pending_sync_;
   std::vector<Blob<float>> last_sync_;
   std::unordered_map<int, std::vector<Msg*>> buffer_requests_;
+
+  Dealer* dealer_;
 };
 
 }  // namespace singa

--- a/include/singa/utils/safe_queue.h
+++ b/include/singa/utils/safe_queue.h
@@ -1,0 +1,263 @@
+#ifndef SINGA_UTILS_SAFE_QUEUE_H_
+#define SINGA_UTILS_SAFE_QUEUE_H_
+
+// source: http://gnodebian.blogspot.sg/2013/07/a-thread-safe-asynchronous-queue-in-c11.html
+#include <queue>
+#include <list>
+#include <mutex>
+#include <thread>
+#include <cstdint>
+#include <condition_variable>
+
+/** A thread-safe asynchronous queue */
+template <class T, class Container = std::list<T>>
+class SafeQueue {
+
+  typedef typename Container::value_type value_type;
+  typedef typename Container::size_type size_type;
+  typedef Container container_type;
+
+ public:
+
+  /*! Create safe queue. */
+  SafeQueue() = default;
+  SafeQueue (SafeQueue&& sq) {
+    m_queue = std::move (sq.m_queue);
+  }
+  SafeQueue (const SafeQueue& sq) {
+    std::lock_guard<std::mutex> lock (sq.m_mutex);
+    m_queue = sq.m_queue;
+  }
+
+  /*! Destroy safe queue. */
+  ~SafeQueue() {
+    std::lock_guard<std::mutex> lock (m_mutex);
+  }
+
+  /**
+   * Sets the maximum number of items in the queue. Defaults is 0: No limit
+   * \param[in] item An item.
+   */
+  void set_max_num_items (unsigned int max_num_items) {
+    m_max_num_items = max_num_items;
+  }
+
+  /**
+   *  Pushes the item into the queue.
+   * \param[in] item An item.
+   * \return true if an item was pushed into the queue
+   */
+  bool push (const value_type& item) {
+    std::lock_guard<std::mutex> lock (m_mutex);
+
+    if (m_max_num_items > 0 && m_queue.size() > m_max_num_items)
+      return false;
+
+    m_queue.push (item);
+    m_condition.notify_one();
+    return true;
+  }
+
+  /**
+   *  Pushes the item into the queue.
+   * \param[in] item An item.
+   * \return true if an item was pushed into the queue
+   */
+  bool push (const value_type&& item) {
+    std::lock_guard<std::mutex> lock (m_mutex);
+
+    if (m_max_num_items > 0 && m_queue.size() > m_max_num_items)
+      return false;
+
+    m_queue.push (item);
+    m_condition.notify_one();
+    return true;
+  }
+
+  /**
+   *  Pops item from the queue. If queue is empty, this function blocks until item becomes available.
+   * \param[out] item The item.
+   */
+  void pop (value_type& item) {
+    std::unique_lock<std::mutex> lock (m_mutex);
+    m_condition.wait (lock, [this]() // Lambda funct
+        {
+        return !m_queue.empty();
+        });
+    item = m_queue.front();
+    m_queue.pop();
+  }
+
+  /**
+   *  Pops item from the queue using the contained type's move assignment operator, if it has one..
+   *  This method is identical to the pop() method if that type has no move assignment operator.
+   *  If queue is empty, this function blocks until item becomes available.
+   * \param[out] item The item.
+   */
+  void move_pop (value_type& item) {
+    std::unique_lock<std::mutex> lock (m_mutex);
+    m_condition.wait (lock, [this]() // Lambda funct
+        {
+        return !m_queue.empty();
+        });
+    item = std::move (m_queue.front());
+    m_queue.pop();
+  }
+
+  /**
+   *  Tries to pop item from the queue.
+   * \param[out] item The item.
+   * \return False is returned if no item is available.
+   */
+  bool try_pop (value_type& item) {
+    std::unique_lock<std::mutex> lock (m_mutex);
+
+    if (m_queue.empty())
+      return false;
+
+    item = m_queue.front();
+    m_queue.pop();
+    return true;
+  }
+
+  /**
+   *  Tries to pop item from the queue using the contained type's move assignment operator, if it has one..
+   *  This method is identical to the try_pop() method if that type has no move assignment operator.
+   * \param[out] item The item.
+   * \return False is returned if no item is available.
+   */
+  bool try_move_pop (value_type& item) {
+    std::unique_lock<std::mutex> lock (m_mutex);
+
+    if (m_queue.empty())
+      return false;
+
+    item = std::move (m_queue.front());
+    m_queue.pop();
+    return true;
+  }
+
+  /**
+   *  Pops item from the queue. If the queue is empty, blocks for timeout microseconds, or until item becomes available.
+   * \param[out] t An item.
+   * \param[in] timeout The number of microseconds to wait.
+   * \return true if get an item from the queue, false if no item is received before the timeout.
+   */
+  bool timeout_pop (value_type& item, std::uint64_t timeout) {
+    std::unique_lock<std::mutex> lock (m_mutex);
+
+    if (m_queue.empty())
+    {
+      if (timeout == 0)
+        return false;
+
+      if (m_condition.wait_for (lock, std::chrono::microseconds (timeout)) == std::cv_status::timeout)
+        return false;
+    }
+
+    item = m_queue.front();
+    m_queue.pop();
+    return true;
+  }
+
+  /**
+   *  Pops item from the queue using the contained type's move assignment operator, if it has one..
+   *  If the queue is empty, blocks for timeout microseconds, or until item becomes available.
+   *  This method is identical to the try_pop() method if that type has no move assignment operator.
+   * \param[out] t An item.
+   * \param[in] timeout The number of microseconds to wait.
+   * \return true if get an item from the queue, false if no item is received before the timeout.
+   */
+  bool timeout_move_pop (value_type& item, std::uint64_t timeout) {
+    std::unique_lock<std::mutex> lock (m_mutex);
+
+    if (m_queue.empty())
+    {
+      if (timeout == 0)
+        return false;
+
+      if (m_condition.wait_for (lock, std::chrono::microseconds (timeout)) == std::cv_status::timeout)
+        return false;
+    }
+
+    item = std::move (m_queue.front());
+    m_queue.pop();
+    return true;
+  }
+
+  /**
+   *  Gets the number of items in the queue.
+   * \return Number of items in the queue.
+   */
+  size_type size() const {
+    std::lock_guard<std::mutex> lock (m_mutex);
+    return m_queue.size();
+  }
+
+  /**
+   *  Check if the queue is empty.
+   * \return true if queue is empty.
+   */
+  bool empty() const {
+    std::lock_guard<std::mutex> lock (m_mutex);
+    return m_queue.empty();
+  }
+
+  /**
+   *  Swaps the contents.
+   * \param[out] sq The SafeQueue to swap with 'this'.
+   */
+  void swap (SafeQueue& sq) {
+    if (this != &sq) {
+      std::lock_guard<std::mutex> lock1 (m_mutex);
+      std::lock_guard<std::mutex> lock2 (sq.m_mutex);
+      m_queue.swap (sq.m_queue);
+
+      if (!m_queue.empty())
+        m_condition.notify_all();
+
+      if (!sq.m_queue.empty())
+        sq.m_condition.notify_all();
+    }
+  }
+
+  /*! The copy assignment operator */
+  SafeQueue& operator= (const SafeQueue& sq) {
+    if (this != &sq) {
+      std::lock_guard<std::mutex> lock1 (m_mutex);
+      std::lock_guard<std::mutex> lock2 (sq.m_mutex);
+      std::queue<T, Container> temp {sq.m_queue};
+      m_queue.swap (temp);
+
+      if (!m_queue.empty())
+        m_condition.notify_all();
+    }
+
+    return *this;
+  }
+
+  /*! The move assignment operator */
+  SafeQueue& operator= (SafeQueue && sq) {
+    std::lock_guard<std::mutex> lock (m_mutex);
+    m_queue = std::move (sq.m_queue);
+
+    if (!m_queue.empty())  m_condition.notify_all();
+
+    return *this;
+  }
+
+
+ private:
+
+  std::queue<T, Container> m_queue;
+  mutable std::mutex m_mutex;
+  std::condition_variable m_condition;
+  unsigned int m_max_num_items = 0;
+};
+
+/*! Swaps the contents of two SafeQueue objects. */
+template <class T, class Container>
+void swap (SafeQueue<T, Container>& q1, SafeQueue<T, Container>& q2) {
+  q1.swap (q2);
+}
+#endif // SINGA_UTILS_SAFE_QUEUE_H_

--- a/src/comm/socket.cc
+++ b/src/comm/socket.cc
@@ -31,6 +31,10 @@ Dealer::~Dealer() {
 #endif
 }
 
+Dealer::Dealer(int id) : id_ (id) {
+  msgQueues[id];
+}
+
 int Dealer::Connect(const std::string& endpoint) {
   if (endpoint.length() > 0) {
 #ifdef USE_ZMQ
@@ -77,6 +81,10 @@ Router::~Router() {
 #ifdef USE_ZMQ
   zsock_destroy(&router_);
 #endif
+}
+
+Router::Router() {
+  msgQueues[-1];
 }
 
 int Router::Bind(const std::string& endpoint) {

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -232,18 +232,6 @@ void Driver::Train(const JobProto& job_conf) {
       net->ToGraph(true).ToJson());
   const vector<Worker*> workers = CreateWorkers(job_conf, net);
   const vector<Server*> servers = CreateServers(job_conf, net);
-  // Add msg queues for each socket
-  for (auto worker : workers) {
-    msgQueues[Addr(worker->grp_id(), worker->id(), kWorkerParam)];
-    msgQueues[Addr(worker->grp_id(), worker->id(), kWorkerLayer)];
-//    LOG(ERROR) << "worker addr " << Addr(worker->grp_id(), worker->id(), kWorkerParam);
-//    LOG(ERROR) << "worker addr " << Addr(worker->grp_id(), worker->id(), kWorkerLayer);
-  }
-  for (auto server : servers) {
-    msgQueues[Addr(server->grp_id(), server->id(), kServer)];
-//    LOG(ERROR) << "server addr " << Addr(server->grp_id(), server->id(), kServer);
-  }
-  msgQueues[-1];
 
   vector<std::thread> threads;
   for (auto server : servers)

--- a/src/utils/cluster_rt.cc
+++ b/src/utils/cluster_rt.cc
@@ -7,9 +7,9 @@
 * to you under the Apache License, Version 2.0 (the
 * "License"); you may not use this file except in compliance
 * with the License.  You may obtain a copy of the License at
-* 
+*
 *   http://www.apache.org/licenses/LICENSE-2.0
-* 
+*
 * Unless required by applicable law or agreed to in writing,
 * software distributed under the License is distributed on an
 * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/utils/param.cc
+++ b/src/utils/param.cc
@@ -235,6 +235,7 @@ Msg* Param::GenPutMsg(bool copy, int idx) {
   if (copy) {
     msg->AddFrame(ptr, slice_size_[idx] * sizeof(float));
   }
+//  LOG(ERROR) << "gen put msg: " << msg;
   return msg;
 }
 
@@ -281,6 +282,7 @@ Msg* Param::HandlePutMsg(Msg** msg, bool reserve) {
   int size;
   float lr, wc;
   float* ptr;
+//  LOG(ERROR) << "handle put msg:" << *msg;
   (*msg)->ParseFormatFrame("iffp", &size, &lr, &wc, &ptr);
   ParamProto proto;
   proto.set_lr_scale(lr);

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -53,7 +53,7 @@ void Worker::Setup(int grp_id, int id, const JobProto& conf,
   train_net_ = train_net;
   val_net_ = val_net;
   test_net_ = test_net;
-  bridge_dealer_ = dealer_ = nullptr;
+  InitSockets(train_net);
 }
 
 Worker::~Worker() {


### PR DESCRIPTION
SINGA depends on ZMQ and CZMQ, which are used for intra and inter process communication.
In fact, for training using a single process (with multiple threads), we can avoid ZMQ and CZMQ for intra-process communication. 
This ticket implements the intra-process communication by assigning a thread-safe queue for each socket (i.e., dealer and router). The sender pushes the msg onto the receiver's queue. In this way, we can remove the dependency on ZMQ and CZMQ for single process training.
There is a macro 'USE_ZMQ', which controls the compiling of ZMQ related code. If USE_ZMQ is not defined, SINGA can only run for single process. Otherwise, SINGA uses ZMQ for inter-process communication and uses the msg queues for intra-process communication.