### PR TITLE
SINGA-331 Fix the bug of tensor division operation

### DIFF
--- a/python/singa/tensor.py
+++ b/python/singa/tensor.py
@@ -384,7 +384,7 @@ class Tensor(object):
         if isinstance(x, Tensor):
             self.singa_tensor /= x.singa_tensor
         else:
-            self.singa_tensor /= float(x)
+            self.__imul__(1/float(x))
         return self
 
     '''


### PR DESCRIPTION
Tensor division operation error resulted in failure of backward propagation when training CNN models.
Change division to multiplication of the inverse.
