### PR TITLE
SINGA-409 [Singa 1.2.0] Basic `singa-cpu` import throws error

### DIFF
--- a/tool/conda/singa/meta.yaml
+++ b/tool/conda/singa/meta.yaml
@@ -35,7 +35,7 @@ requirements:
   build:
     - swig 3.0.10
     - openblas 0.2.19
-    - protobuf >=3.2.0
+    - protobuf 3.6.1
     - glog 0.3.4
     - libgfortran 3.0.0 # [osx]
     - gcc 4.8.5 # [linux]
@@ -45,7 +45,7 @@ requirements:
 
   run:
     - openblas 0.2.19
-    - protobuf >=3.2.0
+    - protobuf 3.6.1
     - glog 0.3.4
     - libgfortran 3.0.0 # [osx]
     - libgcc 4.8.5 # [linux]


### PR DESCRIPTION
It is due to the version mismatch of Protobuf.
In SINGA-396, we updated the protobuf version to be >=3.2.0. And the
singa package is built using 3.2.0.
However, 3.6.1 is installed in your OS. In other words, the runtime env
and the building env mismatch.
In this commit, we fix the version for both building and runtime to
3.6.1.