### PR TITLE
SINGA-252 Use the snapshot methods to dump and load models for pysinga

### DIFF
--- a/examples/cifar10/predict.py
+++ b/examples/cifar10/predict.py
@@ -81,7 +81,7 @@ def compute_image_mean(train_dir):
 
 if __name__ == '__main__':
     model = alexnet.create_net(True)
-    model.load('model.bin')  # the checkpoint from train.py
+    model.load('model', 20)  # the checkpoint from train.py
     dev = device.get_default_device()
     model.to_device(dev)
 

--- a/examples/cifar10/train.py
+++ b/examples/cifar10/train.py
@@ -156,7 +156,7 @@ def train(data, net, max_epoch, get_lr, weight_decay, batch_size=100,
 
         print 'test loss = %f, test accuracy = %f' \
             % (loss / num_test_batch, acc / num_test_batch)
-    net.save('model.bin')  # save model params into checkpoint file
+    net.save('model', 20)  # save model params into checkpoint file
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Train vgg/alexnet for cifar10')

--- a/python/singa/snapshot.py
+++ b/python/singa/snapshot.py
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# =============================================================================
+'''
+This script includes io::snapshot class and its methods.
+
+'''
+
+from . import singa_wrap as singa
+import tensor
+
+class Snapshot(object):
+    ''' Class and member functions for singa::Snapshot.
+
+    '''
+    def __init__(self, f, mode, buffer_size = 10):
+        '''Snapshot constructor given file name and R/W mode.
+
+        Args:
+            file (string): snapshot file name.
+            mode (boolean): True for write, False for read
+            buffer_size (int): Buffer size (in MB), default is 10
+        '''
+        self.snapshot = singa.Snapshot(f, mode, buffer_size)
+    
+    def write(self, param_name, param_val):
+        '''Call Write method to write a parameter
+
+        Args:
+            param_name (string): name of the parameter
+            param_val (Tensor): value tensor of the parameter
+        '''
+        self.snapshot.Write(str(param_name), param_val.singa_tensor)
+    def read(self):
+        '''Call read method to load all (param_name, param_val)
+
+        Returns:
+            a dict of (parameter name, parameter Tensor)
+        '''
+        params = {}
+        p = self.snapshot.Read();
+        for (param_name, param_val) in p:
+            print param_name
+            params[param_name] = tensor.from_raw_tensor(param_val)
+        return params

--- a/src/api/io_snapshot.i
+++ b/src/api/io_snapshot.i
@@ -21,12 +21,26 @@
 
 /*interface file for swig */
 
-%module singa_wrap
-%include "config.i"
-%include "core_tensor.i"
-%include "core_device.i"
-%include "model_layer.i"
-%include "model_optimizer.i"
-%include "model_loss.i"
-%include "model_metric.i"
-%include "io_snapshot.i"
+%module io_snapshot
+
+%{
+#include "singa/io/snapshot.h"
+%}
+
+namespace std{
+%template(nametensorPair) std::pair<string, singa::Tensor>;
+%template(nametensorVec) std::vector<std::pair<string, singa::Tensor>>;
+}
+
+namespace singa {
+
+class Snapshot {
+ public:
+  enum Mode { kRead, kWrite };
+  Snapshot(const std::string& prefix, Mode mode, int max_param_size = 10);
+  ~Snapshot() {}
+  std::vector<std::pair<std::string, Tensor>> Read();
+  void Write(const std::string& key, const Tensor& param);
+};
+
+}

--- a/src/proto/core.proto
+++ b/src/proto/core.proto
@@ -71,8 +71,8 @@ message TensorProto {
   repeated uint32 shape = 1;
   optional DataType data_type = 2;
   optional bool transpose = 3;
-  repeated float float_data = 4;
-  repeated double double_data = 5;
-  repeated int32 int_data = 6;
+  repeated float float_data = 4 [packed = true];
+  repeated double double_data = 5 [packed = true];
+  repeated int32 int_data = 6 [packed = true];
   repeated bytes bytes_data = 7;
 }


### PR DESCRIPTION
Use the snapshot methods to dump and load models for pysinga to make the
model checkpoint slimmer.

Previously we use Pickle to checkpoint in pysinga, which make the
model checkpoints heavier than using io/snapshot which leveraging
protobuf to serialize parameters of models.