### PR TITLE
SINGA-440 update available dockerhub tags

### DIFF
--- a/tool/docker/README.md
+++ b/tool/docker/README.md
@@ -21,12 +21,11 @@
 
 ## Available tags
 
-* `1.2.0-cuda10.0-cudnn7.4.2-devel-ubuntu18.04`
-* `1.2.0-cuda10.0-cudnn7.4.2-ubuntu16.04`
-* `1.2.0-cuda9.0-cudnn7.4.2-devel-ubuntu16.04`
-* `1.2.0-cuda9.0-cudnn7.4.2-ubuntu16.04`
-* `1.2.0-cpu-devel-ubuntu18.04`
-* `1.2.0-cpu-runtime-ubuntu16.04`
+* `2.0.0-cuda10.0-cudnn7.4.2-devel-ubuntu18.04`
+* `2.0.0-cuda9.0-cudnn7.4.2-devel-ubuntu16.04`
+* `2.0.0-cuda9.0-cudnn7.4.2-ubuntu16.04`
+* `2.0.0-cpu-devel-ubuntu18.04`
+* `2.0.0-cpu-ubuntu16.04`
 
 ## Use the existing Docker images
 

--- a/tool/docker/README.md
+++ b/tool/docker/README.md
@@ -21,8 +21,12 @@
 
 ## Available tags
 
-* `devel`, with SINGA and the development packages installed on Ubuntu16.04 (no GPU)
-* `devel-cuda`, with SINGA, CUDA8.0, CUDNN5, and other development packages installed on Ubuntu16.04
+* `1.2.0-cuda10.0-cudnn7.4.2-devel-ubuntu18.04`
+* `1.2.0-cuda10.0-cudnn7.4.2-ubuntu16.04`
+* `1.2.0-cuda9.0-cudnn7.4.2-devel-ubuntu16.04`
+* `1.2.0-cuda9.0-cudnn7.4.2-ubuntu16.04`
+* `1.2.0-cpu-devel-ubuntu18.04`
+* `1.2.0-cpu-runtime-ubuntu16.04`
 
 ## Use the existing Docker images
 


### PR DESCRIPTION
dear team,

Among all the available tags on https://hub.docker.com/r/apache/singa/tags
These are tested and workings, thus updating the tags names in the README.

ref. SINGA-440