### PR TITLE
SINGA-417 #close adding a link to Apache Security page

### DIFF
--- a/doc/en/docs/install_win.rst
+++ b/doc/en/docs/install_win.rst
@@ -40,13 +40,13 @@ The dependencies are:
 * Protocol Buffers
 	* Download a suitable version such as 2.6.1: https://github.com/google/protobuf/releases/tag/v2.6.1 .	
 	* Download both protobuf-2.6.1.zip and protoc-2.6.1-win32.zip . 
-	* Extract both of them in dependecies folder. Add the path to protoc executable to the system path, or use full path when calling it.
+	* Extract both of them in dependencies folder. Add the path to protoc executable to the system path, or use full path when calling it.
 	* Open the Visual Studio solution which can be found in vsproject folder.
 	* Change the build settings to Release and x64.
 	* build libprotobuf project. 
 * Openblas
 	* Download a suitable source version such as 0.2.20 from http://www.openblas.net 
-	* Extract the source in the dependecies folder.
+	* Extract the source in the dependencies folder.
 	* If you don't have Perl installed, download a perl environment such as Strawberry Perl (http://strawberryperl.com/)
 	* Build the Visual Studio solution by running this command in the source folder:
 
@@ -300,12 +300,12 @@ In addition to the dependencies in section 1 above, we will need the following:
 5.2.2 Building singa-kernel
 ---------------------------	
 
-* Create a new Visual Studio projcet of type "CUDA 9.1 Runtime". Give it a name such as singa-kernel.
+* Create a new Visual Studio project of type "CUDA 9.1 Runtime". Give it a name such as singa-kernel.
 * The project comes with an initial file called kernel.cu. Remove this file from the project.
 * Add this file: src/core/tensor/math_kernel.cu 
 * In the project settings:
 
-	* Set Platfrom Toolset to "Visual Studio 2015 (v140)"
+	* Set Platform Toolset to "Visual Studio 2015 (v140)"
 	* Set Configuration Type to " Static Library (.lib)"
 	* In the Include Directories, add build/include.
 

--- a/doc/en/docs/security.rst
+++ b/doc/en/docs/security.rst
@@ -15,26 +15,9 @@
    specific language governing permissions and limitations
    under the License.
 
+Security
+========
 
-Documentation
-=============
+Users can report security vulnerabilities to Apache Security Team: http://www.apache.org/security/ 
 
-.. toctree::
-
-   installation
-   software_stack
-   device
-   tensor
-   layer
-   net
-   initializer
-   loss
-   metric
-   optimizer
-   data
-   image_tool
-   snapshot
-   converter
-   utils
-   model_zoo/index
-   security
+SINGA is creating a new team for security. More details will be added soon.

--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -21,6 +21,8 @@ Welcome to Apache SINGA
 Recent News
 -----------
 
+* SINGA was presented at `DIBRIS, University of Genoa, Italy <https://www.dibris.unige.it/>`_ on 16 July 2018.
+
 * **Version 1.2.0** is now available, 6 June, 2018. `Download SINGA v1.2.0 <downloads.html>`_
 
 * **Version 1.1.0** is now available, 12 Feb, 2017. `Download SINGA v1.1.0 <downloads.html>`_


### PR DESCRIPTION
This commit closes the issue with the minimal solution. But more work will be needed in future to improve SINGA security.

It includes also fixing little typing mistakes in install_win.rst