### PR TITLE
SINGA-275 - Add Cross Entropy Loss for multiple labels

### DIFF
--- a/include/singa/core/tensor.h
+++ b/include/singa/core/tensor.h
@@ -440,8 +440,13 @@ void Mult(const SType alpha, const Tensor &A, const Tensor &B, const SType beta,
 // Misc.
 // ****************
 /// Compute the cross entropy loss given the prediction probability 'p' and
-/// the target (ground truth) labels 't'. 'p' and 't' are either 1-d vector
-/// or 2-d matrix. 'loss' is 1-d vector. The loss is computed into p.
+/// the target (ground truth) labels 't'. 'p' could be either a 1-d vector for
+/// a single instance or a 2-d matrix for a batch of instances. t[i]
+/// could be the ground truth label index or a label weighted
+/// array of the i-th instance. For example, if there are 3 candidate labels for
+/// each instance, t[i] could be 2 or [0, 0, 1]. If one instance could have
+/// multiple labels, then t[i] could be [1, 0, 1].
+/// The loss is computed into p.
 void ComputeCrossEntropy(const Tensor &p, const Tensor &t, Tensor *loss);
 /// Compute the dx, given prediction probability 'p' (p=softmax(x)) and
 /// the target (ground truth) labels 't'. 'p' and 't' are either 1-d vector

--- a/include/singa/model/loss.h
+++ b/include/singa/model/loss.h
@@ -66,7 +66,8 @@ class MSE : public Loss {
   /// and the target, which is 0.5/||prediction-target||^2
   /// Users can call Average(const Tensor&) to get the average
   /// loss value over all samples in the batch.
-  Tensor Forward(int flag, const Tensor& prediction, const Tensor& target) override;
+  Tensor Forward(int flag, const Tensor& prediction,
+      const Tensor& target) override;
 
   /// Compute the gradients of the loss values w.r.t. the prediction,
   /// which is (prediction-target)/batchsize
@@ -83,16 +84,23 @@ class MSE : public Loss {
 class SoftmaxCrossEntropy : public Loss {
  public:
   /// Compute the loss values for each sample/instance given the prediction
-  /// and the target, which is -log(p[idx_truth]), idx_truth is the truth
-  /// category's index and p[] is the probability for each category, computed
-  /// from Softmax(prediction).
+  /// and the target.
+  ///
+  /// If the target consists one integer per instance, i.e. the label index
+  /// (dentoed as idx_truth), the loss is -log(p[idx_truth]), p[] is the
+  /// probability for each category, computed from Softmax(prediction).
+  /// If the target consists one array per instance (e.g., for multiple
+  /// labels), the loss is -\sum_i (t[i] * log(p[i]) / \sum_j t[j], t[i]
+  /// is the weight of the i-th label (e.g., 1: the instance has this label, 0:
+  /// the instance does not have this label).
+  ///
   /// Users can call Average(const Tensor&) to get the average
   /// loss value over all samples in the batch.
-  Tensor Forward(int flag, const Tensor& prediction, const Tensor& target) override;
+  Tensor Forward(int flag, const Tensor& prediction,
+      const Tensor& target) override;
 
   /// Compute the gradients of the loss values w.r.t. the prediction,
-  /// which is: p[idx] - 1 if idx is the truth category's index; else,
-  /// p[idx]
+  /// which is: p[i] - t[i]/\sum_j t[j]
   Tensor Backward() override;
 
  private:

--- a/python/singa/layer.py
+++ b/python/singa/layer.py
@@ -814,7 +814,10 @@ class Concat(Layer):
         self.in_shapes = input_sample_shapes
         self.axis = axis
         self.conf.concat_conf.axis = axis
-        self.layer = _create_layer(engine, 'Concat')
+	if engine == "cudnn":
+            self.layer = _create_layer('singacuda', 'Concat')
+        else:
+            self.layer = _create_layer(engine, 'Concat')
         if input_sample_shapes is not None:
             self.setup(input_sample_shapes)
 
@@ -836,7 +839,10 @@ class Slice(Layer):
         self.axis = axis
         self.conf.slice_conf.axis = axis
         self.conf.slice_conf.slice_point.extend(slice_point)
-        self.layer = _create_layer(engine, 'Slice')
+	if engine == "cudnn":
+            self.layer = _create_layer('singacuda', 'Slice')
+        else:
+            self.layer = _create_layer(engine, 'Slice')
         if input_sample_shape is not None:
             self.setup(input_sample_shape)
 

--- a/python/singa/loss.py
+++ b/python/singa/loss.py
@@ -38,7 +38,9 @@ Example usage::
 
 
 from . import singa_wrap as singa
+from proto import model_pb2
 import tensor
+
 
 
 class Loss(object):
@@ -64,6 +66,11 @@ class Loss(object):
         Returns:
             a tensor of floats for the loss values, one per sample
         '''
+        if type(flag) is bool:
+            if flag:
+                flag = model_pb2.kTrain
+            else:
+                flag = model_pb2.kEval
         return tensor.from_raw_tensor(
             self.swig_loss.Forward(flag, x.singa_tensor, y.singa_tensor))
 
@@ -84,6 +91,12 @@ class Loss(object):
         Returns:
             the averaged loss for all samples in x.
         '''
+        if type(flag) is bool:
+            if flag:
+                flag = model_pb2.kTrain
+            else:
+                flag = model_pb2.kEval
+
         return self.swig_loss.Evaluate(flag, x.singa_tensor, y.singa_tensor)
 
 
@@ -92,6 +105,12 @@ class SoftmaxCrossEntropy(Loss):
 
     It converts the inputs via SoftMax function and then
     computes the cross-entropy loss against the ground truth values.
+
+    For each sample, the ground truth could be a integer as the label index;
+    or a binary array, indicating the label distribution. The ground truth
+    tensor thus could be a 1d or 2d tensor.
+    The data/feature tensor could 1d (for a single sample) or 2d for a batch of
+    samples.
     '''
 
     def __init__(self):

--- a/src/core/tensor/math_kernel.h
+++ b/src/core/tensor/math_kernel.h
@@ -103,12 +103,12 @@ void div(const size_t n, const float *in1, const float *in2, float *out,
 
 // void sum(const size_t n, const float *in, float *out, cudaStream_t s);
 
-void ComputeCrossEntropy(const size_t batchsize, const size_t dim,
-                         const float *p, const int *t, float *loss,
-                         cudaStream_t stream);
-void SoftmaxCrossEntropyBwd(const size_t batchsize, const size_t dim,
-                            const float *p, const int *t, float *grad,
-                            cudaStream_t stream);
+void ComputeCrossEntropy(bool int_target, const size_t batchsize,
+                         const size_t dim, const float *p, const int *t,
+                         float *loss, cudaStream_t stream);
+void SoftmaxCrossEntropyBwd(bool int_target, const size_t batchsize,
+                            const size_t dim, const float *p, const int *t,
+                            float *grad, cudaStream_t stream);
 
 void RowMax(const size_t nrow, const size_t ncol, const float *inPtr,
     float *outPtr, cudaStream_t stream);

--- a/src/core/tensor/tensor_math.h
+++ b/src/core/tensor/tensor_math.h
@@ -347,19 +347,17 @@ void GEMM(const bool transA, const bool transB, const size_t nrowA,
   LOG(FATAL) << "GEMM Not Implemented";
 }
 
-/// Divide alpha by each element of 'in'.
-// following the consistency guide.
 template <typename DType, typename Lang>
-void ComputeCrossEntropy(const size_t batchsize, const size_t dim,
-                         const Block *p, const Block *t, Block *loss,
-                         Context *ctx) {
+void ComputeCrossEntropy(bool int_target, const size_t batchsize,
+                         const size_t dim, const Block *p, const Block *t,
+                         Block *loss, Context *ctx) {
   LOG(FATAL) << "Not Implemented";
 }
 
 template <typename DType, typename Lang>
-void SoftmaxCrossEntropyBwd(const size_t batchsize, const size_t dim,
-                            const Block *p, const Block *t, Block *grad,
-                            Context *ctx) {
+void SoftmaxCrossEntropyBwd(bool int_target, const size_t batchsize,
+                            const size_t dim, const Block *p, const Block *t,
+                            Block *grad, Context *ctx) {
   LOG(FATAL) << "Not Implemented";
 }
 

--- a/src/core/tensor/tensor_math_cuda.h
+++ b/src/core/tensor/tensor_math_cuda.h
@@ -432,17 +432,20 @@ void GEMM<float, lang::Cuda>(const bool transA, const bool transB,
 }
 
 template <>
-void ComputeCrossEntropy<float, lang::Cuda>(const size_t batchsize,
+void ComputeCrossEntropy<float, lang::Cuda>(bool int_target,
+                                            const size_t batchsize,
                                             const size_t dim, const Block* p,
                                             const Block* t, Block* loss,
                                             Context* ctx) {
   const float* pPtr = static_cast<const float*>(p->data());
   const int* tPtr = static_cast<const int*>(t->data());
   float* lossPtr = static_cast<float*>(loss->mutable_data());
-  cuda::ComputeCrossEntropy(batchsize, dim, pPtr, tPtr, lossPtr, ctx->stream);
+  cuda::ComputeCrossEntropy(int_target, batchsize, dim, pPtr, tPtr, lossPtr,
+      ctx->stream);
 }
 template <>
-void SoftmaxCrossEntropyBwd<float, lang::Cuda>(const size_t batchsize,
+void SoftmaxCrossEntropyBwd<float, lang::Cuda>(bool int_target,
+                                               const size_t batchsize,
                                                const size_t dim, const Block* p,
                                                const Block* t, Block* grad,
                                                Context* ctx) {
@@ -450,7 +453,7 @@ void SoftmaxCrossEntropyBwd<float, lang::Cuda>(const size_t batchsize,
   const float* pPtr = static_cast<const float*>(p->data());
   const int* tPtr = static_cast<const int*>(t->data());
   float* gradPtr = static_cast<float*>(grad->mutable_data());
-  cuda::SoftmaxCrossEntropyBwd(batchsize, dim, pPtr, tPtr, gradPtr,
+  cuda::SoftmaxCrossEntropyBwd(int_target, batchsize, dim, pPtr, tPtr, gradPtr,
                                ctx->stream);
 }
 

--- a/src/model/loss/softmax_cross_entropy.cc
+++ b/src/model/loss/softmax_cross_entropy.cc
@@ -26,7 +26,8 @@ Tensor SoftmaxCrossEntropy::Forward(int flag, const Tensor& prediction,
   CHECK(buf_.empty()) << "Do not call Forward successively for more than twice."
                       << " The calling pattern is [Forward|Evaluate] Backward";
   size_t batchsize = 1;
-  if (prediction.nDim() > 1) batchsize = prediction.shape().at(0);
+  if (prediction.nDim() == 2)
+    batchsize = prediction.shape(0);
   size_t dim = prediction.Size() / batchsize;
   const Tensor& input = Reshape(prediction, Shape{batchsize, dim});
   Tensor prob = SoftMax(input);

--- a/test/python/test_optimizer.py
+++ b/test/python/test_optimizer.py
@@ -20,7 +20,6 @@ import os
 import unittest
 import numpy as np
 
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../build/python'))
 
 import singa.tensor as tensor
 import singa.optimizer as opt


### PR DESCRIPTION
Updated the softmax cross entorpy loss layer and the tensor functions to enable
the ground truth be an binary array for each instance;

Added unittests for cross entropy with multiple labels per instance;

For input of a batch of instances, the ground truth tensor could be either an integer array, one value per
instance, or a binary matrix one row per instance.

For a single instance input, the feature tensor is 1-d array, and the
ground truth tensor is a 1-d array (with a single integer value or a
binary array)