### PR TITLE
SINGA-358: Consolidated RUN steps and cleaned caches in Docker contai…

### DIFF
--- a/tool/docker/devel/conda/cuda/Dockerfile
+++ b/tool/docker/devel/conda/cuda/Dockerfile
@@ -20,32 +20,42 @@ FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
 
 # install dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends git build-essential cmake wget openssh-server ca-certificates\
-    && apt-get clean && apt-get autoremove && apt-get autoclean \
-    && rm -rf /var/lib/apt/lists/* 
+    && apt-get install -y --no-install-recommends \
+        git \
+        build-essential \
+        cmake \
+        wget \
+        openssh-server \
+        ca-certificates \
+    && apt-get clean \
+    && apt-get autoremove \
+    && apt-get autoclean \
+    && rm -rf /var/lib/apt/lists/* \
+    #
+    # install conda, conda-build and anaconda-client
+    #
+    && wget --no-check-certificate https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh \
+    && bash miniconda.sh -b -p /root/miniconda \
+    && /root/miniconda/bin/conda config --set always_yes yes --set changeps1 no \
+    && /root/miniconda/bin/conda update -q conda \
+    && /root/miniconda/bin/conda install -y \
+        conda-build \
+        anaconda-client \
+    && /root/miniconda/bin/conda clean -tipsy \
+    # config ssh service
+    && mkdir /var/run/sshd \
+    && echo 'root:singa' | chpasswd \
+    # for ubuntu 14.04
+    # RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+    # for ubuntu 16.04 prohibit
+    && sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config \
+    # SSH login fix. Otherwise user is kicked off after login
+    && sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd \
+    # dump environment variables into files, so that ssh can see also
+    && env | grep _ >> /etc/environment
 
-# install conda, conda-build and anaconda-client
-RUN wget --no-check-certificate https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-RUN bash miniconda.sh -b -p /root/miniconda
-RUN /root/miniconda/bin/conda config --set always_yes yes --set changeps1 no
-RUN /root/miniconda/bin/conda update -q conda
-RUN /root/miniconda/bin/conda install conda-build
-RUN /root/miniconda/bin/conda install anaconda-client
+# Add conda to PATH. Doing this here so other RUN steps can be grouped above
 ENV PATH /root/miniconda/bin:${PATH}
-
-
-# config ssh service
-RUN mkdir /var/run/sshd
-RUN echo 'root:singa' | chpasswd
-# for ubuntu 14.04
-# RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-# for ubuntu 16.04 prohibit
-RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-# SSH login fix. Otherwise user is kicked off after login
-RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
-
-# dump environment variables into files, so that ssh can see also
-RUN env | grep _ >> /etc/environment
 
 EXPOSE 22
 

--- a/tool/docker/devel/native/centos6/Dockerfile
+++ b/tool/docker/devel/native/centos6/Dockerfile
@@ -20,28 +20,27 @@
 FROM nvidia/cuda:7.5-cudnn5-devel-centos6
 
 # install dependencies
-RUN yum -y update && yum -y install git wget openssh-server cmake
-
-
-
-# download singa source
-# RUN git clone https://github.com/apache/incubator-singa.git
-
-# config ssh service
-RUN mkdir /var/run/sshd
-RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key
-RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key
-
-RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
-RUN sed -ri 's/#UsePAM no/UsePAM no/g' /etc/ssh/sshd_config
-RUN echo 'root:singa' | chpasswd
-
-#RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-# SSH login fix. Otherwise user is kicked off after login
-#RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
-
-# dump environment variables into files, so that ssh can see also
-RUN env | grep _ >> /etc/environment
+RUN yum -y update \
+    && yum install -y \
+        git \
+        wget \
+        openssh-server \
+        cmake \
+    && yum clean all \
+    # download singa source
+    # RUN git clone https://github.com/apache/incubator-singa.git
+    # config ssh service
+    && mkdir /var/run/sshd \
+    && ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key \
+    && ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key \
+    && sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config \
+    && sed -ri 's/#UsePAM no/UsePAM no/g' /etc/ssh/sshd_config \
+    && echo 'root:singa' | chpasswd \
+    #RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+    # SSH login fix. Otherwise user is kicked off after login
+    #RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+    # dump environment variables into files, so that ssh can see also
+    && env | grep _ >> /etc/environment
 
 EXPOSE 22
 

--- a/tool/docker/devel/native/ubuntu/cuda/py2/Dockerfile
+++ b/tool/docker/devel/native/ubuntu/cuda/py2/Dockerfile
@@ -20,33 +20,52 @@ FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
 
 # install dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends git build-essential autoconf libtool cmake libprotobuf-dev libopenblas-dev libpcre3-dev protobuf-compiler wget openssh-server swig python-dev python-pip python-setuptools\
-    && apt-get clean && apt-get autoremove && apt-get autoclean \
+    && apt-get install -y --no-install-recommends \
+        git \
+        build-essential \
+        autoconf \
+        libtool \
+        cmake \
+        libprotobuf-dev \
+        libopenblas-dev \
+        libpcre3-dev \
+        protobuf-compiler \
+        wget \
+        openssh-server \
+        swig \
+        python-dev \
+        python-pip \
+        python-setuptools \
+    && apt-get clean \
+    && apt-get autoremove \
+    && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/* \
-    && pip install -U pip wheel numpy setuptools unittest-xml-reporting protobuf future
-
-
-# install swig > 3.0.10 for ubuntu < 16.04
-# RUN wget http://prdownloads.sourceforge.net/swig/swig-3.0.10.tar.gz && \
-#     tar zxf swig-3.0.10.tar.gz && cd swig-3.0.10 && \
-#     ./configure && make && make install
-
-# set environment
-# ENV CMAKE_INCLUDE_PATH /usr/local/cuda/include:${CMAKE_INCLUDE_PATH}
-# ENV CMAKE_LIBRARY_PATH /usr/local/cuda/lib64:${CMAKE_LIBRARY_PATH}
-
-# config ssh service
-RUN mkdir /var/run/sshd
-RUN echo 'root:singa' | chpasswd
-# for ubuntu 14.04
-# RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-# for ubuntu 16.04 prohibit
-RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-# SSH login fix. Otherwise user is kicked off after login
-RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
-
-# dump environment variables into files, so that ssh can see also
-RUN env | grep _ >> /etc/environment
+    && pip install -U --no-cache \
+        pip \
+        wheel \
+        numpy \
+        setuptools \
+        unittest-xml-reporting \
+        protobuf \
+        future \
+    # install swig > 3.0.10 for ubuntu < 16.04
+    # RUN wget http://prdownloads.sourceforge.net/swig/swig-3.0.10.tar.gz && \
+    #     tar zxf swig-3.0.10.tar.gz && cd swig-3.0.10 && \
+    #     ./configure && make && make install
+    # set environment
+    # ENV CMAKE_INCLUDE_PATH /usr/local/cuda/include:${CMAKE_INCLUDE_PATH}
+    # ENV CMAKE_LIBRARY_PATH /usr/local/cuda/lib64:${CMAKE_LIBRARY_PATH}
+    # config ssh service
+    && mkdir /var/run/sshd \
+    && echo 'root:singa' | chpasswd \
+    # for ubuntu 14.04
+    # RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+    # for ubuntu 16.04 prohibit
+    && sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config \
+    # SSH login fix. Otherwise user is kicked off after login
+    && sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd \
+    # dump environment variables into files, so that ssh can see also
+    && env | grep _ >> /etc/environment
 
 EXPOSE 22
 

--- a/tool/docker/devel/native/ubuntu/cuda/py3/Dockerfile
+++ b/tool/docker/devel/native/ubuntu/cuda/py3/Dockerfile
@@ -20,34 +20,51 @@ FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
 
 # install dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends git build-essential autoconf libtool cmake libprotobuf-dev libopenblas-dev libpcre3-dev protobuf-compiler wget openssh-server swig python3-dev python3-pip python3-setuptools\
-    && apt-get clean && apt-get autoremove && apt-get autoclean \
+    && apt-get install -y --no-install-recommends \
+        git \
+        build-essential \
+        autoconf \
+        libtool \
+        cmake \
+        libprotobuf-dev \
+        libopenblas-dev \
+        libpcre3-dev \
+        protobuf-compiler \
+        wget \
+        openssh-server \
+        swig \
+        python3-dev \
+        python3-pip \
+        python3-setuptools \
+    && apt-get clean \
+    && apt-get autoremove \
+    && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/* \
-    && pip3 install -U wheel numpy setuptools unittest-xml-reporting protobuf future
-
-
-# install swig > 3.0.10 for ubuntu < 16.04
-# RUN wget http://prdownloads.sourceforge.net/swig/swig-3.0.10.tar.gz && \
-#     tar zxf swig-3.0.10.tar.gz && cd swig-3.0.10 && \
-#     ./configure && make && make install
-
-# set environment
-
-# ENV CMAKE_INCLUDE_PATH /usr/local/cuda/include:${CMAKE_INCLUDE_PATH}
-# ENV CMAKE_LIBRARY_PATH /usr/local/cuda/lib64:${CMAKE_LIBRARY_PATH}
-
-# config ssh service
-RUN mkdir /var/run/sshd
-RUN echo 'root:singa' | chpasswd
-# for ubuntu 14.04
-# RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-# for ubuntu 16.04 prohibit
-RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-# SSH login fix. Otherwise user is kicked off after login
-RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
-
-# dump environment variables into files, so that ssh can see also
-RUN env | grep _ >> /etc/environment
+    && pip3 install -U --no-cache \
+        wheel \
+        numpy \
+        setuptools \
+        unittest-xml-reporting \
+        protobuf \
+        future \
+    # install swig > 3.0.10 for ubuntu < 16.04
+    # RUN wget http://prdownloads.sourceforge.net/swig/swig-3.0.10.tar.gz && \
+    #     tar zxf swig-3.0.10.tar.gz && cd swig-3.0.10 && \
+    #     ./configure && make && make install
+    # set environment
+    # ENV CMAKE_INCLUDE_PATH /usr/local/cuda/include:${CMAKE_INCLUDE_PATH}
+    # ENV CMAKE_LIBRARY_PATH /usr/local/cuda/lib64:${CMAKE_LIBRARY_PATH}
+    # config ssh service
+    && mkdir /var/run/sshd \
+    && echo 'root:singa' | chpasswd \
+    # for ubuntu 14.04
+    # RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+    # for ubuntu 16.04 prohibit
+    && sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config \
+    # SSH login fix. Otherwise user is kicked off after login
+    && sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd \
+    # dump environment variables into files, so that ssh can see also
+    && env | grep _ >> /etc/environment
 
 EXPOSE 22
 


### PR DESCRIPTION
 In this PR, I propose some small changes to this project's Dockerfiles. See [SINGA-358](https://issues.apache.org/jira/browse/SINGA-358) for a full description of what I'm proposing here.

Changes in containers:

`centos6`: 1.54GB ---> 1.48GB   (-60 MB)
`py3`:         3.33GB --> 3.31GB    (-20 MB)
`py2`:         3.32GB --> 3.3GB      (-20 MB)
`conda`:     3.36GB --> 3.26GB   (-100 MB)