### PR TITLE
SINGA-396 Upgrade `protobuf` to 3.6.1 to match Tensorflow's

### DIFF
--- a/tool/conda/cpu/meta.yaml
+++ b/tool/conda/cpu/meta.yaml
@@ -20,11 +20,11 @@
 
 package:
   name: singa-cpu
-  version: 1.1.1
+  version: 1.2.0
 
 requirements:
   run:
-    - singa 1.1.1 py36_cpu
+    - singa 1.2.0 py36_cpu
 
 about:
   home: http://singa.apache.org/

--- a/tool/conda/gpu/meta.yaml
+++ b/tool/conda/gpu/meta.yaml
@@ -19,11 +19,11 @@
 
 package:
   name: singa-gpu
-  version: 1.1.1
+  version: 1.2.0
 
 requirements:
   run:
-    - singa 1.1.1 py36_cuda9.0_cudnn7.1.2
+    - singa 1.2.0 py36_cuda9.0_cudnn7.1.2
 
 about:
   home: http://singa.apache.org/

--- a/tool/conda/singa/meta.yaml
+++ b/tool/conda/singa/meta.yaml
@@ -35,7 +35,7 @@ requirements:
   build:
     - swig 3.0.10
     - openblas 0.2.19
-    - protobuf 3.2.0
+    - protobuf >=3.2.0
     - glog 0.3.4
     - libgfortran 3.0.0 # [osx]
     - gcc 4.8.5 # [linux]
@@ -45,7 +45,7 @@ requirements:
 
   run:
     - openblas 0.2.19
-    - protobuf 3.2.0
+    - protobuf >=3.2.0
     - glog 0.3.4
     - libgfortran 3.0.0 # [osx]
     - libgcc 4.8.5 # [linux]


### PR DESCRIPTION
The depdency rule on protobuf is relax to >= 3.2.0 (from == 3.2.0)