### PR TITLE
Fix the size-not-match problem when batch-normalization layer connect to dense layer

### DIFF
--- a/src/model/layer/cudnn_batchnorm.cc
+++ b/src/model/layer/cudnn_batchnorm.cc
@@ -80,13 +80,13 @@ const Tensor CudnnBatchNorm::Forward(int flag, const Tensor& input) {
           &n, &c, &h, &w, &s, &s, &s, &s));
     if (shape[0] != static_cast<size_t>(n))
       InitCudnn(shape, dtype);
-    CHECK(input.shape(1) == static_cast<size_t>(c)
-        && input.shape(2) == static_cast<size_t>(h)
-        && input.shape(3) == static_cast<size_t>(w))
+    CHECK(shape[1] == static_cast<size_t>(c)
+        && shape[2] == static_cast<size_t>(h)
+        && shape[3] == static_cast<size_t>(w))
       << "input sample shape should not change"
       << "previous shape " << c << ", " << h << ", " << w
-      << "current shape " << input.shape(1) << ", " << input.shape(2) << ", "
-      << input.shape(3);
+      << "current shape " << shape[1] << ", " << shape[2] << ", "
+      << shape[3];
   }
 
 


### PR DESCRIPTION
When size of batch-normalization layer and dense layer doesn't match, here is one error that may pop up when run "examples/cifar-10/train.py", which should look like:

[tensor.h: 99] Check failed: idx < shape_.size() (2 vs. 2)

By modifying the code, this problem should have been fixed. 