### PR TITLE
SINGA-283 Fix a bug of net.py backward function for layers with multiple inputs

### DIFF
--- a/python/singa/layer.py
+++ b/python/singa/layer.py
@@ -206,7 +206,8 @@ class Layer(object):
             y = self.layer.ForwardWithMultInputs(flag, xs)
         else:
             assert isinstance(x, tensor.Tensor), \
-                'input must be a Tensor or a list of Tensor'
+                    'input of %s (type:%s) must be a Tensor or Tensor list'\
+                    % (self.name, type(x).__name__)
             y = self.layer.Forward(flag, x.singa_tensor)
         if type(y) is tuple:
             return tensor.from_raw_tensors(y)
@@ -235,7 +236,8 @@ class Layer(object):
             ret = self.layer.BackwardWithMultInputs(flag, dys)
         else:
             assert isinstance(dy, tensor.Tensor), \
-                'the input must be a Tensor or a set of Tensor'
+                    'input of %s (type:%s) must be a Tensor or Tensor list'\
+                    % (self.name, type(dy).__name__)
             dys = dy.singa_tensor
             ret = self.layer.Backward(flag, dys)
         if type(ret[0]) is tuple:
@@ -761,7 +763,8 @@ class Merge(Layer):
         Returns:
             A list of replicated grad, one per source layer
         '''
-        assert isinstance(grad, tensor.Tensor), 'The input must be Tensor'
+        assert isinstance(grad, tensor.Tensor), 'The input must be Tensor'\
+                ' instead of %s' % type(grad).__name__
         return [grad] * self.num_input, []  # * self.num_input
 
 

--- a/python/singa/net.py
+++ b/python/singa/net.py
@@ -301,8 +301,17 @@ class FeedForwardNet(object):
                 grads = grads[0]
             outs, _pgrads = cur.backward(kTrain, grads)
             pgrads.append(_pgrads)
+            if verbose:
+                disp_src = '+'.join(
+                        [dst.name for dst in self.dst_of_layer[cur.name]])
+                disp_src += '-->' + cur.name
+                if type(outs) is list:
+                    print '%s: %s' % (disp_src,
+                                      ' '.join([str(o.l1()) for o in outs]))
+                else:
+                    print '%s: %f' % (disp_src, outs.l1())
             if type(outs) is list:
-                output_of_layer[cur.name] = reversed(outs)
+                output_of_layer[cur.name] = outs[::-1]
             else:
                 output_of_layer[cur.name] = outs
             grads = []


### PR DESCRIPTION
1. reversed(list) returns a reversedlistiterator, it should return a list. fixed by using list[::-1]
2. add debugging output for backward function