### PR TITLE
hf:reshape error

### DIFF
--- a/src/model/operation/batchnorm.cc
+++ b/src/model/operation/batchnorm.cc
@@ -195,8 +195,11 @@ const std::vector<Tensor> CpuBatchNormBackwardx(const BatchNormHandle &bnh,
   }, {x.block(), dy.block(), mean.block(), var.block()},
   {dx.block(), dw.block()});
 
-  Tensor dbnScale = CopyRows(dw, 0, bnScale.Size()).Reshape({bnScale.Size()});
-  Tensor dbnBias = CopyRows(dw, 1, bnBias.Size()).Reshape({bnBias.Size()});
+  singa::Tensor dbnScale(bnScale.shape());
+  CopyDataToFrom(&dbnScale, dw, bnScale.Size(), 0, 0);
+  singa::Tensor dbnBias(bnBias.shape());
+  CopyDataToFrom(&dbnBias, dw, bnBias.Size(), 0, bnScale.Size());
+
   CHECK(dbnScale.nDim() == bnScale.nDim()) << "dbnScale ndim not match bnScale";
   CHECK(dbnBias.nDim() == bnBias.nDim()) << "dbnScale ndim not match bnScale";
   CHECK(dbnScale.shape()[0] == bnScale.shape()[0]) << "dbnScale shape not match bnScale";

--- a/test/singa/test_cross_entropy.cc
+++ b/test/singa/test_cross_entropy.cc
@@ -31,7 +31,7 @@ class TestSoftmaxCrossEntropy : public ::testing::Test {
   virtual void SetUp() {
     p.SetShape(singa::Shape{2, 4});
     t.SetShape(singa::Shape{2, 1});
-    ta.Reshape(singa::Shape{2, 4});
+    ta.SetShape(singa::Shape{2, 4});
   }
   const float pdat[8] = {0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f };
   const int tdat[2] = {0, 2};

--- a/test/singa/test_tensor.cc
+++ b/test/singa/test_tensor.cc
@@ -53,18 +53,18 @@ TEST(TensorTest, TestConstructor) {
 
 TEST(TensorClass, Reshape) {
   Tensor t;
-  t.Reshape(Shape{2,3});
+  t.SetShape(Shape{2,3});
   EXPECT_TRUE((Shape{2,3} == t.shape()));
 
-  t.Reshape(Shape{3,3, 4});
+  t.SetShape(Shape{3,3, 4});
   EXPECT_TRUE((Shape{3,3, 4} == t.shape()));
 
-  t.Reshape(Shape{12});
+  t.SetShape(Shape{12});
   EXPECT_TRUE((Shape{12} == t.shape()));
 
   Tensor o;
   EXPECT_TRUE(o.shape() != t.shape());
-  o.Reshape(Shape{3, 3});
+  o.SetShape(Shape{3, 3});
   EXPECT_TRUE(o.shape() != t.shape());
 }
 


### PR DESCRIPTION
Hi teams,

This is to fix some broken `Reshape` after adding a extra restriction on reshaping.

After this fix, unit_test all passing by directly compiling against updated dockerfile except `Tensor.T` test, which is discussed at: https://github.com/apache/incubator-singa/pull/438