### PR TITLE
SINGA-491 Code Cleaning with the Reference of LGTM Analysis Result

### DIFF
--- a/examples/autograd/mnist_cnn.py
+++ b/examples/autograd/mnist_cnn.py
@@ -23,15 +23,10 @@ from singa import tensor
 from singa import device
 from singa import opt
 import numpy as np
-from tqdm import trange
 import os
 import sys
 import gzip
 import codecs
-try:
-    import pickle
-except ImportError:
-    import cPickle as pickle
 import time
 
 class CNN:

--- a/examples/autograd/resnet.py
+++ b/examples/autograd/resnet.py
@@ -28,17 +28,6 @@ from singa import opt
 import numpy as np
 from tqdm import trange
 
-
-__all__ = [
-    "ResNet",
-    "resnet18",
-    "resnet34",
-    "resnet50",
-    "resnet101",
-    "resnet152",
-]
-
-
 def conv3x3(in_planes, out_planes, stride=1):
     """3x3 convolution with padding"""
     return autograd.Conv2d(
@@ -242,6 +231,14 @@ def resnet152(pretrained=False, **kwargs):
 
     return model
 
+__all__ = [
+    'ResNet',
+    'resnet18',
+    'resnet34',
+    'resnet50',
+    'resnet101',
+    'resnet152',
+]
 
 if __name__ == "__main__":
     model = resnet50()
@@ -268,7 +265,7 @@ if __name__ == "__main__":
     softmax = 0
     update = 0
     with trange(niters) as t:
-        for b in t:
+        for _ in t:
             dev.Sync()
             tick = time.time()
             x = model(tx)
@@ -287,11 +284,11 @@ if __name__ == "__main__":
 
     dev.Sync()            
     end = time.time()
-    throughput = niters * batch_size / (end - start)
+    throughput = float(niters * batch_size) / (end - start)
     print("Throughput = {} per second".format(throughput))
-    titer = (end - start) / niters
-    tforward = fd / niters
-    tsoftmax = softmax / niters
+    titer = (end - start) / float(niters)
+    tforward = float(fd) / float(niters)
+    tsoftmax = float(softmax) / float(niters)
     tbackward = titer - tforward - tsoftmax
-    tsgd = update / niters
+    tsgd = float(update) / float(niters)
     print("Total={}, forward={}, softmax={}, backward={}, sgd={}".format(titer, tforward, tsoftmax, tbackward, tsgd))

--- a/examples/autograd/resnet_dist.py
+++ b/examples/autograd/resnet_dist.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     softmax = 0
     update = 0
     with trange(niters) as t:
-        for b in t:
+        for _ in t:
             dev.Sync()
             tick = time.time()
             x = model(tx)
@@ -78,12 +78,12 @@ if __name__ == "__main__":
 
     dev.Sync()            
     end = time.time()
-    throughput = sgd.world_size * niters * batch_size / (end - start)
-    titer = (end - start) / niters
-    tforward = fd / niters
-    tsoftmax = softmax / niters
+    throughput = float(sgd.world_size * niters * batch_size) / (end - start)
+    titer = (end - start) / float(niters)
+    tforward = float(fd) / float(niters)
+    tsoftmax = float(softmax) / float(niters)
     tbackward = titer - tforward - tsoftmax
-    tsgd = update / niters
+    tsgd = float(update) / float(niters)
 
     if (sgd.rank_in_global == 0):
         print("\nThroughput = {} per second".format(throughput), flush=True)

--- a/examples/autograd/xceptionnet.py
+++ b/examples/autograd/xceptionnet.py
@@ -27,9 +27,6 @@ from tqdm import trange
 # the code is modified from
 # https://github.com/Cadene/pretrained-models.pytorch/blob/master/pretrainedmodels/models/xception.py
 
-__all__ = ['xception']
-
-
 class Block(autograd.Layer):
 
     def __init__(self, in_filters, out_filters, reps, strides=1, padding=0, start_with_relu=True, grow_first=True):
@@ -189,6 +186,7 @@ class Xception(autograd.Layer):
         x = self.logits(x)
         return x
 
+__all__ = ['xception']
 
 if __name__ == '__main__':
     model = Xception(num_classes=1000)
@@ -210,7 +208,7 @@ if __name__ == '__main__':
     ty.copy_from_numpy(y)
 
     with trange(niters) as t:
-        for b in t:
+        for _ in t:
             x = model(tx)
             loss = autograd.softmax_cross_entropy(x, ty)
             for p, g in autograd.backward(loss):

--- a/examples/imagenet/googlenet/serve.py
+++ b/examples/imagenet/googlenet/serve.py
@@ -20,14 +20,12 @@ https://github.com/BVLC/caffe/blob/master/models/bvlc_googlenet/
 from __future__ import print_function
 from builtins import zip
 from builtins import str
-import os
 import sys
 import time
 import numpy as np
-import threading
 import traceback
 from argparse import ArgumentParser
-from scipy.misc import imread, imresize
+from scipy.misc import imread
 import numpy as np
 
 from singa.layer import Layer, Conv2D, Activation, MaxPooling2D, AvgPooling2D,\

--- a/examples/imagenet/resnet/model.py
+++ b/examples/imagenet/resnet/model.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 from builtins import zip
 from builtins import range
 from singa.layer import Conv2D, Activation, MaxPooling2D, AvgPooling2D,\
-        Split, Merge, Flatten, Dense, BatchNormalization, Softmax
+        Split, Merge, Flatten, Dense, BatchNormalization
 from singa import net as ffnet
 from singa import initializer
 from singa import layer
@@ -140,7 +140,7 @@ def stage(sid, net, num_blk, inplane, midplane, outplane, stride, block, preact=
         block('stage%d-blk%d' % (sid, i), net, outplane, midplane, outplane, 1, preact, add_bn)
 
 def init_params(net, weight_path=None):
-    if weight_path == None:
+    if weight_path is None:
         for pname, pval in zip(net.param_names(), net.param_values()):
             print(pname, pval.shape)
             if 'conv' in pname and len(pval.shape) > 1:
@@ -261,7 +261,7 @@ def create_wide_resnet(depth=50):
     return net
 
 
-def create_net(name, depth, use_cpu):
+def create_net(name, depth, use_cpu=True):
     if use_cpu:
         layer.engine = 'singacpp'
     if name == 'resnet':

--- a/examples/mnist/train.py
+++ b/examples/mnist/train.py
@@ -48,7 +48,6 @@ def train(data_file, use_gpu, num_epoch=10, batch_size=100):
     weight_decay = 0.0002
     hdim = 1000
     vdim = 784
-    opt = optimizer.SGD(momentum=0.8, weight_decay=weight_decay)
 
     tweight = tensor.Tensor((vdim, hdim))
     tweight.gaussian(0.0, 0.1)

--- a/python/singa/autograd.py
+++ b/python/singa/autograd.py
@@ -418,11 +418,8 @@ class Less(Operation):
         """
         Args:
             dy (CTensor): data for the dL / dy, L is the loss
-        Returns:
-            a tuple for (dx0, dx1)
         """
         assert 0,('no backward function for less')
-        return None
 
 def less(x,y):
     return Less()(x,y)[0]
@@ -538,11 +535,8 @@ class Greater(Operation):
         """
         Args:
             dy (CTensor): data for the dL / dy, L is the loss
-        Returns:
-            a tuple for (dx0, dx1)
         """
         assert 0,('no backward function for greater')
-        return None
 
 def greater(x,y):
     return Greater()(x,y)[0]
@@ -730,11 +724,8 @@ class Equal(Operation):
         """
         Args:
             dy (CTensor): data for the dL / dy, L is the loss
-        Returns:
-            a tuple for (dx, dx1)
         """
         assert 0,('no backward function for equal')
-        return None
 
 def equal(x,y):
     return Equal()(x,y)[0]

--- a/python/singa/autograd.py
+++ b/python/singa/autograd.py
@@ -419,7 +419,7 @@ class Less(Operation):
         Args:
             dy (CTensor): data for the dL / dy, L is the loss
         """
-        assert 0,('no backward function for less')
+        assert False,('no backward function for less')
 
 def less(x,y):
     return Less()(x,y)[0]
@@ -536,7 +536,7 @@ class Greater(Operation):
         Args:
             dy (CTensor): data for the dL / dy, L is the loss
         """
-        assert 0,('no backward function for greater')
+        assert False,('no backward function for greater')
 
 def greater(x,y):
     return Greater()(x,y)[0]
@@ -725,7 +725,7 @@ class Equal(Operation):
         Args:
             dy (CTensor): data for the dL / dy, L is the loss
         """
-        assert 0,('no backward function for equal')
+        assert False,('no backward function for equal')
 
 def equal(x,y):
     return Equal()(x,y)[0]
@@ -1654,7 +1654,7 @@ class MaxPool1d(Pooling2d):
     def __init__(self, kernel_size, stride=None, padding=0):
         if stride is None:
             stride = kernel_size
-        super(MaxPool2d, self).__init__(
+        super(MaxPool1d, self).__init__(
             (1, kernel_size), (0, stride), (0, padding), True
         )
 
@@ -1663,7 +1663,7 @@ class AvgPool1d(Pooling2d):
     def __init__(self, kernel_size, stride=None, padding=0):
         if stride is None:
             stride = kernel_size
-        super(MaxPool2d, self).__init__(
+        super(AvgPool1d, self).__init__(
             (1, kernel_size), (0, stride), (0, padding), False
         )
 

--- a/python/singa/image_tool.py
+++ b/python/singa/image_tool.py
@@ -114,7 +114,7 @@ def crop_and_resize(img, patch, position):
     box = (left, upper, right, bottom)
     new_img = img.crop(box)
 
-    new_img = img.resize(patch, Image.BILINEAR)
+    new_img = new_img.resize(patch, Image.BILINEAR)
     # print box+crop
     # print "crop to box %d,%d,%d,%d and scale to %d,%d" % (box+crop)
     return new_img
@@ -326,7 +326,7 @@ class ImageTool(object):
             raise Exception('num_case must be in [1,5]')
         for img in self.imgs:
 
-            if num_case > 0 and num_case < 5:
+            if num_case < 5:
                 positions = get_list_sample(positions, num_case)
 
             for position in positions:
@@ -361,12 +361,12 @@ class ImageTool(object):
         for img in self.imgs:
             size = img.size
             if size[0] > size[1]:
-                if num_case > 0 and num_case < 3:
+                if num_case < 3:
                     positions = get_list_sample(positions_horizental, num_case)
                 else:
                     positions = positions_horizental
             else:
-                if num_case > 0 and num_case < 3:
+                if num_case < 3:
                     positions = get_list_sample(positions_vertical, num_case)
                 else:
                     positions = positions_vertical

--- a/python/singa/optimizer.py
+++ b/python/singa/optimizer.py
@@ -170,7 +170,6 @@ class Optimizer(object):
             updated parameter value
         '''
         assert False, 'This is the base function, pls call the subclass func'
-        return value
 
     def apply(self, epoch, grad, value, name=None, step=-1):
         '''Do update assuming the learning rate generator is set.
@@ -380,7 +379,6 @@ class Regularizer(object):
 
     def apply(self, epoch, value, grad, step=-1):
         assert False, 'Not Implemented. Call the subclass function.'
-        return grad
 
 
 class CppRegularizer(Regularizer):

--- a/python/singa/sonnx.py
+++ b/python/singa/sonnx.py
@@ -26,7 +26,6 @@ from collections import deque
 from . import singa_wrap as singa
 from . import autograd
 from . import tensor
-from . import device
 
 import collections
 
@@ -657,7 +656,6 @@ class SingaBackend(Backend):
         Returns: 
             the autograd of singa operator
         """
-        x = inputs[0]
         alpha = onnx_node.attrs["alpha"]
         beta = onnx_node.attrs["beta"]
         transA = False if onnx_node.attrs["transA"] == 0 else True
@@ -941,8 +939,8 @@ class SingaRep(BackendRep):
                 return outputs[op_name]
             else:
                 raise RuntimeError(
-                    "The op_name {} does not exist, please check. The available op_names are: {}" %
-                    (op_name, [val for key, val in op_name.items()]))
+                    "The op_name {} does not exist, please check. The available op_names are: {}".format(
+                        op_name, [val for key, val in op_name.items()]))
 
         # return all outputs if all_outputs==True
         # else return last outputs

--- a/python/singa/tensor.py
+++ b/python/singa/tensor.py
@@ -142,7 +142,7 @@ class Tensor(object):
         To transpose the tensor
         '''
         t = Tensor(self.shape, self.device, self.dtype)
-        if axes == None:
+        if axes is None:
             tshape = [self.shape[x] for x in range(len(t.shape))]
             t.shape = tuple(tshape)
             t.data = singa.DefaultTranspose(self.data)
@@ -298,7 +298,7 @@ class Tensor(object):
             if axis != None and axis < 0:
                 axis += t_ndim
             # broadcast = True
-            if axis == None:
+            if axis is None:
                 axis = 9999
                 t.shape = (product(self.shape) * repeats,)
                 Repeats = [repeats, ]
@@ -318,8 +318,7 @@ class Tensor(object):
 
             if axis != None and axis < 0:
                 axis += t_ndim
-            if axis == None:
-                axis = 9999
+            if axis is None:
                 raise ValueError(
                     "when axis us None, 'repeats' should be int: {}".format(repeats))
             elif axis >= 0:
@@ -1265,7 +1264,6 @@ def tensordot(A, B, axes=2):
     if type(axes) == int:
         axes_A = list(range(-axes, 0))
         axes_B = list(range(0, axes))
-        axes_B = axes_B
     else:
         axes_A, axes_B = axes
     # when axes is a pair of sequences of integers.For example, A is in shape(3,2,4),

--- a/src/core/tensor/tensor_math_cpp.h
+++ b/src/core/tensor/tensor_math_cpp.h
@@ -809,11 +809,11 @@ void ComputeCrossEntropy<float, lang::Cpp>(bool int_target,
       for (size_t j = 0; j < dim; j++) {
         sum += tPtr[i * dim + j];
       }
-      float loss = 0.f;
+      float loss_value = 0.f;
       for (size_t j = 0, offset = i * dim; j < dim; j++, offset++) {
-        loss -= tPtr[offset] / sum * std::log((std::max)(pPtr[offset], FLT_MIN));
+        loss_value -= tPtr[offset] / sum * std::log((std::max)(pPtr[offset], FLT_MIN));
       }
-      lossPtr[i] = loss;
+      lossPtr[i] = loss_value;
     }
   }
 }

--- a/src/model/layer/convolution.cc
+++ b/src/model/layer/convolution.cc
@@ -227,7 +227,7 @@ void Col2im(const float *data_col, const int channels,
                          const int pad_h, const int pad_w,
                          const int stride_h, const int stride_w,
                          float *data_im) {
-  memset(data_im, 0, height * width * channels * sizeof(float));
+  memset(data_im, 0, (unsigned long) height * width * channels * sizeof(float));
   int height_col = (height + 2 * pad_h - kernel_h) / stride_h + 1;
   int width_col  = ( width + 2 * pad_w - kernel_w) / stride_w + 1;
   int channels_col = channels * kernel_h * kernel_w;

--- a/tool/opencl/clsrc_to_str.py
+++ b/tool/opencl/clsrc_to_str.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
  */
 """
         fout.write(license)
-		fout.write("#ifdef USE_OPENCL\n\n")
+        fout.write("#ifdef USE_OPENCL\n\n")
         fout.write("#include <string>\n\n")
         fout.write("namespace singa {\n namespace opencl {\n")
         for name, path in iteritems(files):


### PR DESCRIPTION
Since LGTM has been applied for our code analysis (see SINGA-484), I have cleaned up many of the obvious issues alerted by LGTM.


The compile result is okay as follows:
```
ubuntu@ip-172-31-39-137:~/incubator-singa/build$ rm -rf *
ubuntu@ip-172-31-39-137:~/incubator-singa/build$ cmake -D CMAKE_PREFIX_PATH="/usr/local/cuda/lib64;/usr/local/                          cuda/" -DENABLE_TEST=OFF -DUSE_CUDA=ON -DUSE_PYTHON3=ON -DUSE_MKLDNN=ON -DUSE_MODULES=OFF -DUSE_DIST=ON ..
-- The C compiler identification is GNU 5.4.0
-- The CXX compiler identification is GNU 5.4.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE
-- Found Protobuf: /usr/local/lib/libprotobuf.so;-lpthread (found suitable version "3.0.0", minimum required i                          s "3.0")
-- Found CBLAS: /usr/local/include
-- Found GLOG: /usr/include
-- Found cuda_v10.0
-- Found CUDNN: /usr/local/cuda/include
-- Found Cudnn_7401 at /usr/local/cuda/include /usr/local/cuda/lib64/libcudnn.so
-- Found PythonInterp: /usr/bin/python3 (found suitable version "3.5.2", minimum required is "3")
-- Found PythonLibs: /usr/lib/x86_64-linux-gnu/libpython3.5m.so (found suitable version "3.5.2", minimum requi                          red is "3")
-- Found SWIG: /usr/local/bin/swig (found suitable version "3.0.12", minimum required is "3.0.10")
-- Found MKLDNN at /usr/local/include
-- Found MPI at /home/ubuntu/mpich-3.3/build/include
-- Found MPI lib at /home/ubuntu/mpich-3.3/build/lib/libmpi.so
-- Found all lib at /usr/local/lib/libprotobuf.so;/usr/local/lib/libopenblas.so;/usr/lib/x86_64-linux-gnu/libg                          log.so;/usr/local/cuda/lib64/libcudnn.so;/usr/local/cuda/lib64/libcudart.so;/usr/local/cuda/lib64/libcurand.so                          ;/usr/local/cuda/lib64/libcublas.so;/home/ubuntu/incubator-singa/build/lib/libcnmem.a;/usr/local/lib/libmkldnn                          .so;/home/ubuntu/mpich-3.3/build/lib/libmpi.so;/home/ubuntu/mpich-3.3/build/lib/libmpicxx.so
-- Found NCCL at /usr/local/cuda/include
-- Found NCCL lib at /usr/local/cuda/lib/libnccl.so
-- Configuring done
-- Generating done
-- Build files have been written to: /home/ubuntu/incubator-singa/build
ubuntu@ip-172-31-39-137:~/incubator-singa/build$ make -j4
Scanning dependencies of target cnmem
Scanning dependencies of target copy_protobuf
[  1%] Running C++ protocol buffer compiler on /home/ubuntu/incubator-singa/src/proto/model.proto
[  2%] Creating directories for 'cnmem'
[  3%] Running C++ protocol buffer compiler on /home/ubuntu/incubator-singa/src/proto/caffe.proto
[  4%] Running C++ protocol buffer compiler on /home/ubuntu/incubator-singa/src/proto/core.proto
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: core.prot                          o. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 s                          yntax.)
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: model.pro                          to. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2                           syntax.)
[  5%] Running C++ protocol buffer compiler on /home/ubuntu/incubator-singa/src/proto/io.proto
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: io.proto.                           Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syn                          tax.)
[  6%] Performing download step (git clone) for 'cnmem'
Cloning into 'cnmem'...
[  7%] Copying Protobuf headers
[  7%] Built target copy_protobuf
[  8%] Building NVCC (Device) object src/CMakeFiles/cuda_compile_1.dir/core/tensor/cuda_compile_1_generated_ma                          th_kernel.cu.o
Scanning dependencies of target singa_objects
[  9%] Building CXX object src/CMakeFiles/singa_objects.dir/caffe.pb.cc.o
[ 10%] Building CXX object src/CMakeFiles/singa_objects.dir/io.pb.cc.o
[ 11%] Building CXX object src/CMakeFiles/singa_objects.dir/core.pb.cc.o
Already on 'master'
Your branch is up-to-date with 'origin/master'.
[ 12%] No patch step for 'cnmem'
[ 13%] Performing update step for 'cnmem'
Current branch master is up to date.
[ 14%] Performing configure step for 'cnmem'
-- The C compiler identification is GNU 5.4.0
-- The CXX compiler identification is GNU 5.4.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
[ 15%] Building CXX object src/CMakeFiles/singa_objects.dir/model.pb.cc.o
[ 16%] Building CXX object src/CMakeFiles/singa_objects.dir/utils/channel.cc.o
-- Detecting CXX compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE
-- Configuring done
-- Generating done
-- Build files have been written to: /home/ubuntu/incubator-singa/build/cnmem-prefix/src/cnmem-build
[ 17%] Performing build step for 'cnmem'
Scanning dependencies of target cnmem
[ 50%] Building CXX object CMakeFiles/cnmem.dir/src/cnmem.cpp.o
[100%] Linking CXX static library libcnmem.a
[100%] Built target cnmem
[ 18%] Performing install step for 'cnmem'
[100%] Built target cnmem
Install the project...
-- Install configuration: ""
-- Installing: /home/ubuntu/incubator-singa/build/lib/libcnmem.a
-- Installing: /home/ubuntu/incubator-singa/build/include/cnmem.h
[ 19%] Completed 'cnmem'
[ 20%] Building CXX object src/CMakeFiles/singa_objects.dir/utils/logging.cc.o
[ 20%] Built target cnmem
[ 21%] Building CXX object src/CMakeFiles/singa_objects.dir/io/binfile_reader.cc.o
[ 22%] Building CXX object src/CMakeFiles/singa_objects.dir/io/binfile_writer.cc.o
[ 23%] Building CXX object src/CMakeFiles/singa_objects.dir/io/communicator.cc.o
[ 24%] Building CXX object src/CMakeFiles/singa_objects.dir/io/csv_decoder.cc.o
[ 25%] Building CXX object src/CMakeFiles/singa_objects.dir/io/csv_encoder.cc.o
[ 26%] Building CXX object src/CMakeFiles/singa_objects.dir/io/image_transformer.cc.o
[ 27%] Building CXX object src/CMakeFiles/singa_objects.dir/io/jpg_decoder.cc.o
[ 28%] Building CXX object src/CMakeFiles/singa_objects.dir/io/jpg_encoder.cc.o
[ 29%] Building CXX object src/CMakeFiles/singa_objects.dir/io/lmdb_reader.cc.o
[ 30%] Building CXX object src/CMakeFiles/singa_objects.dir/io/lmdb_writer.cc.o
[ 31%] Building CXX object src/CMakeFiles/singa_objects.dir/io/snapshot.cc.o
[ 32%] Building CXX object src/CMakeFiles/singa_objects.dir/io/textfile_reader.cc.o
[ 34%] Building CXX object src/CMakeFiles/singa_objects.dir/io/textfile_writer.cc.o
[ 35%] Building CXX object src/CMakeFiles/singa_objects.dir/io/network/endpoint.cc.o
[ 36%] Building CXX object src/CMakeFiles/singa_objects.dir/io/network/message.cc.o
[ 37%] Building CXX object src/CMakeFiles/singa_objects.dir/core/device/cpp_cpu.cc.o
[ 38%] Building CXX object src/CMakeFiles/singa_objects.dir/core/device/cuda_gpu.cc.o
[ 39%] Building CXX object src/CMakeFiles/singa_objects.dir/core/device/device.cc.o
[ 40%] Building CXX object src/CMakeFiles/singa_objects.dir/core/device/opencl_device.cc.o
[ 41%] Building CXX object src/CMakeFiles/singa_objects.dir/core/device/platform.cc.o
[ 42%] Building CXX object src/CMakeFiles/singa_objects.dir/core/memory/memory.cc.o
[ 43%] Building CXX object src/CMakeFiles/singa_objects.dir/core/scheduler/scheduler.cc.o
[ 44%] Building CXX object src/CMakeFiles/singa_objects.dir/core/tensor/sparse_tensor.cc.o
[ 45%] Building CXX object src/CMakeFiles/singa_objects.dir/core/tensor/tensor.cc.o
[ 46%] Building CXX object src/CMakeFiles/singa_objects.dir/model/feed_forward_net.cc.o
[ 47%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/activation.cc.o
[ 48%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/batchnorm.cc.o
[ 49%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/concat.cc.o
[ 50%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/convolution.cc.o
[ 51%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/cudnn_activation.cc.o
[ 52%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/cudnn_batchnorm.cc.o
[ 53%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/cudnn_convolution.cc.o
[ 54%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/cudnn_dropout.cc.o
[ 55%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/cudnn_lrn.cc.o
[ 56%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/cudnn_pooling.cc.o
[ 57%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/cudnn_rnn.cc.o
[ 58%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/cudnn_softmax.cc.o
[ 59%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/dense.cc.o
[ 60%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/dropout.cc.o
[ 61%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/flatten.cc.o
[ 62%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/lrn.cc.o
[ 63%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/merge.cc.o
[ 64%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/opencl_convolution.cc.o
[ 65%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/opencl_pooling.cc.o
[ 67%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/pooling.cc.o
[ 68%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/prelu.cc.o
[ 69%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/rnn.cc.o
[ 70%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/slice.cc.o
[ 71%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/softmax.cc.o
[ 72%] Building CXX object src/CMakeFiles/singa_objects.dir/model/layer/split.cc.o
[ 73%] Building CXX object src/CMakeFiles/singa_objects.dir/model/optimizer/adagrad.cc.o
[ 74%] Building CXX object src/CMakeFiles/singa_objects.dir/model/optimizer/local_all_reduce.cc.o
[ 75%] Building CXX object src/CMakeFiles/singa_objects.dir/model/optimizer/nesterov.cc.o
[ 76%] Building CXX object src/CMakeFiles/singa_objects.dir/model/optimizer/optimizer.cc.o
[ 77%] Building CXX object src/CMakeFiles/singa_objects.dir/model/optimizer/rmsprop.cc.o
[ 78%] Building CXX object src/CMakeFiles/singa_objects.dir/model/optimizer/sgd.cc.o
[ 79%] Building CXX object src/CMakeFiles/singa_objects.dir/model/loss/mse.cc.o
[ 80%] Building CXX object src/CMakeFiles/singa_objects.dir/model/loss/softmax_cross_entropy.cc.o
[ 81%] Building CXX object src/CMakeFiles/singa_objects.dir/model/metric/accuracy.cc.o
[ 82%] Building CXX object src/CMakeFiles/singa_objects.dir/model/updater/local_updater.cc.o
[ 83%] Building CXX object src/CMakeFiles/singa_objects.dir/model/updater/updater.cc.o
[ 84%] Building CXX object src/CMakeFiles/singa_objects.dir/model/operation/batchnorm.cc.o
[ 85%] Building CXX object src/CMakeFiles/singa_objects.dir/model/operation/convolution.cc.o
[ 86%] Building CXX object src/CMakeFiles/singa_objects.dir/model/operation/pooling.cc.o
/home/ubuntu/incubator-singa/src/model/operation/pooling.cc: In function ‘singa::Tensor singa::GpuPoolingForwa                          rd(const singa::CudnnPoolingHandle&, const singa::Tensor&)’:
/home/ubuntu/incubator-singa/src/model/operation/pooling.cc:220:51: warning: narrowing conversion of ‘(int)(&                           cph)->singa::CudnnPoolingHandle::<anonymous>.singa::PoolingHandle::batchsize’ from ‘int’ to ‘long unsigned in                           ’ inside { } [-Wnarrowing]
                          x.device(), x.data_type());
                                                   ^
/home/ubuntu/incubator-singa/src/model/operation/pooling.cc:219:31: warning: narrowing conversion of ‘(& cph)-                          >singa::CudnnPoolingHandle::<anonymous>.singa::PoolingHandle::batchsize’ from ‘const int’ to ‘long unsigned in                          t’ inside { } [-Wnarrowing]
   Tensor output = Tensor({cph.batchsize, cph.channels, cph.pooled_height, cph.pooled_width},
                               ^
/home/ubuntu/incubator-singa/src/model/operation/pooling.cc:220:51: warning: narrowing conversion of ‘(int)(&                           cph)->singa::CudnnPoolingHandle::<anonymous>.singa::PoolingHandle::channels’ from ‘int’ to ‘long unsigned int’                           inside { } [-Wnarrowing]
                          x.device(), x.data_type());
                                                   ^
/home/ubuntu/incubator-singa/src/model/operation/pooling.cc:219:46: warning: narrowing conversion of ‘(& cph)-                          >singa::CudnnPoolingHandle::<anonymous>.singa::PoolingHandle::channels’ from ‘const int’ to ‘long unsigned in                           ’ inside { } [-Wnarrowing]
   Tensor output = Tensor({cph.batchsize, cph.channels, cph.pooled_height, cph.pooled_width},
                                              ^
/home/ubuntu/incubator-singa/src/model/operation/pooling.cc:220:51: warning: narrowing conversion of ‘(int)(&                           cph)->singa::CudnnPoolingHandle::<anonymous>.singa::PoolingHandle::pooled_height’ from ‘int’ to ‘long unsigned                           int’ inside { } [-Wnarrowing]
                          x.device(), x.data_type());
                                                   ^
/home/ubuntu/incubator-singa/src/model/operation/pooling.cc:219:60: warning: narrowing conversion of ‘(& cph)-                          >singa::CudnnPoolingHandle::<anonymous>.singa::PoolingHandle::pooled_height’ from ‘const int’ to ‘long unsigne                          d int’ inside { } [-Wnarrowing]
   Tensor output = Tensor({cph.batchsize, cph.channels, cph.pooled_height, cph.pooled_width},
                                                            ^
/home/ubuntu/incubator-singa/src/model/operation/pooling.cc:220:51: warning: narrowing conversion of ‘(int)(&                           cph)->singa::CudnnPoolingHandle::<anonymous>.singa::PoolingHandle::pooled_width’ from ‘int’ to ‘long unsigned                           int’ inside { } [-Wnarrowing]
                          x.device(), x.data_type());
                                                   ^
/home/ubuntu/incubator-singa/src/model/operation/pooling.cc:219:79: warning: narrowing conversion of ‘(& cph)-                          >singa::CudnnPoolingHandle::<anonymous>.singa::PoolingHandle::pooled_width’ from ‘const int’ to ‘long unsigned                           int’ inside { } [-Wnarrowing]
   Tensor output = Tensor({cph.batchsize, cph.channels, cph.pooled_height, cph.pooled_width},
                                                                               ^
[ 90%] Built target singa_objects
Scanning dependencies of target singa
[ 91%] Running Python protocol buffer compiler on /home/ubuntu/incubator-singa/src/proto/caffe.proto
[ 92%] Running Python protocol buffer compiler on /home/ubuntu/incubator-singa/src/proto/core.proto
[ 93%] Running Python protocol buffer compiler on /home/ubuntu/incubator-singa/src/proto/io.proto
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: io.proto.                           Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syn                          tax.)
[ 94%] Linking CXX shared library ../lib/libsinga.so
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: core.prot                          o. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 s                          yntax.)
[ 95%] Running Python protocol buffer compiler on /home/ubuntu/incubator-singa/src/proto/model.proto
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: model.pro                          to. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2                           syntax.)
Scanning dependencies of target _singa_wrap
[ 96%] Building CXX object python/CMakeFiles/_singa_wrap.dir/__/src/api/singa_wrap.cxx.o
[ 97%] Built target singa
[ 98%] Linking CXX shared library singa/_singa_wrap.so
[100%] Built target _singa_wrap
```

The test results are okay as follows:

```
ubuntu@ip-172-31-39-137:~/incubator-singa/examples/autograd$ python3 mnist_cnn.py
Starting Epoch 0:
Training loss = 582.689453, training accuracy = 0.794207
Evaluation accuracy = 0.937200, Elapsed Time = 4.268453s
Starting Epoch 1:
Training loss = 231.800217, training accuracy = 0.922559
Evaluation accuracy = 0.950120, Elapsed Time = 4.180309s
Starting Epoch 2:
Training loss = 168.152725, training accuracy = 0.943103
Evaluation accuracy = 0.966346, Elapsed Time = 4.185745s
Starting Epoch 3:
Training loss = 135.532410, training accuracy = 0.954259
Evaluation accuracy = 0.977464, Elapsed Time = 4.186186s
Starting Epoch 4:
Training loss = 116.884033, training accuracy = 0.960312
Evaluation accuracy = 0.972256, Elapsed Time = 4.202717s
Starting Epoch 5:
Training loss = 104.868248, training accuracy = 0.965815
Evaluation accuracy = 0.976462, Elapsed Time = 4.200955s
Starting Epoch 6:
Training loss = 95.433990, training accuracy = 0.967766
Evaluation accuracy = 0.980869, Elapsed Time = 4.190672s
Starting Epoch 7:
Training loss = 87.900131, training accuracy = 0.970418
Evaluation accuracy = 0.983273, Elapsed Time = 4.217619s
Starting Epoch 8:
Training loss = 81.392876, training accuracy = 0.973102
Evaluation accuracy = 0.985978, Elapsed Time = 4.247715s
Starting Epoch 9:
Training loss = 77.320335, training accuracy = 0.973969
Evaluation accuracy = 0.980869, Elapsed Time = 4.236908s

ubuntu@ip-172-31-39-137:~/incubator-singa/test/python$ python3 test_operation.py
...............................................................................WARNING: Logging before InitGoo                          gleLogging() is written to STDERR
I0920 09:42:13.534116  5992 tensor_math_cpp.h:146] not equal stride
I0920 09:42:13.534477  5992 tensor_math_cpp.h:146] not equal stride
.I0920 09:42:13.535104  5992 tensor_math_cpp.h:146] not equal stride
I0920 09:42:13.535485  5992 tensor_math_cpp.h:146] not equal stride
....
----------------------------------------------------------------------
Ran 84 tests in 0.963s

OK

ubuntu@ip-172-31-39-137:~/incubator-singa/examples/autograd$ python3 resnet.py
Start intialization............
100%|███████████████████████████████████████████████████████████████████████| 100/100 [01:27<00:00,  1.14it/s]
Throughput = 36.70721025063381 per second
Total=0.871763334274292, forward=0.27190722942352297, softmax=0.002759065628051758, backward=0.597097039222717                          3, sgd=0.018022277355194093

```