### PR TITLE
SINGA-460 - Build packages for Py36 and Py37

### DIFF
--- a/tool/conda/docker/cuda10/Dockerfile
+++ b/tool/conda/docker/cuda10/Dockerfile
@@ -15,15 +15,8 @@
 # limitations under the License.
 #
 
-# 18.04 has erros in ssh 
+# 18.04 has erros in ssh
 FROM nvidia/cuda:10.0-devel-ubuntu16.04
-
-ENV CUDNN_VERSION 7.4.2.24
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        libcudnn7=$CUDNN_VERSION-1+cuda10.0 \
-        libcudnn7-dev=$CUDNN_VERSION-1+cuda10.0 && \
-    apt-mark hold libcudnn7 && \
-    rm -rf /var/lib/apt/lists/*
 
 # install dependencies
 RUN apt-get update \

--- a/tool/conda/docker/cuda9/Dockerfile
+++ b/tool/conda/docker/cuda9/Dockerfile
@@ -19,14 +19,6 @@
 FROM nvidia/cuda:9.0-devel-ubuntu16.04
 
 
-ENV CUDNN_VERSION 7.4.2.24
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        libcudnn7=$CUDNN_VERSION-1+cuda9.0 \
-        libcudnn7-dev=$CUDNN_VERSION-1+cuda9.0 && \
-    apt-mark hold libcudnn7 && \
-    rm -rf /var/lib/apt/lists/*
-
 # install dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/tool/conda/singa/meta.yaml
+++ b/tool/conda/singa/meta.yaml
@@ -29,7 +29,7 @@ build:
   number: 0
   script_env:
     - CUDA   # E.g., export CUDA=9.0
-  string: {{ build_str }}
+  string: {{ build_str }}_py{{ py }}
   # py{{py}}_{{ environ.get('BUILD_STR', 'cpu') }}
 
 requirements:
@@ -37,19 +37,19 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
     - cmake >=3.12.2
-    - make # [unix]    
+    - make # [unix]
 
   host:
     - swig 3.0.12
     - openblas 0.3.3
     - protobuf 3.6.1
-    - glog 0.3.5    
+    - glog 0.3.5
     - numpy 1.16.0
     - cudnn {{ cudnn }}       # ['cudnn' in str(build_str)]
     - mkl-dnn {{ mkldnn }}
     - python {{ python }}
 
-  run:    
+  run:
     - {{ pin_compatible('glog', max_pin='x.x') }}
     - {{ pin_compatible('numpy', max_pin='x.x') }}
     - {{ pin_compatible('mkl-dnn', max_pin='x.x') }}


### PR DESCRIPTION
Add py36 or py37 to the build string of conda packages
Update the docker file for conda build by removing cudnn