### PR TITLE
SINGA-493 Update news: SINGA graduation as a TLP

### DIFF
--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -21,6 +21,8 @@ Welcome to Apache SINGA
 Recent News
 -----------
 
+* SINGA has graduated as a Top-Level Project (TLP) of the Apache Software Foundation on 16 Oct 2019.
+
 * Food(lg), the mobile app to `help patients with prediabetes <https://ssi.nus.edu.sg/ntfgh/>`_, is powered by SINGA and this app can now be downloaded on the `APP Store <https://apps.apple.com/us/app/food-lg/id1213299378>`_ or `Google Play <https://play.google.com/store/apps/details?id=com.nusidmi.foodlg&hl=en_SG>`_. Watch this `video <https://www.youtube.com/watch?v=MHp-saJiP-0>`_ of Food(lg) for more details.
 
 * A tutorial on SINGA was given at Singapore Infocomm Media Development Authority (IMDA), 16 August, 2019. Snapshots of the tutorial:


### PR DESCRIPTION
The added message is :
"SINGA was graduated as a Top-Level Project (TLP) of the Apache Software Foundation in October 2019."

The built webpage looks like this: 
![Message](https://user-images.githubusercontent.com/38325429/66987316-24679c80-f0f3-11e9-9bc3-ebb84733f280.png)
