### PR TITLE
Singa-157 Change the priority of cudnn library and install libsingagpu.so

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -177,6 +177,8 @@ lib_LTLIBRARIES = libsinga.la $(LTLIBS)
 bin_PROGRAMS = singa singatool $(PROGS)
 pydir = $(CURDIR)/tool/python/singa/
 py_LTLIBRARIES = $(PY_PROGS)
+#gpudir = $(CURDIR)/.libs
+#gpu_LTLIBRARIES = libsingagpu.so 
 
 #lib_LTLIBRARIES = libsinga.la
 libsinga_la_SOURCES = $(PROTO_SRCS) $(SINGA_SRCS)
@@ -185,6 +187,13 @@ libsinga_la_LDFLAGS =
 if LMDB
 libsinga_la_CXXFLAGS += -DUSE_LMDB
 endif
+
+if DCUDNN
+libsinga_la_SOURCES += $(CUDNN_SRCS)
+libsinga_la_CXXFLAGS += $(CUDNN_CFLAGS)
+libsinga_la_LDFLAGS += $(CUDNN_LDFLAGS) $(CUDNN_LIBS)
+endif
+
 if DCUDA
 libsinga_la_SOURCES += $(CUDA_SRCS) $(CUDA_HDRS)
 libsinga_la_CXXFLAGS += $(CUDA_CFLAGS)
@@ -192,11 +201,6 @@ libsinga_la_LDFLAGS += $(CUDA_LDFLAGS) $(CUDA_LIBS) -L./ -lsingagpu -Wl,-rpath=.
 libsinga_la_LIBADD = libsingagpu.so
 endif
 
-if DCUDNN
-libsinga_la_SOURCES += $(CUDNN_SRCS)
-libsinga_la_CXXFLAGS += $(CUDNN_CFLAGS)
-libsinga_la_LDFLAGS += $(CUDNN_LDFLAGS) $(CUDNN_LIBS)
-endif
 if DDIST
 libsinga_la_SOURCES += $(ZOOKEEPER_SRCS)
 libsinga_la_CXXFLAGS += $(DIST_CFLAGS)
@@ -221,6 +225,12 @@ if LMDB
 singa_LDFLAGS += -llmdb
 endif
 
+if DCUDNN
+singa_SOURCES += $(CUDNN_SRCS)
+singa_CXXFLAGS += $(CUDNN_CFLAGS)
+singa_LDFLAGS += $(CUDNN_LDFLAGS) $(CUDNN_LIBS)
+endif
+
 if DCUDA
 singa_SOURCES += $(CUDA_SRCS) $(CUDA_HDRS)
 singa_CXXFLAGS += $(CUDA_CFLAGS)
@@ -231,12 +241,6 @@ if DDIST
 singa_SOURCES += $(ZOOKEEPER_SRCS)
 singa_CXXFLAGS += $(DIST_CFLAGS)
 singa_LDFLAGS += $(DIST_LDFLAGS) $(DIST_LIBS)
-endif
-
-if DCUDNN
-singa_SOURCES += $(CUDNN_SRCS)
-singa_CXXFLAGS += $(CUDNN_CFLAGS)
-singa_LDFLAGS += $(CUDNN_LDFLAGS) $(CUDNN_LIBS)
 endif
 
 if DHDFS
@@ -281,16 +285,16 @@ if LMDB
 singatest_LDFLAGS += -llmdb
 endif
 
-if DCUDA
-singatest_SOURCES += $(CUDA_SRCS) $(CUDA_HDRS)
-singatest_CXXFLAGS += $(CUDA_CFLAGS)
-singatest_LDFLAGS += $(CUDA_LDFLAGS) $(CUDA_LIBS)
-endif
-
 if DCUDNN
 singatest_SOURCES += $(CUDNN_SRCS)
 singatest_CXXFLAGS += $(CUDNN_CFLAGS)
 singatest_LDFLAGS += $(CUDNN_LDFLAGS) $(CUDNN_LIBS)
+endif
+
+if DCUDA
+singatest_SOURCES += $(CUDA_SRCS) $(CUDA_HDRS)
+singatest_CXXFLAGS += $(CUDA_CFLAGS)
+singatest_LDFLAGS += $(CUDA_LDFLAGS) $(CUDA_LIBS)
 endif
 
 if DDIST
@@ -303,14 +307,14 @@ _driver_la_SOURCES = $(PY_SRCS)
 _driver_la_CXXFLAGS = $(DEFAULT_FLAGS) $(MSHADOW_FLAGS) -I$(top_srcdir)/include $(PYFLAGS)
 _driver_la_LDFLAGS = -lsinga -module -shared $(PYLIBS) -avoid-version -rpath $(pydir)
 
-if DCUDA
-_driver_la_CXXFLAGS += $(CUDA_CFLAGS)
-_driver_la_LDFLAGS += $(CUDA_LDFLAGS) $(CUDA_LIBS)
-endif
-
 if DCUDNN
 _driver_la_CXXFLAGS += $(CUDNN_CFLAGS)
 _driver_la_LDFLAGS += $(CUDNN_LDFLAGS) $(CUDNN_LIBS)
+endif
+
+if DCUDA
+_driver_la_CXXFLAGS += $(CUDA_CFLAGS)
+_driver_la_LDFLAGS += $(CUDA_LDFLAGS) $(CUDA_LIBS)
 endif
 
 clean-local:
@@ -329,6 +333,7 @@ all-local:
 		cp -f .libs/_driver.so tool/python/singa/; \
 		touch tool/python/singa/__init__.py; \
 	fi
+	cp libsingagpu.so .libs/
 
 # For rat check
 rat:

--- a/Makefile.am
+++ b/Makefile.am
@@ -333,7 +333,9 @@ all-local:
 		cp -f .libs/_driver.so tool/python/singa/; \
 		touch tool/python/singa/__init__.py; \
 	fi
-	cp libsingagpu.so .libs/
+	@if [ -f "libsingagpu.so" ]; then \
+		cp libsingagpu.so .libs/; \
+	fi
 
 # For rat check
 rat:

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,39 @@ AC_CHECK_LIB([protobuf], [main], [], [
 PROGS=''
 LTLIBS=''
 
+# Setup custom CUDNN paths
+AC_ARG_ENABLE([cudnn],
+    [AS_HELP_STRING(--enable-cudnn,enable CUDNN support)],
+    [enable_cudnn="yes"], [enable_cudnn="no"])
+AM_CONDITIONAL(DCUDNN, [test "$enable_cudnn" = "yes"])
+AC_ARG_WITH([cudnn],
+    [AS_HELP_STRING([--with-cudnn=PATH], [prefix where CUDNN is installed])],
+    [cudnn_prefix=$withval], [cudnn_prefix="/usr/local/cudnn"])
+if test "$cudnn_prefix" == "yes"; then
+    if test "$withval" == "yes"; then
+        cudnn_prefix="/usr/local/cudnn"
+    fi
+fi
+if test x"$enable_cudnn" == x"yes"; then
+    CUDNN_CFLAGS="-I$cudnn_prefix/include"
+    CUDNN_LDFLAGS="-L$cudnn_prefix/lib64 -L$cudnn_prefix/lib"
+    CUDNN_LIBS="-lcudnn"
+    LIBS="$LIBS $CUDNN_LIBS"
+    LDFLAGS="$LDFLAGS $CUDNN_LDFLAGS"
+    DEBUG="-DUSE_CUDNN"
+    AC_DEFINE(DCUDNN,[1],[Defined if CUDNN should be used])
+    AC_CHECK_LIB([cudnn], [main], [], [
+        AC_MSG_ERROR([unable to find cudnn library])
+        ])
+else
+    CUDNN_CFLAGS=""
+    CUDNN_LDFLAGS=""
+    CUDNN_LIBS=""
+fi
+AC_SUBST(CUDNN_CFLAGS)
+AC_SUBST(CUDNN_LDFLAGS)
+AC_SUBST(CUDNN_LIBS)
+
 # Setup custom CUDA paths
 AC_ARG_ENABLE(cuda,
   [AS_HELP_STRING(--enable-cuda,enable CUDA support)],
@@ -86,7 +119,7 @@ if test x"$cudaval" = x"yes"; then
     LDFLAGS="$LDFLAGS $CUDA_LDFLAGS -L./"
     LIBTOOL='LD_LIBRARY_PATH=$(PWD) $(SHELL) $(top_builddir)/libtool'
     NVCC="nvcc"
-  DEBUG="-DUSE_GPU"
+  DEBUG+=" -DUSE_GPU"
     AC_DEFINE(DCUDA,[1],[Defined if CUDA should be used])
   AC_CHECK_LIB([cublas], [main], [], [
      AC_MSG_ERROR([unable to find cuda library])
@@ -110,40 +143,7 @@ AC_SUBST(CUDA_LDFLAGS)
 AC_SUBST(CUDA_LIBS)
 AC_SUBST(CUDA_CFLAGS)
 
-# Setup custom CUDNN paths
-AC_ARG_ENABLE([cudnn],
-    [AS_HELP_STRING(--enable-cudnn,enable CUDNN support)],
-    [enable_cudnn="yes"], [enable_cudnn="no"])
-AM_CONDITIONAL(DCUDNN, [test "$enable_cudnn" = "yes"])
-AC_ARG_WITH([cudnn],
-    [AS_HELP_STRING([--with-cudnn=PATH], [prefix where CUDNN is installed])],
-    [cudnn_prefix=$withval], [cudnn_prefix="/usr/local/cuda"])
-if test "$cudnn_prefix" == "yes"; then
-    if test "$withval" == "yes"; then
-        cudnn_prefix="/usr/local/cuda"
-    fi
-fi
-if test x"$enable_cudnn" == x"yes"; then
-    CUDNN_CFLAGS="-I$cudnn_prefix/include"
-    CUDNN_LDFLAGS="-L$cudnn_prefix/lib64 -L$cudnn_prefix/lib"
-    CUDNN_LIBS="-lcudnn"
-    LIBS="$LIBS $CUDNN_LIBS"
-    LDFLAGS="$LDFLAGS $CUDNN_LDFLAGS"
-    DEBUG+=" -DUSE_CUDNN"
-    AC_DEFINE(DCUDNN,[1],[Defined if CUDNN should be used])
-    AC_CHECK_LIB([cudnn], [main], [], [
-        AC_MSG_ERROR([unable to find cudnn library])
-        ])
-else
-    CUDNN_CFLAGS=""
-    CUDNN_LDFLAGS=""
-    CUDNN_LIBS=""
-fi
-AC_SUBST(CUDNN_CFLAGS)
-AC_SUBST(CUDNN_LDFLAGS)
-AC_SUBST(CUDNN_LIBS)
-
-# Setup custom zookeeper paths 
+# Setup custom zookeeper and zmq paths 
 AC_ARG_ENABLE(dist,
   AS_HELP_STRING([--enable-dist],[enable dist support]),
   [enable_dist="yes"],[enable_dist="no"])

--- a/include/singa/neuralnet/neuron_layer.h
+++ b/include/singa/neuralnet/neuron_layer.h
@@ -478,7 +478,9 @@ class CudnnBMLayer : public BMLayer, public CudnnBase {
   void ComputeFeature(int flag, const vector<Layer*>& srclayers) override;
   void ComputeGradient(int flag, const vector<Layer*>& srclayers) override;
  protected:
+#if CUDNN_MAJOR == 4
   cudnnBatchNormMode_t mode_;
+#endif
   cudnnTensorDescriptor_t bnScaleBiasMeanVar_desc_;
   cudnnTensorDescriptor_t bnScaleBiasDiff_desc_;
   Blob<float> resultSaveMean_;

--- a/include/singa/neuralnet/neuron_layer.h
+++ b/include/singa/neuralnet/neuron_layer.h
@@ -468,8 +468,10 @@ class CudnnSoftmaxLayer : public SoftmaxLayer, public CudnnBase {
   void ComputeGradient(int flag, const vector<Layer*>& srclayers) override;
 };
 
+
+#if CUDNN_MAJOR == 4
 /**
- * Cudnn Batch Normalization layer
+ * Cudnn Batch Normalization layer -- supported by cudnn_v4
  */
 class CudnnBMLayer : public BMLayer, public CudnnBase {
  public:
@@ -478,9 +480,7 @@ class CudnnBMLayer : public BMLayer, public CudnnBase {
   void ComputeFeature(int flag, const vector<Layer*>& srclayers) override;
   void ComputeGradient(int flag, const vector<Layer*>& srclayers) override;
  protected:
-#if CUDNN_MAJOR == 4
   cudnnBatchNormMode_t mode_;
-#endif
   cudnnTensorDescriptor_t bnScaleBiasMeanVar_desc_;
   cudnnTensorDescriptor_t bnScaleBiasDiff_desc_;
   Blob<float> resultSaveMean_;
@@ -488,6 +488,7 @@ class CudnnBMLayer : public BMLayer, public CudnnBase {
   Blob<float> resultRunningMean_;
   Blob<float> resultRunningInvVariance_;
 };
+#endif
 #endif  // USE_CUDNN
 
 /******************** RBM layers *****************/

--- a/src/driver.cc
+++ b/src/driver.cc
@@ -103,7 +103,9 @@ void Driver::Init(int argc, char **argv) {
   RegisterLayer<CudnnLRNLayer, int>(kCudnnLRN);
   RegisterLayer<CudnnSoftmaxLayer, int>(kCudnnSoftmax);
   RegisterLayer<CudnnSoftmaxLossLayer, int>(kCudnnSoftmaxLoss);
+#if CUDNN_MAJOR == 4
   RegisterLayer<CudnnBMLayer, int>(kCudnnBM);
+#endif
 #endif
 
   RegisterLayer<DropoutLayer, int>(kDropout);

--- a/src/neuralnet/neuron_layer/cudnn_bm.cc
+++ b/src/neuralnet/neuron_layer/cudnn_bm.cc
@@ -18,9 +18,9 @@
 * under the License.
 *
 *************************************************************/
-#if CUDNN_MAJOR == 4
 #include "singa/neuralnet/neuron_layer.h"
 
+#if CUDNN_MAJOR == 4
 namespace singa {
 
 CudnnBMLayer::~CudnnBMLayer() {

--- a/src/neuralnet/neuron_layer/cudnn_bm.cc
+++ b/src/neuralnet/neuron_layer/cudnn_bm.cc
@@ -18,7 +18,7 @@
 * under the License.
 *
 *************************************************************/
-
+#if CUDNN_MAJOR == 4
 #include "singa/neuralnet/neuron_layer.h"
 
 namespace singa {
@@ -148,3 +148,4 @@ void CudnnBMLayer::ComputeGradient(int flag,
       resultSaveInvVariance_.gpu_data()));
 }
 }  // namespace singa
+#endif

--- a/tool/docker/singa/Dockerfile_gpu
+++ b/tool/docker/singa/Dockerfile_gpu
@@ -1,3 +1,23 @@
+#/**
+# * Copyright 2015 The Apache Software Foundation
+# *
+# * Licensed to the Apache Software Foundation (ASF) under one
+# * or more contributor license agreements.  See the NOTICE file
+# * distributed with this work for additional information
+# * regarding copyright ownership.  The ASF licenses this file
+# * to you under the Apache License, Version 2.0 (the
+# * "License"); you may not use this file except in compliance
+# * with the License.  You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# */
+
 FROM singa/base
 MAINTAINER NVIDIA CORPORATION <digits@nvidia.com>
 


### PR DESCRIPTION
If the cudnn.h is in cuda/include folder, then the --with-cudnn is invalid as cuda/include is looked up first. We need to change the order of these two paths during compilation. On the other hand, we also need to put libsingagpu.so file into a proper folder to make our scripts runnable.