### PR TITLE
SINGA-264 Extend the FeedForwardNet to accept multiple inputs

### DIFF
--- a/src/api/model_layer.i
+++ b/src/api/model_layer.i
@@ -70,12 +70,8 @@ class Layer {
     virtual void ToDevice(std::shared_ptr<Device> device);
     virtual void AsType(DataType dtype);
     virtual const Tensor Forward(int flag, const Tensor& input);
-    virtual const std::vector<Tensor> Forward(
-        int flag, const std::vector<Tensor>& inputs);
     virtual const std::pair<Tensor, std::vector<Tensor>> Backward(
         int flag, const Tensor& grad);
-    virtual const std::pair<std::vector<Tensor>, std::vector<Tensor>>
-    Backward(int flag, const vector<Tensor>& grads);
 };
 
 std::shared_ptr<Layer> CreateLayer(const std::string& type);

--- a/test/python/run.py
+++ b/test/python/run.py
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+loader = unittest.TestLoader()
+tests = loader.discover('.')
+testRunner = unittest.runner.TextTestRunner()
+testRunner.run(tests)

--- a/test/python/test_net.py
+++ b/test/python/test_net.py
@@ -1,0 +1,77 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+import math
+import numpy as np
+
+from singa import net
+from singa import layer
+from singa import tensor
+from singa import loss
+
+layer.engine = 'singacpp'
+# net.verbose = True
+
+class TestFeedForwardNet(unittest.TestCase):
+
+    def test_single_input_output(self):
+        ffn = net.FeedForwardNet(loss.SoftmaxCrossEntropy())
+        ffn.add(layer.Activation('relu1', input_sample_shape=(2,)))
+        ffn.add(layer.Activation('relu2'))
+        x = np.array([[-1, 1], [1, 1], [-1, -2]], dtype=np.float32)
+        x = tensor.from_numpy(x)
+        y = tensor.Tensor((3,))
+        y.set_value(0)
+        out, _ = ffn.evaluate(x, y)
+        self.assertAlmostEqual(out * 3,
+                - math.log(1.0/(1+math.exp(1))) - math.log(0.5) -math.log(0.5),
+                5);
+
+    def test_mult_inputs(self):
+        ffn = net.FeedForwardNet(loss.SoftmaxCrossEntropy())
+        s1 = ffn.add(layer.Activation('relu1', input_sample_shape=(2,)), [])
+        s2 = ffn.add(layer.Activation('relu2', input_sample_shape=(2,)), [])
+        ffn.add(layer.Merge('merge', input_sample_shape=(2,)), [s1, s2])
+        x1 = tensor.Tensor((2, 2))
+        x1.set_value(1.1)
+        x2 = tensor.Tensor((2, 2))
+        x2.set_value(0.9)
+        out = ffn.forward(False, {'relu1':x1, 'relu2':x2})
+        out = tensor.to_numpy(out)
+        self.assertAlmostEqual(np.average(out), 2)
+
+    def test_mult_outputs(self):
+        ffn = net.FeedForwardNet(loss.SoftmaxCrossEntropy())
+        s1 = ffn.add(layer.Activation('relu1', input_sample_shape=(2,)), [])
+        s2 = ffn.add(layer.Activation('relu2', input_sample_shape=(2,)), [])
+        ffn.add(layer.Merge('merge', input_sample_shape=(2,)), [s1, s2])
+        split = ffn.add(layer.Split('split', 2))
+        ffn.add(layer.Dummy('split1'), split)
+        ffn.add(layer.Dummy('split2'), split)
+        x1 = tensor.Tensor((2, 2))
+        x1.set_value(1.1)
+        x2 = tensor.Tensor((2, 2))
+        x2.set_value(0.9)
+        out = ffn.forward(False, {'relu1':x1, 'relu2':x2})
+        out = tensor.to_numpy(out['split1'])
+        self.assertAlmostEqual(np.average(out), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Extend FeedForwardNet to support multiple input tensors and output tensors.
The input variable x, of train(x, y), forward(x), predict(x), evaluate(x)
could be a single tensor or a dictionary: layer name -> a single tensor or tensor list.
The key is the name of the layer to feed the input data.

The output of out=forward(x, output), would be a single tensor or a dictionary:
layer name -> a single tensor or a tensor list. The key is the name of
the layer to get the output values, e.g, the net has multiple layers
whose outgoing degree is 0. By configuring the argument
'output' as a list of layer names, we can get values of those layers in
'out'.

Passed unittests.