### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Apache SINGA
+# Apache SINGA
 
 [![Build Status](https://travis-ci.org/apache/incubator-singa.png)](https://travis-ci.org/apache/incubator-singa)
 ![License](http://img.shields.io/:license-Apache%202.0-blue.svg)
@@ -16,7 +16,7 @@ Distributed deep learning system
 
 * [JIRA tickets](https://issues.apache.org/jira/browse/SINGA)
 
-##Mailing Lists
+## Mailing Lists
 
 * [Development Mailing List](mailto:dev-subscribe@singa.incubator.apache.org) ([Archive](http://mail-archives.apache.org/mod_mbox/singa-dev/))
 * [Commits Mailing List](mailto:commits-subscribe@singa.incubator.apache.org) ([Archive](http://mail-archives.apache.org/mod_mbox/singa-commits/))

--- a/doc/en/docs/cnn.md
+++ b/doc/en/docs/cnn.md
@@ -1,4 +1,4 @@
-#Quickstart - Cifar10 example
+# Quickstart - Cifar10 example
 Convolution neural network (CNN) is a type of feed-forward artificial neural network widely used for image classification. In this example, we will use a deep CNN model to do image classification for the [CIFAR10 dataset](http://www.cs.toronto.edu/~kriz/cifar.html).
 
 ## Running instructions for CPP version

--- a/doc/en/releases/RELEASE_NOTES_0.1.0.md
+++ b/doc/en/releases/RELEASE_NOTES_0.1.0.md
@@ -1,4 +1,4 @@
-#singa-incubating-0.1.0 Release Notes
+# singa-incubating-0.1.0 Release Notes
 
 ---
 

--- a/doc/en/releases/RELEASE_NOTES_0.2.0.md
+++ b/doc/en/releases/RELEASE_NOTES_0.2.0.md
@@ -1,4 +1,4 @@
-#singa-incubating-0.2.0 Release Notes
+# singa-incubating-0.2.0 Release Notes
 
 ---
 

--- a/doc/en/releases/RELEASE_NOTES_0.3.0.md
+++ b/doc/en/releases/RELEASE_NOTES_0.3.0.md
@@ -1,4 +1,4 @@
-#singa-incubating-0.3.0 Release Notes
+# singa-incubating-0.3.0 Release Notes
 
 ---
 

--- a/doc/en/releases/RELEASE_NOTES_1.0.0.md
+++ b/doc/en/releases/RELEASE_NOTES_1.0.0.md
@@ -1,4 +1,4 @@
-#singa-incubating-1.0.0 Release Notes
+# singa-incubating-1.0.0 Release Notes
 
 ---
 

--- a/doc/en/releases/RELEASE_NOTES_1.1.0.md
+++ b/doc/en/releases/RELEASE_NOTES_1.1.0.md
@@ -1,4 +1,4 @@
-#singa-incubating-1.1.0 Release Notes
+# singa-incubating-1.1.0 Release Notes
 
 ---
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
