### PR TITLE
SINGA-214 Add LMDBReader and LMDBWriter for LMDB

### DIFF
--- a/src/io/lmdb_reader.cc
+++ b/src/io/lmdb_reader.cc
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "singa/io/reader.h"
+#include "singa/utils/logging.h"
+#ifdef USE_LMDB
+
+namespace singa {
+namespace io {
+bool LMDBReader::Open(const std::string& path) {
+  path_ = path;
+  MDB_CHECK(mdb_env_create(&mdb_env_));
+  int flags = MDB_RDONLY | MDB_NOTLS;
+  int rc = mdb_env_open(mdb_env_, path_.c_str(), flags, 0664);
+#ifndef ALLOW_LMDB_NOLOCK
+  MDB_CHECK(rc);
+#else
+  if (rc == EACCES) {
+    LOG(WARNING) << "Permission denied. Trying with MDB_NOLOCK ...";
+    // Close and re-open environment handle
+    mdb_env_close(mdb_env_);
+    MDB_CHECK(mdb_env_create(&mdb_env_));
+    // Try again with MDB_NOLOCK
+    flags |= MDB_NOLOCK;
+    MDB_CHECK(mdb_env_open(mdb_env_, source.c_str(), flags, 0664));
+  } else {
+    MDB_CHECK(rc);
+  }
+#endif
+  MDB_CHECK(mdb_txn_begin(mdb_env_, NULL, MDB_RDONLY, &mdb_txn_));
+  MDB_CHECK(mdb_dbi_open(mdb_txn_, NULL, 0, &mdb_dbi_));
+  MDB_CHECK(mdb_cursor_open(mdb_txn_, mdb_dbi_, &mdb_cursor_));
+  SeekToFirst();
+  return true;
+}
+
+void LMDBReader::Close() {
+  if (mdb_env_ != nullptr) {
+    mdb_cursor_close(mdb_cursor_);
+    mdb_txn_abort(mdb_txn_);
+    mdb_dbi_close(mdb_env_, mdb_dbi_);
+    mdb_env_close(mdb_env_);
+    mdb_env_ = nullptr;
+    mdb_txn_ = nullptr;
+    mdb_cursor_ = nullptr;
+  }
+}
+
+bool LMDBReader::Read(std::string* key, std::string* value) {
+  if (first_ != true)
+    Seek(MDB_NEXT);
+  if (valid_ == false) return false;
+  *key = string(static_cast<const char*>(mdb_key_.mv_data), mdb_key_.mv_size);
+  *value =
+      string(static_cast<const char*>(mdb_value_.mv_data), mdb_value_.mv_size);
+  first_ = false;
+  return true;
+}
+
+int LMDBReader::Count() {
+  MDB_env* env;
+  MDB_dbi dbi;
+  MDB_txn* txn;
+  MDB_cursor* cursor;
+  int flags = MDB_RDONLY | MDB_NOTLS | MDB_NOLOCK;
+  MDB_CHECK(mdb_env_create(&env));
+  MDB_CHECK(mdb_env_open(env, path_.c_str(), flags, 0664));
+  MDB_CHECK(mdb_txn_begin(env, NULL, MDB_RDONLY, &txn));
+  MDB_CHECK(mdb_dbi_open(txn, NULL, 0, &dbi));
+  MDB_CHECK(mdb_cursor_open(txn, dbi, &cursor));
+  int status = MDB_SUCCESS;
+  int count = 0;
+  MDB_val key, value;
+  while (true) {
+    status = mdb_cursor_get(cursor, &key, &value, MDB_NEXT);
+    if (status == MDB_NOTFOUND) break;
+    count++;
+  }
+  mdb_cursor_close(cursor);
+  mdb_txn_abort(txn);
+  mdb_dbi_close(env, dbi);
+  mdb_env_close(env);
+  return count;
+}
+
+void LMDBReader::SeekToFirst() { Seek(MDB_FIRST); first_ = true; }
+
+void LMDBReader::Seek(MDB_cursor_op op) {
+  int mdb_status = mdb_cursor_get(mdb_cursor_, &mdb_key_, &mdb_value_, op);
+  if (mdb_status == MDB_NOTFOUND) {
+    valid_ = false;
+  } else {
+    MDB_CHECK(mdb_status);
+    valid_ = true;
+  }
+}
+
+inline void LMDBReader::MDB_CHECK(int mdb_status) {
+  CHECK_EQ(mdb_status, MDB_SUCCESS) << mdb_strerror(mdb_status);
+}
+}  // namespace io
+}  // namespace singa
+#endif  // USE_LMDB

--- a/src/io/lmdb_writer.cc
+++ b/src/io/lmdb_writer.cc
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "singa/io/writer.h"
+#include "singa/utils/logging.h"
+#ifdef USE_LMDB
+
+namespace singa {
+namespace io {
+bool LMDBWriter::Open(const std::string& path, Mode mode) {
+  path_ = path;
+  mode_ = mode;
+  MDB_CHECK(mdb_env_create(&mdb_env_));
+  if (mode_ != kCreate && mode_ != kAppend) {
+    LOG(FATAL) << "unknown mode to open LMDB" << mode_;
+    return false;
+  }
+  if (mode_ == kCreate)
+    // It will fail if there is a dir at "path"
+    CHECK_EQ(mkdir(path.c_str(), 0744), 0) << "mkdir " << path << " failed";
+  int flags = 0;
+  int rc = mdb_env_open(mdb_env_, path.c_str(), flags, 0664);
+#ifndef ALLOW_LMDB_NOLOCK
+  MDB_CHECK(rc);
+#else
+  if (rc == EACCES) {
+    LOG(WARNING) << "Permission denied. Trying with MDB_NOLOCK ...";
+    // Close and re-open environment handle
+    mdb_env_close(mdb_env_);
+    MDB_CHECK(mdb_env_create(&mdb_env_));
+    // Try again with MDB_NOLOCK
+    flags |= MDB_NOLOCK;
+    MDB_CHECK(mdb_env_open(mdb_env_, path.c_str(), flags, 0664));
+  } else
+    MDB_CHECK(rc);
+#endif
+  return true;
+}
+
+void LMDBWriter::Close() {
+  Flush();
+  if (mdb_env_ != nullptr) {
+    mdb_env_close(mdb_env_);
+    mdb_env_ = nullptr;
+  }
+}
+
+bool LMDBWriter::Write(const std::string& key, const std::string& value) {
+  CHECK_NE(key, "") << "Key is an empty string!";
+  keys.push_back(key);
+  values.push_back(value);
+  return true;
+}
+
+// Flush is to "commit to DB"
+void LMDBWriter::Flush() {
+  if (keys.size() == 0) return;
+  MDB_dbi mdb_dbi;
+  MDB_val mdb_key, mdb_data;
+  MDB_txn* mdb_txn;
+
+  // Initialize MDB variables
+  MDB_CHECK(mdb_txn_begin(mdb_env_, NULL, 0, &mdb_txn));
+  MDB_CHECK(mdb_dbi_open(mdb_txn, NULL, 0, &mdb_dbi));
+
+  for (size_t i = 0; i < keys.size(); i++) {
+    mdb_key.mv_size = keys[i].size();
+    mdb_key.mv_data = const_cast<char*>(keys[i].data());
+    mdb_data.mv_size = values[i].size();
+    mdb_data.mv_data = const_cast<char*>(values[i].data());
+
+    // Add data to the transaction
+    int put_rc = mdb_put(mdb_txn, mdb_dbi, &mdb_key, &mdb_data, 0);
+    CHECK_NE(put_rc, MDB_KEYEXIST) << "Key already exist: " << keys[i];
+    if (put_rc == MDB_MAP_FULL) {
+      // Out of memory - double the map size and retry
+      mdb_txn_abort(mdb_txn);
+      mdb_dbi_close(mdb_env_, mdb_dbi);
+      DoubleMapSize();
+      Flush();
+      return;
+    }
+    // May have failed for some other reason
+    MDB_CHECK(put_rc);
+  }
+
+  // Commit the transaction
+  int commit_rc = mdb_txn_commit(mdb_txn);
+  if (commit_rc == MDB_MAP_FULL) {
+    // Out of memory - double the map size and retry
+    mdb_dbi_close(mdb_env_, mdb_dbi);
+    DoubleMapSize();
+    Flush();
+    return;
+  }
+  // May have failed for some other reason
+  MDB_CHECK(commit_rc);
+
+  // Cleanup after successful commit
+  mdb_dbi_close(mdb_env_, mdb_dbi);
+  keys.clear();
+  values.clear();
+}
+
+void LMDBWriter::DoubleMapSize() {
+  struct MDB_envinfo current_info;
+  MDB_CHECK(mdb_env_info(mdb_env_, &current_info));
+  size_t new_size = current_info.me_mapsize * 2;
+  LOG(INFO) << "Doubling LMDB map size to " << (new_size >> 20) << "MB ...";
+  MDB_CHECK(mdb_env_set_mapsize(mdb_env_, new_size));
+}
+
+inline void LMDBWriter::MDB_CHECK(int mdb_status) {
+  CHECK_EQ(mdb_status, MDB_SUCCESS) << mdb_strerror(mdb_status);
+}
+}  // namespace io
+}  // namespace singa
+#endif  // USE_LMDB

--- a/src/io/textfile_reader.cc
+++ b/src/io/textfile_reader.cc
@@ -59,5 +59,11 @@ int TextFileReader::Count() {
   return count;
 }
 
+void TextFileReader::SeekToFirst() {
+  CHECK(fdat_ != nullptr);
+  lineNo_ = 0;
+  fdat_.clear();
+  fdat_.seekg(0);
+}
 }  // namespace io
 }  // namespace singa

--- a/test/singa/test_lmdb_rw.cc
+++ b/test/singa/test_lmdb_rw.cc
@@ -22,41 +22,24 @@
 #include "../include/singa/io/reader.h"
 #include "../include/singa/io/writer.h"
 #include "gtest/gtest.h"
+#ifdef USE_LMDB
 
-const char* path_bin = "./binfile_test";
-using singa::io::BinFileReader;
-using singa::io::BinFileWriter;
-TEST(BinFileWriter, Create) {
-  BinFileWriter writer;
+const char* path_lmdb = "./test_lmdb";
+using singa::io::LMDBReader;
+using singa::io::LMDBWriter;
+TEST(LMDBWriter, Create) {
+  LMDBWriter writer;
   bool ret;
-  ret = writer.Open(path_bin, singa::io::kCreate);
-  EXPECT_EQ(true, ret);
-
-  std::string key = "";
-  std::string value = "\nThis is a test for binfile io.";
-  ret = writer.Write(key, value);
-  EXPECT_EQ(true, ret);
-
-  ret = writer.Write(key, value);
-  EXPECT_EQ(true, ret);
-
-  writer.Flush();
-  writer.Close();
-}
-
-TEST(BinFileWriter, Append) {
-  BinFileWriter writer;
-  bool ret;
-  ret = writer.Open(path_bin, singa::io::kAppend, 20971520);
+  ret = writer.Open(path_lmdb, singa::io::kCreate);
   EXPECT_EQ(true, ret);
 
   std::string key = "1";
-  std::string value = "\nThis is another test for binfile io.";
+  std::string value = "This is the first test for lmdb io.";
   ret = writer.Write(key, value);
   EXPECT_EQ(true, ret);
 
   key = "2";
-  value = "\nThis is another test for binfile io.";
+  value = "This is the second test for lmdb io.";
   ret = writer.Write(key, value);
   EXPECT_EQ(true, ret);
 
@@ -64,10 +47,30 @@ TEST(BinFileWriter, Append) {
   writer.Close();
 }
 
-TEST(BinFileReader, Read) {
-  BinFileReader reader;
+TEST(LMDBWriter, Append) {
+  LMDBWriter writer;
   bool ret;
-  ret = reader.Open(path_bin);
+  ret = writer.Open(path_lmdb, singa::io::kAppend);
+  EXPECT_EQ(true, ret);
+
+  std::string key = "3";
+  std::string value = "This is the third test for lmdb io.";
+  ret = writer.Write(key, value);
+  EXPECT_EQ(true, ret);
+
+  key = "4";
+  value = "This is the fourth test for lmdb io.";
+  ret = writer.Write(key, value);
+  EXPECT_EQ(true, ret);
+
+  writer.Flush();
+  writer.Close();
+}
+
+TEST(LMDBReader, Read) {
+  LMDBReader reader;
+  bool ret;
+  ret = reader.Open(path_lmdb);
   EXPECT_EQ(true, ret);
 
   int cnt = reader.Count();
@@ -75,28 +78,28 @@ TEST(BinFileReader, Read) {
 
   std::string key, value;
   reader.Read(&key, &value);
-  EXPECT_STREQ("", key.c_str());
-  EXPECT_STREQ("\nThis is a test for binfile io.", value.c_str());
-
-  reader.Read(&key, &value);
-  EXPECT_STREQ("", key.c_str());
-  EXPECT_STREQ("\nThis is a test for binfile io.", value.c_str());
-
-  reader.Read(&key, &value);
   EXPECT_STREQ("1", key.c_str());
-  EXPECT_STREQ("\nThis is another test for binfile io.", value.c_str());
+  EXPECT_STREQ("This is the first test for lmdb io.", value.c_str());
 
   reader.Read(&key, &value);
   EXPECT_STREQ("2", key.c_str());
-  EXPECT_STREQ("\nThis is another test for binfile io.", value.c_str());
+  EXPECT_STREQ("This is the second test for lmdb io.", value.c_str());
+
+  reader.Read(&key, &value);
+  EXPECT_STREQ("3", key.c_str());
+  EXPECT_STREQ("This is the third test for lmdb io.", value.c_str());
+
+  reader.Read(&key, &value);
+  EXPECT_STREQ("4", key.c_str());
+  EXPECT_STREQ("This is the fourth test for lmdb io.", value.c_str());
 
   reader.Close();
 }
 
-TEST(BinFileReader, SeekToFirst) {
-  BinFileReader reader;
+TEST(LMDBReader, SeekToFirst) {
+  LMDBReader reader;
   bool ret;
-  ret = reader.Open(path_bin);
+  ret = reader.Open(path_lmdb);
   EXPECT_EQ(true, ret);
 
   int cnt = reader.Count();
@@ -104,30 +107,30 @@ TEST(BinFileReader, SeekToFirst) {
 
   std::string key, value;
   reader.Read(&key, &value);
-  EXPECT_STREQ("", key.c_str());
-  EXPECT_STREQ("\nThis is a test for binfile io.", value.c_str());
+  EXPECT_STREQ("1", key.c_str());
+  EXPECT_STREQ("This is the first test for lmdb io.", value.c_str());
 
   reader.Read(&key, &value);
-  EXPECT_STREQ("", key.c_str());
-  EXPECT_STREQ("\nThis is a test for binfile io.", value.c_str());
+  EXPECT_STREQ("2", key.c_str());
+  EXPECT_STREQ("This is the second test for lmdb io.", value.c_str());
 
   reader.SeekToFirst();
   reader.Read(&key, &value);
-  EXPECT_STREQ("", key.c_str());
-  EXPECT_STREQ("\nThis is a test for binfile io.", value.c_str());
-
-  reader.Read(&key, &value);
-  EXPECT_STREQ("", key.c_str());
-  EXPECT_STREQ("\nThis is a test for binfile io.", value.c_str());
-
-  reader.Read(&key, &value);
   EXPECT_STREQ("1", key.c_str());
-  EXPECT_STREQ("\nThis is another test for binfile io.", value.c_str());
+  EXPECT_STREQ("This is the first test for lmdb io.", value.c_str());
 
   reader.Read(&key, &value);
   EXPECT_STREQ("2", key.c_str());
-  EXPECT_STREQ("\nThis is another test for binfile io.", value.c_str());
+  EXPECT_STREQ("This is the second test for lmdb io.", value.c_str());
+
+  reader.Read(&key, &value);
+  EXPECT_STREQ("3", key.c_str());
+  EXPECT_STREQ("This is the third test for lmdb io.", value.c_str());
+
+  reader.Read(&key, &value);
+  EXPECT_STREQ("4", key.c_str());
+  EXPECT_STREQ("This is the fourth test for lmdb io.", value.c_str());
 
   reader.Close();
-  remove(path_bin);
 }
+#endif  // USE_LMDB

--- a/test/singa/test_textfile_rw.cc
+++ b/test/singa/test_textfile_rw.cc
@@ -63,6 +63,7 @@ TEST(TextFileWriter, Append) {
   writer.Flush();
   writer.Close();
 }
+
 TEST(TextFileReader, Read) {
   TextFileReader reader;
   bool ret;
@@ -73,6 +74,44 @@ TEST(TextFileReader, Read) {
   EXPECT_EQ(4, cnt);
 
   std::string key, value;
+  reader.Read(&key, &value);
+  EXPECT_STREQ("0", key.c_str());
+  EXPECT_STREQ("This is a test for binfile io.", value.c_str());
+
+  reader.Read(&key, &value);
+  EXPECT_STREQ("1", key.c_str());
+  EXPECT_STREQ("This is a test for binfile io.", value.c_str());
+
+  reader.Read(&key, &value);
+  EXPECT_STREQ("2", key.c_str());
+  EXPECT_STREQ("This is another test for binfile io.", value.c_str());
+
+  reader.Read(&key, &value);
+  EXPECT_STREQ("3", key.c_str());
+  EXPECT_STREQ("This is another test for binfile io.", value.c_str());
+
+  reader.Close();
+}
+
+TEST(TextFileReader, SeekToFirst) {
+  TextFileReader reader;
+  bool ret;
+  ret = reader.Open(path_csv);
+  EXPECT_EQ(true, ret);
+
+  int cnt = reader.Count();
+  EXPECT_EQ(4, cnt);
+
+  std::string key, value;
+  reader.Read(&key, &value);
+  EXPECT_STREQ("0", key.c_str());
+  EXPECT_STREQ("This is a test for binfile io.", value.c_str());
+
+  reader.Read(&key, &value);
+  EXPECT_STREQ("1", key.c_str());
+  EXPECT_STREQ("This is a test for binfile io.", value.c_str());
+
+  reader.SeekToFirst();
   reader.Read(&key, &value);
   EXPECT_STREQ("0", key.c_str());
   EXPECT_STREQ("This is a test for binfile io.", value.c_str());


### PR DESCRIPTION
Add LMDBReader and LMDBWriter for LMDB. The classes are modified from db_lmdb.cpp and db_lmdb.hpp in Caffe.
Need to swith "USE_LMDB" ON when using these two classes.

Todo: LMDB does not support checking empty and duplicate keys, may support by us later.