### PR TITLE
 SINGA-318 - Extend ImageBatchIter to read image list file without meta info

### DIFF
--- a/examples/imagenet/resnet/README.md
+++ b/examples/imagenet/resnet/README.md
@@ -31,7 +31,7 @@ In this example, we convert Residual Networks trained on [Torch](https://github.
         $ python serve.py --parameter_file resnet-18.pickle --model resnet --depth 18 &
 
   The parameter files for the following model and depth configuration pairs are provided:
-  * resnet (original resnet), [18](https://s3-ap-southeast-1.amazonaws.com/dlfile/resnet/resnet-101.tar.gz)|[34](https://s3-ap-southeast-1.amazonaws.com/dlfile/resnet/resnet-34.tar.gz)|[101](https://s3-ap-southeast-1.amazonaws.com/dlfile/resnet/resnet-101.tar.gz)|[152](https://s3-ap-southeast-1.amazonaws.com/dlfile/resnet/resnet-152.tar.gz)
+  * resnet (original resnet), [18](https://s3-ap-southeast-1.amazonaws.com/dlfile/resnet/resnet-18.tar.gz)|[34](https://s3-ap-southeast-1.amazonaws.com/dlfile/resnet/resnet-34.tar.gz)|[101](https://s3-ap-southeast-1.amazonaws.com/dlfile/resnet/resnet-101.tar.gz)|[152](https://s3-ap-southeast-1.amazonaws.com/dlfile/resnet/resnet-152.tar.gz)
   * addbn (resnet with a batch normalization layer after the addition), [50](https://s3-ap-southeast-1.amazonaws.com/dlfile/resnet/resnet-50.tar.gz)
   * wrn (wide resnet), [50](https://s3-ap-southeast-1.amazonaws.com/dlfile/resnet/wrn-50-2.tar.gz)
   * preact (resnet with pre-activation) [200](https://s3-ap-southeast-1.amazonaws.com/dlfile/resnet/resnet-200.tar.gz)


### PR DESCRIPTION
To read the image list file which contains only the image path per line.
The returned value of function next() consists of x (ndarray of images)
and y([None] * batchsize).