### PR TITLE
SINGA-302 - Extend the travis config for building SINGA on OSX

### DIFF
--- a/tool/travis/build.sh
+++ b/tool/travis/build.sh
@@ -15,29 +15,18 @@
 # limitations under the License.
 #
 
-# to use container for building
-sudo: required
-language: cpp
 
-matrix:
-  include:
-  - os: osx
-    compiler: clang
-    osx_image: xcode7.3
-  - os: linux
-    dist: trusty
-    compiler: gcc
-
-#
-#addons:
-#  apt:
-#    packages:
-#      - libopenblas-dev
-#      - libprotobuf-dev
-#      - protobuf-compiler
-
-install:
-  - bash -ex tool/travis/depends.sh
-
-script:
-  - bash -ex tool/travis/build.sh
+if [[ "$TRAVIS_SECURE_ENV_VARS" == "false" ]];
+then
+  if [[ "$TRAVIS_OS_NAME" == "osx" ]];
+  then
+    export CMAKE_LIBRARY_PATH=/usr/local/opt/openblas/lib:$CMAKE_LIBRARY_PATH;
+    export CMAKE_INCLUDE_PATH=/usr/local/opt/openblas/include:$CMAKE_INCLUDE_PATH;
+  fi
+  mkdir build && cd build;
+  cmake -DUSE_CUDA=OFF -DUSE_PYTHON=OFF ..;
+  make;
+  ./bin/test_singa --gtest_output=xml:./../gtest.xml;
+else
+  bash tool/travis/conda.sh;
+fi

--- a/tool/travis/conda.sh
+++ b/tool/travis/conda.sh
@@ -15,29 +15,14 @@
 # limitations under the License.
 #
 
-# to use container for building
-sudo: required
-language: cpp
+# to build SINGA package and upload it to anaconda
 
-matrix:
-  include:
-  - os: osx
-    compiler: clang
-    osx_image: xcode7.3
-  - os: linux
-    dist: trusty
-    compiler: gcc
+USER=nusdbsystem
+OS=$TRAVIS_OS_NAME-64
 
-#
-#addons:
-#  apt:
-#    packages:
-#      - libopenblas-dev
-#      - libprotobuf-dev
-#      - protobuf-compiler
-
-install:
-  - bash -ex tool/travis/depends.sh
-
-script:
-  - bash -ex tool/travis/build.sh
+mkdir ~/conda-bld
+conda config --set anaconda_upload no
+suffix=`TZ=Asia/Singapore date +%Y-%m-%d-%H-%M-%S`
+export CONDA_BLD_PATH=~/conda-bld-$suffix
+conda build tool/conda/
+anaconda -t $ANACONDA_UPLOAD_TOKEN upload -u $USER -l nightly $CONDA_BLD_PATH/$OS/singa-*.tar.bz2 --force

--- a/tool/travis/depends.sh
+++ b/tool/travis/depends.sh
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [[ "$TRAVIS_SECURE_ENV_VARS" == "false" ]];
+then
+  if [[ "$TRAVIS_OS_NAME" == "linux" ]];
+  then
+    sudo apt-get -qq update;
+    sudo apt-get -qq -y install libopenblas-dev libprotobuf-dev protobuf-compiler;
+  else
+    brew update;
+    brew tap homebrew/science;
+    brew install openblas protobuf260;
+  fi
+else
+  if [[ "$TRAVIS_OS_NAME" == "linux" ]];
+  then
+    wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+  else
+    wget https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh -O miniconda.sh;
+  fi
+  bash miniconda.sh -b -p $HOME/miniconda
+  export PATH="$HOME/miniconda/bin:$PATH"
+  hash -r
+  conda config --set always_yes yes --set changeps1 no
+  conda update -q conda
+  conda install conda-build
+  conda install anaconda-client
+fi


### PR DESCRIPTION
Updated the .travis.yml file and added scripts in tool/travis folder.
Test on osx and linux

TODO: add conda scripts for building conda packages for SINGA on Travis
(linux and osx).