### PR TITLE
SINGA-488 Change the path of source code for CI

### DIFF
--- a/tool/conda/singa/meta.yaml
+++ b/tool/conda/singa/meta.yaml
@@ -27,8 +27,8 @@ package:
   version: {{ version }}
 
 source:
-  # path: ../../../
-  git_url: https://github.com/apache/incubator-singa.git
+  path: ../../../
+  # git_url: https://github.com/apache/incubator-singa.git
 
 build:
   number: 0


### PR DESCRIPTION
This will fix the issue in "SINGA-488 Travis CI always build from Apache master branch"