### PR TITLE
SINGA-324 Extend RNN layer to accept variant seq length across batches

### DIFF
--- a/src/model/layer/cudnn_rnn.cc
+++ b/src/model/layer/cudnn_rnn.cc
@@ -60,7 +60,7 @@ void CudnnRNN::ToDevice(std::shared_ptr<Device> device) {
 
 void CudnnRNN::DestroyIODescriptors() {
   if (x_descs_ != nullptr) {
-    for (size_t i = 0; i < seq_length_; i++) {
+    for (size_t i = 0; i < max_length_; i++) {
       CUDNN_CHECK(cudnnDestroyTensorDescriptor(x_descs_[i]));
       CUDNN_CHECK(cudnnDestroyTensorDescriptor(dx_descs_[i]));
     }
@@ -68,7 +68,7 @@ void CudnnRNN::DestroyIODescriptors() {
     delete [] dx_descs_;
   }
   if (y_descs_ != nullptr) {
-    for (size_t i = 0; i < seq_length_; i++) {
+    for (size_t i = 0; i < max_length_; i++) {
       CUDNN_CHECK(cudnnDestroyTensorDescriptor(y_descs_[i]));
       CUDNN_CHECK(cudnnDestroyTensorDescriptor(dy_descs_[i]));
     }
@@ -79,8 +79,9 @@ void CudnnRNN::DestroyIODescriptors() {
 
 void CudnnRNN::UpdateIODescriptors(size_t len, const vector<Tensor> &inputs) {
   bool reset = false;
-  if (seq_length_ < len) {
+  if (max_length_ < len) {
     DestroyIODescriptors();
+    max_length_ = len;
     x_descs_ = new cudnnTensorDescriptor_t[len];
     dx_descs_ = new cudnnTensorDescriptor_t[len];
     y_descs_ = new cudnnTensorDescriptor_t[len];

--- a/src/model/layer/rnn.h
+++ b/src/model/layer/rnn.h
@@ -85,7 +85,7 @@ class RNN : public Layer {
   std::stack<Tensor> buf_;
   bool has_cell_ = false;
   size_t num_directions_ = 1;
-  size_t input_size_ = 0, hidden_size_ = 0, num_stacks_ = 0, seq_length_ = 0;
+  size_t input_size_ = 0, hidden_size_ = 0, num_stacks_ = 0, seq_length_ = 0, max_length_ = 0;
   size_t batch_size_ = 0;
   size_t seed_ = 0x1234567;
   float dropout_ = 0.0f;


### PR DESCRIPTION
The cudnn rnn layer is updated to handle mini-batches with
different seq lengths. The internal data structures are re-allocated if
max_length_ < seq_length_ (the longest sample of the current
mini-batch).