### PR TITLE
Update for protobuf version range, breaks with v3 protobuf

### DIFF
--- a/doc/en/docs/installation.md
+++ b/doc/en/docs/installation.md
@@ -96,7 +96,7 @@ for the instructions of installing them on Ubuntu 16.04.
 
 * cmake (>=2.8)
 * gcc (>=4.8.1)
-* google protobuf (>=2.5)
+* google protobuf (>=2.5 <3.0)
 * blas (tested with openblas >=0.2.10)
 * swig(>=3.0.10) for compiling PySINGA
 * numpy(>=1.11.0) for compiling PySINGA


### PR DESCRIPTION
Building source as per [](https://singa.incubator.apache.org/en/docs/installation.html) from with the `USE_MODULES=ON` flag pulls in protobuf 3.3.0 and the compilation fails with message `/src/caffe.pb.cc:31115:35: error: ‘MergeFromFail’ is not a member of ‘google::protobuf::internal’
     ::google::protobuf::internal::MergeFromFail(__FILE__, __LINE__);`

This is caused by the caffe.proto file being built against the proto 2.xx schema end emitting a c++ file with a call to MergeFromFail which was deprecated in the 3.x.x version of 
protobuf. 

This is a temp message to show the compatibility requirements to get a functional build. 

Full solution is to migrate to v3 protobuf