### PR TITLE
SINGA-478 Improve __itruediv__ in tensor.py

### DIFF
--- a/python/singa/tensor.py
+++ b/python/singa/tensor.py
@@ -475,9 +475,9 @@ class Tensor(object):
             x (float or Tensor):
         '''
         if isinstance(x, Tensor):
-            self.data *= (1.0/x.data)
+            self.data /= x.data
         else:
-            self.data *= (1.0/float(x))
+            self.data /= float(x)
         return self
 
     '''


### PR DESCRIPTION
Improve the `__itruediv__ `operation by using the /= operator of c tensor (i.e tensor.data) directly instead of *= operator.

Has tested two cases (because for end to end purpose):
Case 1. simple tensor division in ncrf docker container
```python
from singa import tensor
from singa import device
import numpy as np

Y = np.ones(shape=[10],dtype=np.float32) * 10.0
y = tensor.from_numpy(Y)
y.to_device(device.get_default_device())

y.to_device(device.create_cuda_gpu_on(1))

def divide(y):
   y /= 10

divide(y)
print(tensor.to_numpy(y))

```
Result
```
root@26c9db193eb0:~/incubator-singa# python3 /root/incubator-singa/python/singa/test.py
[1. 1. 1. 1. 1. 1. 1. 1. 1. 1.]
```

Case 2. 8 GPUs mnist distributed training in AWS (i.e. mnist_dist_demo.py)

```
ubuntu@ip-172-31-17-155:~$ /home/ubuntu/mpich-3.3/build/bin/mpiexec --hostfile host_file python3 mnist_dist_demo.py
Starting Epoch 0:
Training loss = 783.123352, training accuracy = 0.715962
Evaluation accuracy = 0.934725, Elapsed Time = 1.233076s
Starting Epoch 1:
Training loss = 242.677368, training accuracy = 0.918319
Evaluation accuracy = 0.947471, Elapsed Time = 1.212262s
Starting Epoch 2:
Training loss = 170.743698, training accuracy = 0.944528
Evaluation accuracy = 0.969470, Elapsed Time = 1.209891s
Starting Epoch 3:
Training loss = 139.503311, training accuracy = 0.953576
Evaluation accuracy = 0.972245, Elapsed Time = 1.203797s
Starting Epoch 4:
Training loss = 116.949448, training accuracy = 0.960587
Evaluation accuracy = 0.974507, Elapsed Time = 1.198999s
Starting Epoch 5:
Training loss = 105.758972, training accuracy = 0.964660
Evaluation accuracy = 0.978927, Elapsed Time = 1.193396s
Starting Epoch 6:
Training loss = 94.905945, training accuracy = 0.967715
Evaluation accuracy = 0.977899, Elapsed Time = 1.188658s
Starting Epoch 7:
Training loss = 88.838104, training accuracy = 0.969852
Evaluation accuracy = 0.978104, Elapsed Time = 1.183608s
Starting Epoch 8:
Training loss = 80.671959, training accuracy = 0.972740
Evaluation accuracy = 0.981702, Elapsed Time = 1.181310s
Starting Epoch 9:
Training loss = 75.229439, training accuracy = 0.974776
Evaluation accuracy = 0.982833, Elapsed Time = 1.184428s
```
