### PR TITLE
SINGA-485 Add code coverage with codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,8 @@ matrix:
 install:
   - travis_wait bash -ex tool/travis/depends.sh
 
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
 script:
   - bash -ex tool/travis/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,19 @@ matrix:
     compiler: clang
     # system cblas will be used by cmake for other xcode versions
     osx_image: xcode8
+    name: "macOS 10.11 (C++)" 
   - os: linux
     dist: trusty
     compiler: gcc
+    name: "Ubuntu 14.04 (C++)" 
+  - os: linux
+    dist: xenial
+    compiler: gcc
+    name: "Ubuntu 16.04 (C++)" 
+  - os: linux
+    dist: bionic
+    compiler: gcc
+    name: "Ubuntu 18.04 (C++)" 
 
 install:
   - travis_wait bash -ex tool/travis/depends.sh

--- a/doc/en/develop/build.md
+++ b/doc/en/develop/build.md
@@ -43,7 +43,7 @@ To build the CPU version of SINGA
 
     conda build tool/conda/singa/
 
-The above commands have been tested on Ubuntu 16.04 and Mac OSX.
+The above commands have been tested on Ubuntu (14.04, 16.04 and 18.04) and macOS 10.11.
 Refer to the [Travis-CI page](https://travis-ci.org/apache/incubator-singa) for more information.
 
 ### Build GPU Version


### PR DESCRIPTION
Using [Codecov Bash Uploader](https://docs.codecov.io/docs/about-the-codecov-bash-uploader) with Travis CI to upload coverage information to codecov.io .