### PR TITLE
*fix bug: segmentation fault at test case

### DIFF
--- a/src/core/tensor/tensor.cc
+++ b/src/core/tensor/tensor.cc
@@ -1228,6 +1228,8 @@ void SoftmaxCrossEntropyBwd(const Tensor &t, Tensor *p) {
 // if tensor is not transposed yet, we change the shape and generate new strides
 // if tensor is already transposed, we reallocate the memory and generate strides
 Tensor& Tensor::Reshape(const Shape &shape) {
+  // Check original shape's volume is same with the new one
+  CHECK_EQ(Product(shape), Product(shape_));
   if (transpose()) {
     Tensor t(shape, device_, data_type_);
     singa::Transform(*this, &t);

--- a/test/singa/test_cross_entropy.cc
+++ b/test/singa/test_cross_entropy.cc
@@ -29,8 +29,8 @@ using singa::Tensor;
 class TestSoftmaxCrossEntropy : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    p.Reshape(singa::Shape{2, 4});
-    t.Reshape(singa::Shape{2, 1});
+    p.SetShape(singa::Shape{2, 4});
+    t.SetShape(singa::Shape{2, 1});
     ta.Reshape(singa::Shape{2, 4});
   }
   const float pdat[8] = {0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f };

--- a/test/singa/test_mse.cc
+++ b/test/singa/test_mse.cc
@@ -28,8 +28,8 @@ using singa::Tensor;
 class TestMSE : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    p.Reshape(singa::Shape{2, 3});
-    t.Reshape(singa::Shape{2, 3});
+    p.SetShape(singa::Shape{2, 3});
+    t.SetShape(singa::Shape{2, 3});
     p.CopyDataFromHostPtr(pdat, sizeof(pdat) / sizeof(float));
     t.CopyDataFromHostPtr(tdat, sizeof(pdat) / sizeof(float));
   }

--- a/test/singa/test_tensor_math.cc
+++ b/test/singa/test_tensor_math.cc
@@ -25,11 +25,11 @@ using singa::Device;
 class TestTensorMath : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    a.Reshape(singa::Shape{6});
-    b.Reshape(singa::Shape{6});
-    c.Reshape(singa::Shape{6, 1});
-    d.Reshape(singa::Shape{3, 2});
-    e.Reshape(singa::Shape{3, 2});
+    a.SetShape(singa::Shape{6});
+    b.SetShape(singa::Shape{6});
+    c.SetShape(singa::Shape{6, 1});
+    d.SetShape(singa::Shape{3, 2});
+    e.SetShape(singa::Shape{3, 2});
 
     a.CopyDataFromHostPtr<float>(dat1, 6);
     b.CopyDataFromHostPtr<float>(dat2, 6);


### PR DESCRIPTION
*fix bug:
    - allow reshaping on an empty tensor then give it data will invoke segmentation fault.
*how to fix:
    - when reshape, add a check requiring the original shape's volume must be same with new one.
    - fix corresponding test case(test_mse, test_cross_entropy, test_tensor_math)