### PR TITLE
SINGA-187 Add popular parameter initialization methods

### DIFF
--- a/include/singa/model/initializer.h
+++ b/include/singa/model/initializer.h
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SINGA_MODEL_INITIALIZER_H_
+#define SINGA_MODEL_INITIALIZER_H_
+#include <string>
+#include "singa/core/tensor.h"
+#include "singa/proto/model.pb.h"
+namespace singa {
+namespace init {
+/// Base class for initializing parameter values.
+using InitializerConf = FillerConf;
+class Initializer {
+ public:
+  Initializer() = default;
+  void Setup(const std::string& str) {
+    InitializerConf conf;
+    conf.ParseFromString(str);
+    Setup(conf);
+  }
+
+  /// Set meta fields from user configurations.
+  virtual void Setup(const InitializerConf& conf) {}
+
+  virtual void Fill(Tensor* t) = 0;
+};
+
+class Constant : public Initializer {
+public:
+  Constant() = default;
+  Constant(const float x) : v_(x) {}
+  void Setup(const InitializerConf& conf) override { v_ = conf.value(); }
+  void Fill(Tensor* t) override { t->SetValue(v_); }
+
+ private:
+  float v_ = 0;
+};
+
+class Uniform : public Initializer {
+public:
+  Uniform() = default;
+  Uniform(const float low, const float high) : min_(low), max_(high) {}
+  void Setup(const InitializerConf& conf) override {
+    min_ = conf.min();
+    max_ = conf.max();
+  }
+  void Fill(Tensor* t) override { singa::Uniform(min_, max_, t); }
+
+ private:
+  float min_ = 0, max_ = 1;
+};
+
+class Gaussian : public Initializer {
+public:
+  Gaussian() = default;
+  Gaussian(const float m, const float s): mean_(m), std_(s) {}
+  void Setup(const InitializerConf& conf) override {
+    mean_ = conf.mean();
+    std_ = conf.std();
+  }
+  void Fill(Tensor* t) override { singa::Gaussian(mean_, std_, t); }
+
+ private:
+  float mean_ = 0, std_ = 0.01;
+};
+
+/// Ref: [Bengio and Glorot 2010] Understanding the difficulty of training deep
+/// feedforward neural networks
+class Xavier : public Initializer {
+public:
+  void Fill(Tensor* t) override {
+    CHECK_EQ(t->nDim(), 2u);
+    float scale = sqrt(6.0f / (t->shape(0) + t->shape(1)));
+    singa::Uniform(-scale, scale, t);
+  }
+};
+
+/// Ref: [He, Zhang, Ren and Sun 2015]: Delving Deep into Rectifiers:
+/// Surpassing Human-Level Performance on ImageNet Classification
+class MSRA : public Initializer {
+ public:
+  void Fill(Tensor* t) override {
+    CHECK_EQ(t->nDim(), 2u);
+    float std = sqrt(2.0f / t->shape(0));
+    singa::Gaussian(0.0f, std, t);
+  }
+};
+}  // namespace init
+}  // namespace singa
+#endif  // SINGA_MODEL_INITIALIZER_H_

--- a/test/singa/test_initializer.cc
+++ b/test/singa/test_initializer.cc
@@ -1,0 +1,148 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "singa/model/initializer.h"
+#include "gtest/gtest.h"
+
+TEST(Initializer, Constant) {
+  singa::init::Constant x;
+  size_t n = 10;
+  singa::Tensor t(singa::Shape{n});
+  singa::FillerConf conf;
+  conf.set_value(3.1f);
+  x.Setup(conf);
+  x.Fill(&t);
+  const float* xPtr = t.data<const float*>();
+  for (size_t i = 0; i < n; i++)
+    EXPECT_FLOAT_EQ(xPtr[i], 3.1f);
+}
+
+
+TEST(Initializer, Gaussian) {
+  singa::init::Gaussian x;
+  size_t n = 1000;
+  singa::Tensor t(singa::Shape{n});
+  singa::FillerConf conf;
+  conf.set_mean(0.11f);
+  conf.set_std(0.01f);
+  x.Setup(conf);
+  x.Fill(&t);
+  const float* xPtr = t.data<const float*>();
+  float mean = 0.0f, std = 0.0f;
+  for (size_t i = 0; i < n; i++)
+    mean += xPtr[i];
+  mean /= n;
+  EXPECT_NEAR(mean, 0.11f, 1e-3);
+  for (size_t i = 0; i < n; i++)
+    std += (xPtr[i] - mean) * (xPtr[i] - mean);
+  std /= n;
+  std = sqrt(std);
+  EXPECT_NEAR(std, 0.01f, 1e-3);
+}
+
+#ifdef USE_CUDA
+TEST(Initializer, ConstantCUDA) {
+  singa::init::Constant x;
+  singa::CudaGPU dev;
+  size_t n = 10;
+  singa::Tensor t(singa::Shape{n}, &dev);
+  singa::FillerConf conf;
+  conf.set_value(3.1f);
+  x.Setup(conf);
+  x.Fill(&t);
+  t.ToHost();
+  const float* xPtr = t.data<const float*>();
+  for (size_t i = 0; i < n; i++)
+    EXPECT_FLOAT_EQ(xPtr[i], 3.1f);
+
+
+  singa::init::Constant y(-0.1f);
+  singa::Tensor s(singa::Shape{n}, &dev);
+  y.Fill(&s);
+  s.ToHost();
+  const float* sPtr = s.data<const float*>();
+  for (size_t i = 0; i < n; i++)
+    EXPECT_FLOAT_EQ(sPtr[i], -0.1f);
+}
+
+
+TEST(Initializer, GaussianCUDA) {
+  singa::init::Gaussian x;
+  singa::CudaGPU dev;
+  size_t n = 1000;
+  singa::Tensor t(singa::Shape{n}, &dev);
+  singa::FillerConf conf;
+  conf.set_mean(0.11f);
+  conf.set_std(0.01f);
+  x.Setup(conf);
+  x.Fill(&t);
+  t.ToHost();
+  const float* tPtr = t.data<const float*>();
+  float mean = 0.0f, std = 0.0f;
+  for (size_t i = 0; i < n; i++)
+    mean += tPtr[i];
+  mean /= n;
+  EXPECT_NEAR(mean, 0.11f, 1e-2);
+  for (size_t i = 0; i < n; i++)
+    std += (tPtr[i] - mean) * (tPtr[i] - mean);
+  std /= n;
+  std = sqrt(std);
+  EXPECT_NEAR(std, 0.01f, 1e-2);
+
+
+  singa::init::Gaussian y(1.5f, 0.1f);
+  singa::Tensor s(singa::Shape{n}, &dev);
+  y.Fill(&s);
+  s.ToHost();
+  const float* sPtr = s.data<const float*>();
+  for (size_t i = 0; i < n; i++)
+    mean += sPtr[i];
+  mean /= n;
+  EXPECT_NEAR(mean, 1.5f, 0.1f);
+  for (size_t i = 0; i < n; i++)
+    std += (sPtr[i] - mean) * (sPtr[i] - mean);
+  std /= n;
+  std = sqrt(std);
+  EXPECT_NEAR(std, 0.1f, 0.1f);
+}
+
+TEST(Initializer, XavierCUDA) {
+  singa::init::Constant x;
+  singa::CudaGPU dev;
+  size_t m = 30, n=40;
+  singa::Tensor t(singa::Shape{m, n}, &dev);
+  x.Fill(&t);
+  t.ToHost();
+  const float* xPtr = t.data<const float*>();
+  float mean = 0.0f;
+  float high = -100.0f, low = 100.0f;
+  for (size_t i = 0; i < n; i++) {
+    mean += xPtr[i];
+    if (high < xPtr[i])
+      high = xPtr[i];
+    if (low > xPtr[i])
+      low = xPtr[i];
+  }
+  mean /= m * n;
+  EXPECT_NEAR(mean, 0, 1e-2);
+  float scale = sqrt(6.0f / (m + n));
+  EXPECT_LT(high, scale);
+  EXPECT_GT(low, -scale);
+}
+
+#endif


### PR DESCRIPTION
5 initialization methods are added, namely, constant, uniform, gaussian,
Xavier (also called glorot) and MSRA.

We use the same config fields as Caffe, hence we simply rename Caffe's protobuf
message to FillerConf. The base class is singa::init::Initializer. To
avoid name conflicts with Uniform and Gaussian methods, we enclose them
into the namespace init. May consider rename them later.