### PR TITLE
SINGA-422 ModuleNotFoundError: No module named '_singa_wrap'

### DIFF
--- a/tool/conda/singa/meta.yaml
+++ b/tool/conda/singa/meta.yaml
@@ -38,8 +38,12 @@ requirements:
     - protobuf 3.6.1
     - glog 0.3.4
     - libgfortran 3.0.0 # [osx]
-    - gcc 4.8.5 # [linux]
-    - python 2.7* [py27]
+    - gcc_impl_linux-64 7.3.0 habb00fd_1 # [linux]
+    - gcc_linux-64 7.3.0 h553295d_3 # [linux]
+    - gxx_impl_linux-64 7.3.0 hdf63c60_1 # [linux]
+    - gxx_linux-64 7.3.0 h553295d_3 # [linux]
+    - libgcc-ng 8.2.0 hdf63c60_1 # [linux]
+    - libstdcxx-ng 8.2.0 hdf63c60_1 # [linux]
     - python 3.6* [py36]
     - numpy 1.12.0
 
@@ -48,7 +52,8 @@ requirements:
     - protobuf 3.6.1
     - glog 0.3.4
     - libgfortran 3.0.0 # [osx]
-    - libgcc 4.8.5 # [linux]
+    - libgcc-ng >=7.3.0 # [linux]
+    - libstdcxx-ng >=7.3.0 # [linux]
     - python 2.7* [py27]
     - python 3.6* [py36]
     - numpy >=1.12.0


### PR DESCRIPTION
Fix the error due to the upgrade of protobuf version which requires a
higher gcc and glib version.