### PR TITLE
SINGA-422 ModuleNotFoundError: No module named '_singa_wrap'

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -47,9 +47,9 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
+        #'Programming Language :: Python :: 2',
+        #'Programming Language :: Python :: 2.6',
+        #'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         ],
 
@@ -59,18 +59,18 @@ setup(
 
     # py_modules=["singa"],
 
-    install_requires=[
-        'numpy>=1.11.0',
-        'protobuf>=3',
-        'unittest-xml-reporting',
-        'flask>=0.10.1',
-        'flask_cors>=3.0.2',
-        'pillow>=2.3.0',
-        'future',
-    #    'xmlrunner',
-        'tqdm',
-    #    'ipywidgets',
-        ],
+    #install_requires=[
+    #    'numpy>=1.11.0',
+    #    'protobuf==3.6.1',
+    #    'unittest-xml-reporting',
+    #    'flask>=0.10.1',
+    #    'flask_cors>=3.0.2',
+    #    'pillow>=2.3.0',
+    #    'future',
+    #    'tqdm',
+    #    'openblas==0.2.19',
+    #    'glog==0.3.4',
+    #    ],
 
     #List additional groups of dependencies here (e.g. development
     #dependencies). You can install these using the following syntax,

--- a/tool/conda/singa/meta.yaml
+++ b/tool/conda/singa/meta.yaml
@@ -22,8 +22,8 @@ package:
   version: "{{ GIT_DESCRIBE_TAG }}"
 
 source:
-  # path: /home/wangwei/incubator-singa/
-  git_url: https://github.com/apache/incubator-singa.git
+  # path: /path to/incubator-singa/
+  git_url: https://github.com/nusdbsystem/incubator-singa.git
 
 build:
   number: 0
@@ -35,27 +35,20 @@ requirements:
   build:
     - swig 3.0.10
     - openblas 0.2.19
-    - protobuf 3.6.1
+    - protobuf 3.2.0
     - glog 0.3.4
     - libgfortran 3.0.0 # [osx]
-    - gcc_impl_linux-64 7.3.0 habb00fd_1 # [linux]
-    - gcc_linux-64 7.3.0 h553295d_3 # [linux]
-    - gxx_impl_linux-64 7.3.0 hdf63c60_1 # [linux]
-    - gxx_linux-64 7.3.0 h553295d_3 # [linux]
-    - libgcc-ng 8.2.0 hdf63c60_1 # [linux]
-    - libstdcxx-ng 8.2.0 hdf63c60_1 # [linux]
-    - python 3.6* [py36]
+    - gcc 4.8.5 # [linux]
+    - python 3.6*
     - numpy 1.12.0
 
   run:
     - openblas 0.2.19
-    - protobuf 3.6.1
+    - protobuf 3.2.0
     - glog 0.3.4
     - libgfortran 3.0.0 # [osx]
-    - libgcc-ng >=7.3.0 # [linux]
-    - libstdcxx-ng >=7.3.0 # [linux]
-    - python 2.7* [py27]
-    - python 3.6* [py36]
+    - libgcc 4.8.5 # [linux]
+    - python 3.6*
     - numpy >=1.12.0
     - flask >=0.10.1
     - flask-cors >=3.0.2

--- a/tool/conda/singa/meta.yaml
+++ b/tool/conda/singa/meta.yaml
@@ -23,7 +23,7 @@ package:
 
 source:
   # path: /path to/incubator-singa/
-  git_url: https://github.com/nusdbsystem/incubator-singa.git
+  git_url: https://github.com/apache/incubator-singa.git
 
 build:
   number: 0


### PR DESCRIPTION
I tried to use gcc and gxx 5.4 or 7.3. However, there are various errors due to the mismatch of gcc/gxx, cuda, protobuf
versions. E.g., `CXXABI_1.3.8' not found, `GLIBCXX_3.4.20' not found.

Now the solution is to rollback the protobuf version to 3.2.0 and gcc to
4.8.5.

Ref. SINGA-396 SINGA409.

To test: Uninstall the previous singa and protobuf and install the new version.