### PR TITLE
SINGA-134 Extend SINGA to run over a GPU cluster

### DIFF
--- a/bin/singa-run.sh
+++ b/bin/singa-run.sh
@@ -86,7 +86,7 @@ singa_run="$exe $args \
 if [ ! -z $job_conf ]; then
   singa_run="$singa_run -conf $job_conf"
 fi
-singa_sshrun="cd $SINGA_HOME; $singa_run"
+singa_sshrun="source ~/.profile; cd $SINGA_HOME; $singa_run"
 
 # ssh and start singa processes
 ssh_options="-oStrictHostKeyChecking=no \
@@ -99,7 +99,7 @@ for i in ${hosts[@]} ; do
     $singa_run &
   else
     echo Executing @ $i : $singa_sshrun
-    ssh $ssh_options $i $singa_sshrun &
+    ssh $ssh_options $i $singa_sshrun " -host " $i &
   fi
 done
 

--- a/include/singa/driver.h
+++ b/include/singa/driver.h
@@ -18,10 +18,11 @@
 * under the License.
 *
 *************************************************************/
-#ifndef SINGA_SINGA_DRIVER_H_
-#define SINGA_SINGA_DRIVER_H_
+#ifndef SINGA_DRIVER_H_
+#define SINGA_DRIVER_H_
 
 #include <vector>
+#include <string>
 #include "singa/proto/job.pb.h"
 #include "singa/proto/singa.pb.h"
 #include "singa/utils/factory.h"
@@ -50,7 +51,7 @@ class Driver {
    * Used for python binding. Users can also directly call it as a C++ API.
    * - init glog with given parameters
    *
-   */   
+   */
   void InitLog(char *arg);
   /**
    * Update job configuration and call Train(const JobProto&) to start the
@@ -74,7 +75,7 @@ class Driver {
    * files.
    * @param[in] str serialized string recorded job configuration.
    */
-  void Train(bool resume, const std::string str); 
+  void Train(bool resume, const std::string str);
   /**
    * Create workers and servers to conduct the training.
    *
@@ -204,6 +205,7 @@ class Driver {
 
  private:
   int job_id_;
+  std::string hostip_;
   JobProto job_conf_;
   SingaProto singa_conf_;
 };
@@ -259,4 +261,4 @@ int Driver::RegisterWorker(const Type& type) {
 
 }  // namespace singa
 
-#endif  // SINGA_SINGA_DRIVER_H_
+#endif  // SINGA_DRIVER_H_

--- a/include/singa/stub.h
+++ b/include/singa/stub.h
@@ -58,8 +58,8 @@ class Stub {
       const std::vector<Worker*>& workers,
       const std::vector<Server*>& servers);
 
-  const std::string& endpoint() const {
-    return endpoint_;
+  void set_router(Router* router) {
+    router_ = router;
   }
 
  protected:
@@ -100,7 +100,6 @@ class Stub {
 
  protected:
   Router *router_ = nullptr;
-  std::string endpoint_;
   std::vector<int> slice2server_;
 };
 

--- a/include/singa/utils/cluster.h
+++ b/include/singa/utils/cluster.h
@@ -7,9 +7,9 @@
 * to you under the Apache License, Version 2.0 (the
 * "License"); you may not use this file except in compliance
 * with the License.  You may obtain a copy of the License at
-* 
+*
 *   http://www.apache.org/licenses/LICENSE-2.0
-* 
+*
 * Unless required by applicable law or agreed to in writing,
 * software distributed under the License is distributed on an
 * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -122,7 +122,6 @@ class Cluster {
   inline int ProcsIDOf(int group_id, int id, int flag) {
     return procs_ids_.at(Hash(group_id, id, flag));
   }
-  inline std::string hostip() const { return hostip_; }
 
   /**
    * @param pid, processs ID
@@ -150,7 +149,6 @@ class Cluster {
 
   int procs_id_ = -1;
   int nprocs_ = 0;
-  std::string hostip_ = "";
   // cluster config proto
   ClusterProto cluster_;
   SingaProto singa_;

--- a/src/stub.cc
+++ b/src/stub.cc
@@ -41,17 +41,6 @@ using std::string;
 Stub::~Stub() {
   delete router_;
 }
-void Stub::Setup() {
-  router_ = new Router();
-  auto cluster = Cluster::Get();
-  if (cluster->nprocs() > 1) {
-    const string hostip = cluster->hostip();
-    int port = router_->Bind("tcp://" + hostip + ":*");
-    endpoint_ = hostip + ":" + std::to_string(port);
-  } else {
-    endpoint_ = "localhost";
-  }
-}
 /**
  * Get a hash id for a Param object from a group.
  *

--- a/src/utils/cluster.cc
+++ b/src/utils/cluster.cc
@@ -85,7 +85,6 @@ void Cluster::Init(int job, const SingaProto& singaConf,
   // cluster_rt_ = new SPClusterRT();
   cluster_rt_ = ClusterRuntime::Create(singa_.zookeeper_host(), job);
   cluster_rt_->Init();
-  hostip_ = GetHostIP();
 }
 
 void Cluster::SetupFolders(const ClusterProto &cluster) {


### PR DESCRIPTION
Minor changes to extend the single node Multi-GPU training to the GPU
cluster scenario.
1. remove gethostip which is not stable (only work for some OS). Now users have to config the hostfile with each line specifying the IP (must be IP) of one node.
2. register process id no matter the running environment.
3. the singa-run.sh has to `source` the '.profile' ('.bashrc' does not wrok) file right before
executing singa, which exports the LD_LIBRARY_PATH for the cudnn and cuda library. There is no problem if singa is compiled without cuda.

To test this feature,
  1. export the path to cudnn and cuda in LD_LIBRARY_PATH in `.profile`
  2. compile with cudnn, cuda and `--enable-dist`.
  3. set the zookeeper url in conf/singa.conf
  4. add the IP of each node in conf/hostfile (must use IP)
  5. set ssh passwd free from the launching node to all other nodes.

The examples/cifar10/cudnn.conf could be updated for testing,
```
nworkers_per_group: 2
nworkers_per_procs: 1
```